### PR TITLE
Add proxy agent (Support SOCKS and HTTP protocol)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ bundle
 dist
 .DS_Store
 configs/account.js
+configs/network.js
 npm-debug.log
 test
 screenshots
 *backup*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ bundle
 dist
 .DS_Store
 configs/account.js
-configs/network.js
 npm-debug.log
 test
 screenshots

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ Currently, Lepton only supports the search for the gist's description field. Thi
 [title] description #tag1 #tag2
 ```
 
+#### Can I use Lepton behind a proxy server?
+Yes. Copy and paste the following snippet to `~/.leptonrc`. Create the file if it does not exist, and don't forgot to change the address to your own one.
+```
+{
+  "proxy": {
+    "enable": true,
+    "address": "socks://localhost:1080"
+  }
+}
+```
+
 #### How to provide feedback?
 Please submit an issue ticket in the [GitHub Issue page](https://github.com/hackjutsu/Lepton/issues). Or, if you like, send a [pull request](https://github.com/hackjutsu/Lepton/pulls).
 

--- a/README.md
+++ b/README.md
@@ -116,15 +116,21 @@ Please submit an issue ticket in the [GitHub Issue page](https://github.com/hack
 
 
 ## Contributors
-- [hackjutsu](https://github.com/hackjutsu)
-- [wujysh](https://github.com/wujysh)
-- [DNLHC](https://github.com/DNLHC)
-- [meilinz](https://github.com/meilinz)
-- [lcgforever](https://github.com/lcgforever)
-- [Calinou](https://github.com/Calinou)
-- [rogersachan](https://github.com/rogersachan)
-- [passerbyid](https://github.com/passerbyid)
-- [YYSU](https://github.com/YYSU)
+<table id="contributors">
+   <tr>
+      <td><img src=https://avatars1.githubusercontent.com/u/7756581?v=3><a href="https://github.com/hackjutsu">hackjutsu</a></td>
+      <td><img src=https://avatars1.githubusercontent.com/u/5550402?v=3><a href="https://github.com/wujysh">wujysh</a></td>
+      <td><img src=https://avatars2.githubusercontent.com/u/14959483?v=3><a href="https://github.com/DNLHC">DNLHC</a></td>
+      <td><img src=https://avatars2.githubusercontent.com/u/13786673?v=3><a href="https://github.com/meilinz">meilinz</a></td>
+      <td><img src=https://avatars3.githubusercontent.com/u/5697293?v=3><a href="https://github.com/lcgforever">lcgforever</a></td>
+      <td><img src=https://avatars1.githubusercontent.com/u/180032?v=3><a href="https://github.com/Calinou">Calinou</a></td>
+   </tr>
+   <tr>
+      <td><img src=https://avatars0.githubusercontent.com/u/7173984?v=3><a href="https://github.com/rogersachan">rogersachan</a></td>
+      <td><img src=https://avatars3.githubusercontent.com/u/2075566?v=3><a href="https://github.com/passerbyid">passerbyid</a></td>
+      <td><img src=https://avatars2.githubusercontent.com/u/12994810?v=3><a href="https://github.com/YYSU">YYSU</a></td>
+   </tr>
+</table>
 
 ## License
 MIT © [hackjutsu](https://github.com/hackjutsu)

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -9,16 +9,20 @@ import { remote } from 'electron'
 const logger = remote.getGlobal('logger')
 
 import nconf from 'nconf'
-nconf.argv()
-  .env()
-  .file({ file: remote.app.getPath('home') + '/.leptonrc' })
-
 import ProxyAgent from 'proxy-agent'
+const configFilePath = remote.app.getPath('home') + '/.leptonrc'
 let proxyAgent = null
-const proxyUri = nconf.get('proxy:address')
-if (proxyUri) {
-  logger.info("use proxy", proxyUri)
-  proxyAgent = new ProxyAgent(proxyUri)
+try {
+  nconf.argv()
+    .env()
+    .file({ file: configFilePath })
+  if (nconf.get('proxy:enable')) {
+    const proxyUri = nconf.get('proxy:address')
+    proxyAgent = new ProxyAgent(proxyUri)
+    logger.info('use proxy', proxyUri)
+  }
+} catch (error) {
+  logger.error('Please correct the mistakes in your configuration file: [%s].\n' + error, configFilePath)
 }
 
 function exchangeAccessToken (clientId, clientSecret, authCode) {

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -8,18 +8,14 @@ import Notifier from '../notifier'
 import { remote } from 'electron'
 const logger = remote.getGlobal('logger')
 
-// TODO: move to global configuration
-let Network = null
-try {
-  Network = require('../../../configs/network')
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') throw e
-  Network = require('../../../configs/networkDummy')
-}
+import nconf from 'nconf'
+nconf.argv()
+  .env()
+  .file({ file: remote.app.getPath('home') + '/.leptonrc' })
 
 import ProxyAgent from 'proxy-agent'
 let proxyAgent = null
-const proxyUri = process.env.http_proxy || Network.proxy
+const proxyUri = nconf.get('proxy:address')
 if (proxyUri) {
   logger.info("use proxy", proxyUri)
   proxyAgent = new ProxyAgent(proxyUri)

--- a/configs/networkDummy.js
+++ b/configs/networkDummy.js
@@ -1,0 +1,3 @@
+module.exports = {
+  proxy: null, // dummy proxy address (e.g. 'socks5://localhost:1080' or 'http://localhost:8123')
+}

--- a/configs/networkDummy.js
+++ b/configs/networkDummy.js
@@ -1,3 +1,0 @@
-module.exports = {
-  proxy: null, // dummy proxy address (e.g. 'socks5://localhost:1080' or 'http://localhost:8123')
-}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "image-downloader": "^3.2.1",
     "marked": "^0.3.6",
     "moment": "^2.17.1",
+    "nconf": "^0.8.4",
     "proxy-agent": "^2.0.0",
     "react": "^15.5.1",
     "react-bootstrap": "^0.31.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "image-downloader": "^3.2.1",
     "marked": "^0.3.6",
     "moment": "^2.17.1",
+    "proxy-agent": "^2.0.0",
     "react": "^15.5.1",
     "react-bootstrap": "^0.31.0",
     "react-codemirror": "^1.0.0",


### PR DESCRIPTION
Resolve issue #45 #58.

Proxy address should be filled in `config/network.js` copied from template `config/networkDummy.js`.
Of cause, the proxy server should be configured by yourself :)

Example:
```
module.exports = {
  proxy: 'socks://localhost:1080'
}
```
or
```
module.exports = {
  proxy: 'http://localhost:8123'
}
```
| Protocol    | Example
|:--------------:|:------------:
| `http`         | `http://www.example.com:port`
| `https`        | `https://www.example.com:port`
| `socks(v5)`| `socks://{username:password}@www.example.com:port`
| `socks5`    | `socks5://{username:password}@www.example.com:port`
| `socks4`    | `socks4://www.example.com:port`
| `pac`          | `pac+http://www.example.com/proxy.pac`

Only tested on Linux (Ubuntu 16.10).