### PR TITLE
Fix CodeMirror crash while syntax highlighting

### DIFF
--- a/app/containers/gistEditor/index.js
+++ b/app/containers/gistEditor/index.js
@@ -124,7 +124,6 @@ import 'codemirror/mode/sass/sass'
 import 'codemirror/addon/edit/matchbrackets'
 import 'codemirror/addon/edit/matchtags'
 import 'codemirror/addon/dialog/dialog'
-import 'codemirror/addon/mode/loadmode'
 import 'codemirror/addon/search/search'
 import 'codemirror/addon/search/match-highlighter'
 import 'codemirror/addon/search/searchcursor'
@@ -141,30 +140,34 @@ import './index.scss'
 
 class GistEditor extends Component {
   componentDidMount () {
-    const { filename } = this.props
-
-    this.editor = this.refs.editor
-    this.CodeMirror = this.editor.getCodeMirrorInstance();
+    this.editor = this.refs.editor.getCodeMirror()
+    this.CodeMirror = this.refs.editor.getCodeMirrorInstance();
     this.CodeMirror.modeURL = '../../../node_modules/codemirror/mode/%N/%N.js'
-    this.setMode(filename)
+    this.setMode()
   }
 
-  componentDidUpdate (prevProps, prevState) {
-    const { filename } = this.props
+  componentDidUpdate (prevProps) {
+    const { value, filename } = this.props
 
+    if (!this.editor.getValue()) {
+      this.editor.setValue(value)
+    }
     if (prevProps.filename !== filename) {
       this.setMode(filename)
     }
   }
 
   setMode (filename) {
-    const modeInfo = filename ? this.CodeMirror.findModeByFileName(filename) : this.CodeMirror.findModeByName('Plain Text')
-    modeInfo && this.editor.getCodeMirror().setOption('mode', modeInfo.mime)
-    modeInfo && this.CodeMirror.autoLoadMode(this.editor.getCodeMirror(), modeInfo.mode)
+    if (filename) {
+      const modeInfo = this.CodeMirror.findModeByFileName(filename);
+      this.editor.setOption('mode', modeInfo ? modeInfo.mode : null)
+    } else {
+      this.editor.setOption('mode', null)
+    }
   }
 
   render () {
-    const { value, placeholder } = this.props
+    const { placeholder } = this.props
 
     const options = {
       theme: 'github',
@@ -181,7 +184,6 @@ class GistEditor extends Component {
     return (
       <CodeMirror
         ref="editor"
-        value={ value }
         options={ options }
         onChange={ value => this.props.onChange(value) }
       />


### PR DESCRIPTION
Fix the bug in #110.

`value` and `mode` of CodeMirror should not be initialized, and set in `componentDidUpdate()` later.
I don't know why, but it can actually solve the issue. It may be a bug of React-CodeMirror.

---
@hackjutsu 
By tracing the log, I found that when clicking `#edit`/`#new` links, the `componentDidMount()` of `GistEdit` will be called with no `filename` or `value` props. They are all undefined.
Then the `componentDidUpdate()` of `GistEdit` will be called with actual props.
But something is strange. If `mode` and `value` are set in `Render()` directly, they can not be changed in `componentDidUpdate()`. And if `value` is set with https://gist.github.com/hackjutsu/2367861489c591b110a0bdd33270e99a and `mode` is unset, the CodeMirror will crash! So I have to implement it as this commit... I think there may be something of React-CodeMirror is intractable.