### PR TITLE
Lock the electron-builder version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-preset-react": "^6.16.0",
     "css-loader": "^0.28.4",
     "electron": "^1.7.2",
-    "electron-builder": "^18.3.5",
+    "electron-builder": "18.3.5",
     "eslint": "^3.12.2",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-promise": "^3.4.0",


### PR DESCRIPTION
18.7.0 seems to introduce some unexpected breaking changes. I would like to lock its version to 18.3.5 as a workaround at this moment.