### PR TITLE
Add license of Evil icons in ABOUT panel 

### DIFF
--- a/app/containers/settingPage/index.js
+++ b/app/containers/settingPage/index.js
@@ -11,6 +11,13 @@ import './index.scss'
 class SettingPage extends Component {
   renderAboutSection () {
     const licenseList = []
+    /* Add Evil icons license as an exception */
+    licenseList.push(
+      <div key='Evil icons@1.9.0' className='license-item'>
+        <div className='license-project'>Evil icons@1.9.0</div>
+        <div className='license-type'>License: MIT</div>
+      </div>
+    )
     Object.keys(LicenseInfo).forEach(item => {
       if (item.startsWith(appInfo.name)) {
         return

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "file-loader": "^0.11.1",
     "html-loader": "^0.4.4",
     "json-loader": "^0.5.4",
-    "license-checker": "^8.0.4",
+    "license-checker": "^13.0.3",
     "node-sass": "^4.1.1",
     "raw-loader": "^0.5.1",
     "redux-devtools": "^3.3.1",


### PR DESCRIPTION
In [160](https://github.com/hackjutsu/Lepton/issues/160), Evil icons's license (MIT) is required to be added. 

Please see the following:
![image](https://user-images.githubusercontent.com/26782336/29051537-87f723ec-7bb1-11e7-9a74-f86df76941af.png)

Do we need order the licenses?