### PR TITLE
upgrade node sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "html-loader": "^0.4.4",
     "json-loader": "^0.5.4",
     "license-checker": "^13.0.3",
-    "node-sass": "^4.1.1",
+    "node-sass": "^4.5.3",
     "raw-loader": "^0.5.1",
     "redux-devtools": "^3.3.1",
     "sass-loader": "^6.0.5",


### PR DESCRIPTION
Refer to https://github.com/hackjutsu/Lepton/issues/164

Test successfully after upgrading new node sass.

Test environment is Node 8.2.1. macOS Sierra. Node-sass 4.5.3.

The issue before was that node sass did not support node 8.
If any error like:

> Node Sass could not find a binding for your current environment: OS X 64-bit with Node.js 8.x

Please rebuild node-sass like

> npm rebuild node-sass