### PR TITLE
Add a snap package (https://snapcraft.io) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react": "^6.16.0",
     "css-loader": "^0.28.4",
     "electron": "^1.7.10",
-    "electron-builder": "^19.30.4",
+    "electron-builder": "^19.50.0",
     "eslint": "^4.7.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
@@ -46,7 +46,7 @@
     "html-loader": "^0.5.0",
     "json-loader": "^0.5.7",
     "license-checker": "^15.0.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.7.2",
     "raw-loader": "^0.5.1",
     "redux-devtools": "^3.3.1",
     "sass-loader": "^6.0.5",
@@ -64,7 +64,7 @@
     "electron-is-dev": "^0.3.0",
     "electron-json-storage-sync": "^1.1.0",
     "electron-localshortcut": "^3.0.0",
-    "electron-updater": "^2.16.1",
+    "electron-updater": "^2.18.2",
     "electron-window-state": "^4.1.1",
     "fuse.js": "^3.0.0",
     "highlight.js": "^9.9.0",
@@ -124,7 +124,10 @@
     },
     "linux": {
       "category": "Development",
-      "target": "AppImage",
+      "target": [
+        "AppImage",
+        "snap"
+      ],
       "publish": [
         "github"
       ]


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, 17.10, and 18.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist` it will create `dist/lepton_1.5.1_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous lepton_1.5.1_amd64.snap`

Run with `lepton` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "lepton" name](https://dashboard.snapcraft.io/register-snap/?name=lepton).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Lepton out with:
`snapcraft push lepton_1.5.1_amd64.snap --release stable`

(You can also push to the Snap Store [programatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)
  
  
  