### PR TITLE
Enable snippet scrolling even when window doesn't have focus

### DIFF
--- a/app/containers/snippetPanel/index.scss
+++ b/app/containers/snippetPanel/index.scss
@@ -7,7 +7,10 @@
   width: 100%;
   overflow: overlay;
   height: 100vh;
-  visibility: hidden;
+}
+
+.snippet-panel:not(:hover)::-webkit-scrollbar {
+  display: none;
 }
 
 .snippet-panel-immersive {
@@ -25,12 +28,6 @@
     text-align: center;
     height: 100vh;
   }
-}
-
-.snippet-panel-content,
-.snippet-panel:hover,
-.snippet-panel-immersive:hover {
-  visibility: visible;
 }
 
 .snippet-panel {


### PR DESCRIPTION
Closes #281

Adds snippet scrolling even when the window doesn't have focus. Retains hiding the scrollbars unless the snippet pane is hovered over.

![scrolling](https://user-images.githubusercontent.com/13814048/38451738-399244d2-39ea-11e8-8621-30ff86c04f5a.gif)
