### PR TITLE
#240 - fix multiline comment highlighting

### DIFF
--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -37,12 +37,12 @@ export default class CodeArea extends Component {
 
     /*
       Highlight.js wraps comment blocks inside <span class='hljs-comment'></span>.
-      However, when the multi-line comment block is broken down into diffirent
+      However, when the multi-line comment block is broken down into different
       table rows, only the first row, which is appended by the <span> tag, is
       highlighted. The following code fixes it by appending <span> to each line
       of the comment block.
     */
-    const commentPattern = /<span class="hljs-comment">(.|\n)*?<\/span>/g
+    const commentPattern = /<span class="hljs-comment">(.|\n)*?\*\/\s*<\/span>/g
     const adaptedHighlightedContent = highlightedContent.replace(commentPattern, data => {
       return data.replace(/\r?\n/g, () => {
         // Chromium is smart enough to add the closing </span>

--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -42,7 +42,7 @@ export default class CodeArea extends Component {
       highlighted. The following code fixes it by appending <span> to each line
       of the comment block.
     */
-    const commentPattern = /<span class='hljs-comment'>(.|\n)*?<\/span>/g
+    const commentPattern = /<span class="hljs-comment">(.|\n)*?<\/span>/g
     const adaptedHighlightedContent = highlightedContent.replace(commentPattern, data => {
       return data.replace(/\r?\n/g, () => {
         // Chromium is smart enough to add the closing </span>


### PR DESCRIPTION
It'll look like that:

<img width="746" alt="image" src="https://user-images.githubusercontent.com/965804/45594985-d7c00800-b9ac-11e8-9189-32d88842d463.png">
