### PR TITLE
fix: preserve newlines when copying from codeArea

### DIFF
--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -53,7 +53,7 @@ export default class CodeArea extends Component {
     const contentTable = adaptedHighlightedContent.split(/\r?\n/).map(lineContent => {
       return `<tr>
                 <td class='line-number' data-pseudo-content=${++lineNumber}></td>
-                <td>${lineContent}</td>
+                <td>${lineContent === '' ? '\n' : lineContent}</td>
               </tr>`
     }).join('')
 


### PR DESCRIPTION
When copying text from `CodeArea`, empty lines would get lost. This PR fixes this by inserting a newline character into empty lines (instead of an empty string).