### PR TITLE
upgrade electron to 4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,9 +104,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
-      "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
+      "version": "10.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
+      "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -3104,12 +3104,12 @@
       "dev": true
     },
     "electron": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.10.tgz",
-      "integrity": "sha512-I39IeQP3NOlbjKzTDK8uK2JdiHDfhV5SruCS2Gttkn2MaKCY+yIzQ6Wr4DyBXLeTEkL1sbZxbqQVhCavAliv5w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.0.5.tgz",
+      "integrity": "sha512-UWFH6SrzNtzfvusGUFYxXDrgsUEbtBXkH/66hpDWxjA2Ckt7ozcYIujZpshbr7LPy8kV3ZRxIvoyCMdaS5DkVQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^8.0.24",
+        "@types/node": "^10.12.18",
         "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
       }
@@ -4282,7 +4282,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4297,7 +4297,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "css-loader": "^2.0.0",
-    "electron": "^3.0.0",
+    "electron": "^4.0.5",
     "electron-builder": "^20.38.2",
     "eslint": "^5.0.0",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
The issue caused by out-dated chrome will be healed by upgrading electron to latest stable version.
https://github.com/hackjutsu/Lepton/issues/340
I've tested and complied correctly in macOS Mojave 10.14.3

BTW, the chrome version in electron 4.0 is 69, while that in electron 3.0 is 68. Both are ok to avoid auth issue. 
 