### PR TITLE
enhance: small tweaks on scrollbar style

### DIFF
--- a/app/containers/navigationPanel/index.scss
+++ b/app/containers/navigationPanel/index.scss
@@ -162,7 +162,7 @@
 }
 
 ::-webkit-scrollbar {
-  width: 5px;
+  width: 3px;
   height: 5px;
 }
 

--- a/app/containers/navigationPanelDetails/index.scss
+++ b/app/containers/navigationPanelDetails/index.scss
@@ -8,13 +8,15 @@
   width: 100%;
   overflow-y: overlay;
   height: 100%;
-  visibility: hidden;
-}
-
-.panel-thumbnails-content,
-.panel-thumbnails-scroll:hover {
   visibility: visible;
 }
+
+// With .panel-thumbnails-scroll visible, this block is not needed
+//
+// .panel-thumbnails-content,
+// .panel-thumbnails-scroll:hover {
+//   visibility: visible;
+// }
 
 .panel-thumbnails-scroll {
 


### PR DESCRIPTION
Another proposal to mitigate the issue https://github.com/hackjutsu/Lepton/issues/342 by shrinking the size of the scrollbar tracker. This doesn't solve the `overlay` issue, but will at least
1. consistent across scrollbars in different panels
2. make the blank verticle space less visible in the middle panel

<img width="996" alt="Screen Shot 2019-03-31 at 11 53 38 AM" src="https://user-images.githubusercontent.com/7756581/55293476-cddf7e80-53ab-11e9-87ce-5cc20d8b2e8a.png">
