### PR TITLE
Fixed syntax highlighting in markdown.

### DIFF
--- a/app/utilities/markdown/index.js
+++ b/app/utilities/markdown/index.js
@@ -7,8 +7,14 @@ import MdKatex from 'markdown-it-katex'
 
 // Configure markdown-it
 const Md = MarkdownIt({
+  
   highlight: (str, lang) => {
-    return HighlightJS.highlightAuto(str).value
+    if (lang && HighlightJS.getLanguage(lang)) {
+      try {
+        return HighlightJS.highlight(lang, str).value;
+      } catch (__) {}
+    }
+    return HighlightJS.highlightAuto(str).value;
   }
 })
   .use(MdTaskList)


### PR DESCRIPTION
I have fixed the issue I reported here: https://github.com/hackjutsu/Lepton/issues/368
It was a somewhat tricky issue to debug because of the inconsistent rendering of markdown code blocks that were supposedly in the same language. The issue was that even if the language was explicitly declared at the top of a code block it would always run highlightAuto(). The functionality of highlightAuto is to guess the language based on the content, so even if python was explicitly declared highlightjs would make a guess based on the code, which was incorrect nearly every time. Highlight js would apply varying code styles to python code blocks like angelscript, matlab, moonscript, ruby, just to name a few. I fixed this issue by adding a conditional that checks if language is set, if set it will run highlight(). If not set it will retain the previous functionality by making a guess with highlightAuto(). 