### PR TITLE
Bump highlight.js/update GitHub gist css

### DIFF
--- a/app/utilities/vendor/highlightJS/styles/github-gist.css
+++ b/app/utilities/vendor/highlightJS/styles/github-gist.css
@@ -1,9 +1,10 @@
 /**
  * GitHub Gist Theme
+ * Author : Anthony Attard - https://github.com/AnthonyAttard
  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro
  */
 
-.hljs {
+ .hljs {
   display: block;
   background: white;
   padding: 0.5em;
@@ -16,7 +17,6 @@
   color: #969896;
 }
 
-.hljs-string,
 .hljs-variable,
 .hljs-template-variable,
 .hljs-strong,
@@ -28,7 +28,7 @@
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-type {
-  color: #a71d5d;
+  color: #d73a49;
 }
 
 .hljs-literal,
@@ -53,7 +53,7 @@
 .hljs-selector-class,
 .hljs-selector-attr,
 .hljs-selector-pseudo {
-  color: #795da3;
+  color: #6f42c1;
 }
 
 .hljs-addition {
@@ -68,4 +68,12 @@
 
 .hljs-link {
   text-decoration: underline;
+}
+
+.hljs-number {
+  color: #005cc5;
+}
+
+.hljs-string {
+  color: #032f62;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4688,7 +4688,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4709,12 +4710,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4729,17 +4732,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4856,7 +4862,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4868,6 +4875,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4882,6 +4890,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4889,12 +4898,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4913,6 +4924,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4993,7 +5005,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5005,6 +5018,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5090,7 +5104,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5126,6 +5141,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5145,6 +5161,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5188,12 +5205,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5551,9 +5570,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
     },
     "highlightjs-solidity": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "electron-updater": "^4.0.0",
     "electron-window-state": "^5.0.0",
     "fuse.js": "^3.3.0",
-    "highlight.js": "^9.13.1",
+    "highlight.js": "^9.15.10",
     "highlightjs-solidity": "^1.0.6",
     "human-readable-time": "^0.3.0",
     "image-downloader": "^3.4.2",


### PR DESCRIPTION
Updated github-gist styles to match the current styling of gist.github.com. Also updated highlight.js package. See my commit to hightlight.js: https://github.com/highlightjs/highlight.js/commit/ea2a4cd4e4eb194f1d73ca4ed782fef37ff6f59d