### PR TITLE
Change Zoom In Shortcut

### DIFF
--- a/app/utilities/menu/mainMenu.js
+++ b/app/utilities/menu/mainMenu.js
@@ -60,7 +60,8 @@ const template = [
         role: 'resetzoom'
       },
       {
-        role: 'zoomin'
+        role: 'zoomin',
+        accelerator: 'CmdOrCtrl+='
       },
       {
         role: 'zoomout'


### PR DESCRIPTION
This PR is a workaround to the mismatch `Zoom In` menu item.
The issue related is the #390.
As a background context adition the issue #388 has some infos too.

The default combination for `ZoomIn` is `Shif+CmdOrCtrl+Plus`. 
This mismatch is caused by Electron and not Lepton.

Not the ideal solution, but I looked through Electron discussions and see many different points of discussion about this issue.

This is a workaround where we change the `Zoom In` shortcut to `CmdOrCtrl+=`.


