### PR TITLE
Added 'Delete' as a shortcut key for deleting the selected gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | :------------: |:-------------: |:-----:|
 | New Snippet    | `Cmd/Ctrl + N` | Create a snippet      |
 | Edit Snippet   | `Cmd/Ctrl + E` | Edit a snippet      |
-| Delete Snippet   | `Del` | Delete selected snippet      |
+| Delete Snippet   | `Cmd/Ctrl + Del` | Delete selected snippet      |
 | Submit         | `Cmd/Ctrl + S` | Submit the changes from the editor      |
 | Cancel         | `Cmd/Ctrl + ESC` | Exit the editor without saving   |
 | Sync           | `Cmd/Ctrl + R` | Sync with remote Gist server   |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | :------------: |:-------------: |:-----:|
 | New Snippet    | `Cmd/Ctrl + N` | Create a snippet      |
 | Edit Snippet   | `Cmd/Ctrl + E` | Edit a snippet      |
+| Delete Snippet   | `Del` | Delete selected snippet      |
 | Submit         | `Cmd/Ctrl + S` | Submit the changes from the editor      |
 | Cancel         | `Cmd/Ctrl + ESC` | Exit the editor without saving   |
 | Sync           | `Cmd/Ctrl + R` | Sync with remote Gist server   |

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -52,6 +52,9 @@ class Snippet extends Component {
     ipcRenderer.on('exit-editor', () => {
       this.closeGistEditorModal()
     })
+    ipcRenderer.on('delete-gist', () => {
+      this.showDeleteModal()
+    })
   }
 
   componentWillUnmount () {

--- a/app/index.js
+++ b/app/index.js
@@ -495,12 +495,8 @@ function syncLocalPref (userName) {
 /** End: Local storage management **/
 
 /** Start: Response to main process events **/
-function allDialogsClosed (dialogs) {
-  let status = true
-  dialogs.forEach(dialog => {
-    if (dialog !== 'OFF') status = false
-  })
-  return status
+function allDialogsClosed (dialogsStatus) {
+  return dialogsStatus.every(status => status === 'OFF')
 }
 
 ipcRenderer.on('search-gist', data => {
@@ -638,6 +634,33 @@ ipcRenderer.on('edit-gist', data => {
     logoutModalStatus ]
   if (allDialogsClosed(dialogs)) {
     ipcRenderer.emit('edit-gist-renderer')
+  }
+})
+
+ipcRenderer.on('delete-gist-check', data => {
+  const state = reduxStore.getState()
+  const {
+    gistRawModal,
+    searchWindowStatus,
+    aboutModalStatus,
+    gistNewModalStatus,
+    gistEditModalStatus,
+    gistDeleteModalStatus,
+    dashboardModalStatus,
+    logoutModalStatus } = state
+
+  // FIXME: This should be able to extracted to the allDialogsClosed method.
+  const dialogs = [
+    gistRawModal.status,
+    gistNewModalStatus,
+    gistEditModalStatus,
+    searchWindowStatus,
+    aboutModalStatus,
+    gistDeleteModalStatus,
+    logoutModalStatus,
+    dashboardModalStatus ]
+  if (allDialogsClosed(dialogs)) {
+    ipcRenderer.emit('delete-gist')
   }
 })
 

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -32,7 +32,7 @@ module.exports = {
         "keyShortcutForSearch": "Shift+Space",
         "keyNewGist": "CommandOrControl+N",
         "keyEditGist": "CommandOrControl+E",
-        "keyDeleteGist": "Delete",
+        "keyDeleteGist": "CommandOrControl+Delete",
         "keySubmitGist": "CommandOrControl+S",
         "keyImmersiveMode": "CommandOrControl+I",
         "keyAboutPage": "CommandOrControl+,",

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -32,6 +32,7 @@ module.exports = {
         "keyShortcutForSearch": "Shift+Space",
         "keyNewGist": "CommandOrControl+N",
         "keyEditGist": "CommandOrControl+E",
+        "keyDeleteGist": "Delete",
         "keySubmitGist": "CommandOrControl+S",
         "keyImmersiveMode": "CommandOrControl+I",
         "keyAboutPage": "CommandOrControl+,",

--- a/main.js
+++ b/main.js
@@ -187,6 +187,11 @@ function setUpApplicationMenu () {
         click: (item, mainWindow) => mainWindow && mainWindow.send('edit-gist')
       },
       {
+        label: 'Delete Gist',
+        accelerator: shortcuts.keyDeleteGist,
+        click: (item, mainWindow) => mainWindow && mainWindow.send('delete-gist-check')
+      },
+      {
         label: 'Submit Gist',
         accelerator: shortcuts.keySubmitGist,
         click: (item, mainWindow) => mainWindow && mainWindow.send('submit-gist')


### PR DESCRIPTION
@hackjutsu Adding Del key as shortcut comes in handy when you want to quickly cleanup your gists. The code on `app/index.js` could be refactored to remove duplication from older code, but I want to start easy for now. I will push some code refactoring later in another commit if you allow me to do this. I also have more improvements to commit. Hope this helps. ;)
When you have some time can you please take a look at this. Thanks!