### PR TITLE
Configure notifications by type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test
 screenshots
 *backup*
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Lepton's features can be customized by `<home_dir>/.leptonrc`! (Create the file 
 - Enterprise
 - Notifications
 
-Check out the [.leptonrc template](https://gist.github.com/1ad7e4968eb64d881ec9dedd6c0f400b) to explore different customization options.
+Check out the [configuration docs](https://github.com/hackjutsu/Lepton/wiki/Configuration) to explore different customization options.
 
 ## Tech Stack
 ![Based on](./docs/img/erb-logo.png)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Lepton's features can be customized by `<home_dir>/.leptonrc`! (Create the file 
 - Proxy
 - Shortcuts
 - Enterprise
+- Notifications
 
 Check out the [.leptonrc template](https://gist.github.com/1ad7e4968eb64d881ec9dedd6c0f400b) to explore different customization options.
 

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,5 +1,5 @@
 import { getGitHubApi, GET_SINGLE_GIST } from '../utilities/githubApi'
-import Notifier from '../utilities/notifier'
+import { notifyFailure } from '../utilities/notifier'
 import { remote } from 'electron'
 const logger = remote.getGlobal('logger')
 
@@ -232,7 +232,7 @@ export function fetchSingleGist (oldGist, id) {
       })
       .catch((err) => {
         logger.error('The request has failed: ' + err)
-        Notifier('Sync failed', 'Please check your network condition. 01')
+        notifyFailure('Sync failed', 'Please check your network condition. 01')
       })
   }
 }

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -7,7 +7,7 @@ import Autolinker from 'autolinker'
 import CodeArea from '../codeArea'
 import HumanReadableTime from 'human-readable-time'
 import Moment from 'moment'
-import Notifier from '../../utilities/notifier'
+import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
 import {
   addLangPrefix as Prefixed,
@@ -78,11 +78,11 @@ class Snippet extends Component {
       .catch(err => {
         logger.error('Failed to delete the gist ' + activeGist)
         logger.error(JSON.stringify(err))
-        Notifier('Deletion failed', 'Please check your network condition. 02')
+        notifyFailure('Deletion failed', 'Please check your network condition. 02')
       })
       .then(data => {
         logger.info('The gist ' + activeGist + ' has been deleted.')
-        Notifier('The gist has been deleted')
+        notifySuccess('The gist has been deleted')
 
         // For performance purpose, we should perform an internal update, like what
         // we're doing for creating/edit gists. However, since delete is an infrequent
@@ -156,7 +156,7 @@ class Snippet extends Component {
       description,
       processedFiles)
       .catch((err) => {
-        Notifier('Gist update failed')
+        notifyFailure('Gist update failed')
         logger.error(JSON.stringify(err))
       })
       .then((response) => {
@@ -277,7 +277,7 @@ class Snippet extends Component {
       filename: filenameRecords
     })
 
-    Notifier('Gist updated', HumanReadableTime(new Date()))
+    notifySuccess('Gist updated', HumanReadableTime(new Date()))
   }
 
   renderGistEditorModalBody (description, fileArray, isPrivate) {
@@ -328,12 +328,12 @@ class Snippet extends Component {
   handleCopyGistLinkClicked (snippet, file) {
     const link = snippet.details.html_url + '#file-' + file.filename.replace(/\./g, '-').toLowerCase()
     clipboard.writeText(link)
-    Notifier('Copied', 'The link has been copied to the clipboard.')
+    notifySuccess('Copied', 'The link has been copied to the clipboard.')
   }
 
   handleCopyGistFileClicked (gist) {
     clipboard.writeText(gist.content)
-    Notifier('Copied', 'The content has been copied to the clipboard.')
+    notifySuccess('Copied', 'The content has been copied to the clipboard.')
   }
 
   showRawModalModal (gist) {
@@ -375,7 +375,7 @@ class Snippet extends Component {
 
   handleCopyRawLinkClicked (url) {
     clipboard.writeText(url)
-    Notifier('Copied', 'The raw file link has been copied to the clipboard.')
+    notifySuccess('Copied', 'The raw file link has been copied to the clipboard.')
   }
 
   renderPanelHeader (activeSnippet) {

--- a/app/containers/userPanel/index.js
+++ b/app/containers/userPanel/index.js
@@ -4,7 +4,7 @@ import { default as GistEditorForm, NEW_GIST } from '../gistEditorForm'
 import { Image, Modal, Button, ProgressBar } from 'react-bootstrap'
 import { remote, ipcRenderer } from 'electron'
 import HumanReadableTime from 'human-readable-time'
-import Notifier from '../../utilities/notifier'
+import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
 import {
   addLangPrefix as Prefixed,
@@ -78,7 +78,7 @@ class UserPanel extends Component {
 
     return getGitHubApi(CREATE_SINGLE_GIST)(this.props.accessToken, description, processedFiles, isPublic)
       .catch((err) => {
-        Notifier('Gist creation failed')
+        notifyFailure('Gist creation failed')
         logger.error(JSON.stringify(err))
       })
       .then((response) => {
@@ -162,7 +162,7 @@ class UserPanel extends Component {
       filename: filenameRecords
     })
 
-    Notifier('Gist created', HumanReadableTime(new Date()))
+    notifySuccess('Gist created', HumanReadableTime(new Date()))
   }
 
   renderGistEditorModalBody () {

--- a/app/index.js
+++ b/app/index.js
@@ -45,7 +45,7 @@ import {
   updatePinnedTags
 } from './actions/index'
 
-import Notifier from './utilities/notifier'
+import { notifySuccess, notifyFailure } from './utilities/notifier'
 
 const logger = remote.getGlobal('logger')
 
@@ -128,7 +128,7 @@ function launchAuthWindow (token) {
         })
         .catch((err) => {
           logger.error('Failed: ' + JSON.stringify(err.error))
-          Notifier('Sync failed', 'Please check your network condition. 03')
+          notifyFailure('Sync failed', 'Please check your network condition. 03')
         })
     } else if (error) {
       logger.error('Oops! Something went wrong and we couldn\'t' +
@@ -355,12 +355,12 @@ function updateUserGists (userLoginId, token) {
       // clean up the snapshot for the previous state
       clearSyncSnapshot()
 
-      Notifier('Sync succeeds', humanReadableSyncTime)
+      notifySuccess('Sync succeeds', humanReadableSyncTime)
 
       reduxStore.dispatch(updateGistSyncStatus('DONE'))
     })
     .catch(err => {
-      Notifier('Sync failed', 'Please check your network condition. 04')
+      notifyFailure('Sync failed', 'Please check your network condition. 04')
       logger.error('The request has failed: ' + err)
       reduxStore.dispatch(updateGistSyncStatus('DONE'))
       throw err
@@ -411,7 +411,7 @@ function initUserSession (token) {
         logger.info('[Dispatch] updateUserSession INACTIVE')
         reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
       }
-      Notifier('Sync failed', 'Please check your network condition. 00')
+      notifyFailure('Sync failed', 'Please check your network condition. 00')
     })
 }
 /** End: User session management **/

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -1,6 +1,6 @@
 import { Promise } from 'bluebird'
 import { remote } from 'electron'
-import Notifier from '../notifier'
+import { notifyFailure } from '../notifier'
 import ProxyAgent from 'proxy-agent'
 import ReqPromise from 'request-promise'
 import Request from 'request'
@@ -137,7 +137,7 @@ function getAllGistsV1 (token, userId) {
       .catch(err => {
         if (err !== EMPTY_PAGE_ERROR_MESSAGE) {
           logger.error(err)
-          Notifier('Sync failed', 'Please check your network condition. 05')
+          notifyFailure('Sync failed', 'Please check your network condition. 05')
         }
       })
       .finally(() => {

--- a/app/utilities/notifier/index.js
+++ b/app/utilities/notifier/index.js
@@ -1,15 +1,24 @@
 import { remote } from 'electron'
 
 const conf = remote.getGlobal('conf')
+const disableAllNotifications = conf.get('disableNotification')
 
-export default function (title, message = '') {
-  let option = {
-    title: title,
-    body: message,
-    silent: true
+export function notifySuccess (title, message = '') {
+  const showSuccessNotifications = conf.get('notifications:success')
+
+  let option = { title: title, body: message, silent: true }
+
+  if (!disableAllNotifications && showSuccessNotifications) {
+    new Notification(option.title, option)
   }
+}
 
-  if (!conf.get('disableNotification')) {
+export function notifyFailure (title, message = '') {
+  const showFailureNotifications = conf.get('notifications:failure')
+
+  let option = { title: title, body: message, silent: true }
+
+  if (!disableAllNotifications && showFailureNotifications) {
     new Notification(option.title, option)
   }
 }

--- a/app/utilities/notifier/index.js
+++ b/app/utilities/notifier/index.js
@@ -1,14 +1,13 @@
 import { remote } from 'electron'
 
 const conf = remote.getGlobal('conf')
-const disableAllNotifications = conf.get('disableNotification')
 
 export function notifySuccess (title, message = '') {
   const showSuccessNotifications = conf.get('notifications:success')
 
   let option = { title: title, body: message, silent: true }
 
-  if (!disableAllNotifications && showSuccessNotifications) {
+  if (showSuccessNotifications) {
     new Notification(option.title, option)
   }
 }
@@ -18,7 +17,7 @@ export function notifyFailure (title, message = '') {
 
   let option = { title: title, body: message, silent: true }
 
-  if (!disableAllNotifications && showFailureNotifications) {
+  if (showFailureNotifications) {
     new Notification(option.title, option)
   }
 }

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -27,7 +27,6 @@ module.exports = {
         "token": "",
         "avatarUrl": ""
     },
-    "disableNotification": false,
     "notifications": {
         "success": true,
         "failure": true

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -28,6 +28,10 @@ module.exports = {
         "avatarUrl": ""
     },
     "disableNotification": false,
+    "notifications": {
+        "success": true,
+        "failure": true
+    },
     "shortcuts": {
         "keyShortcutForSearch": "Shift+Space",
         "keyNewGist": "CommandOrControl+N",


### PR DESCRIPTION
I have most notifications on all my devices reduced to a minimum. To reduce notification fatigue,  I'm only interested in important notifications. For Lepton, I'm only interested in exceptional notifications, i.e. where the expected result hasn't occurred. I think it's especially important for macOS because these notifications cannot be force closed.

### Tasks
- [x] Add structured configuration for notifications by type so it's extendable
- [x] By default, all notification types are turned on
- [x] Document notification configuration options
  - [x] README
  - [x] Wiki: https://github.com/hackjutsu/Lepton/wiki/Configuration
- [x] Deprecate or immediately remove `disableNotification` option
  - No longer needed, can achieve similar behaviour with config for notification types, or can already block all app notifications at the OS level
  - Wasn't documented anywhere except in #382, so may only affect a small number of users