### PR TITLE
Fix: using path.join instead of concatenate path strings directly.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -445,12 +445,12 @@ function downloadImage (imageUrl, filename) {
     return
   }
 
-  const userProfilePath = (remote.app).getPath('userData') + '/profile/'
+  const userProfilePath = path.join(remote.app.getPath('userData'), 'profile')
   if (!fs.existsSync(userProfilePath)) {
     fs.mkdirSync(userProfilePath)
   }
 
-  const imagePath = userProfilePath + filename + '.png'
+  const imagePath = path.join(userProfilePath, filename + '.png')
   ImageDownloader({
     url: imageUrl,
     dest: imagePath,

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ initGlobalLogger()
 
 logger.info(`\n\n----- ${appInfo.name} v${appInfo.version} ${os.platform()}-----\n`)
 
-logger.info(`[conf] Looking for .leptonrc at ${ app.getPath('home') + '/.leptonrc' }`)
+logger.info(`[conf] Looking for .leptonrc at ${ path.join(app.getPath('home'), '.leptonrc') }`)
 logger.info('[conf] The resolved configuration is ...')
 for (const key of Object.getOwnPropertyNames(defaultConfig)) {
   logger.info(`"${key}": ${JSON.stringify(nconf.get(key))}`)    
@@ -290,7 +290,7 @@ function setUpTouchBar() {
 }
 
 function initGlobalConfigs () {
-  const configFilePath = app.getPath('home') + '/.leptonrc'
+  const configFilePath = path.join(app.getPath('home'), '.leptonrc')
   logger.info(`[conf] Looking for .leptonrc at ${configFilePath}`)
   nconf.argv().env()
   try {


### PR DESCRIPTION
Although Windows API support both forward slash and backslash. But in common sense, Windows should use forward slash as path separator, especially cmd and other command shells usually doesn't support backslash. So the most robust solution is follow the os specified path separator, we can use `path.join` to implement it.

The most important is that, Lepton has shown the config path in UI (About dialog). For now, it shown mixed path separators in one path, it makes user confused. So I fixed it.

Expected (after this fix):
<img width="278" alt="expect" src="https://user-images.githubusercontent.com/11289158/104892983-d3a5ba00-59ad-11eb-840d-068667dc9815.png">

Actual (before this fix):
<img width="278" alt="actual" src="https://user-images.githubusercontent.com/11289158/104893270-2ed7ac80-59ae-11eb-8c7a-bddad9a57832.png">
