### PR TITLE
updated brew install command to reflect --cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Check out the [configuration docs](https://github.com/hackjutsu/Lepton/wiki/Conf
 - Download released binaries(macOS/Windows/Linux) [here](https://github.com/hackjutsu/Lepton/releases).
 - Install via Homebrew (macOS)
 ```bash
-brew cask install lepton
+brew install --cask lepton
 ```
 - Install via SnapCraft (Linux)
 


### PR DESCRIPTION
Received an error installing via HomeBrew

Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

brew install --cask lepton

This is expected behavior. brew cask <command> was deprecated in favor of brew <command> --cask in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled. This was documented in the release notes and on the Homebrew blog in addition to the messages at the command-line
