### PR TITLE
fix: modal scrollbar blink

### DIFF
--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -1,4 +1,4 @@
-*:not(:hover)::-webkit-scrollbar {
+*:not(.modal):not(:hover)::-webkit-scrollbar {
   display: none;
 }
   


### PR DESCRIPTION
close #510 

the css that controls scrollbar to disappear, should exclude modal css.