### PR TITLE
[codex] Add optional all-gist sync config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact pat
 
 - Theme (light/dark)
 - Snippet
+- Gist
 - Editor
 - Logger
 - Proxy

--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDom from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware } from 'redux'
+import { Promise } from 'bluebird'
 import thunk from 'redux-thunk'
 import electronLocalStorage from 'electron-json-storage-sync'
 import electronBridge from './utilities/electronBridge'
@@ -20,6 +21,7 @@ import {
 import {
   getGitHubApi,
   GET_ALL_GISTS,
+  GET_SINGLE_GIST,
   GET_USER_PROFILE,
   EXCHANGE_ACCESS_TOKEN
 } from './utilities/githubApi'
@@ -52,6 +54,7 @@ const { createRequire } = require('module')
 const remote = require('@electron/remote')
 const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
+const conf = electronBridge.config
 const appRequire = createRequire(path.join(electronBridge.app.getAppPath(), 'app/index.js'))
 
 let Account = null
@@ -74,6 +77,7 @@ const CONFIG_OPTIONS = {
   client_secret: Account.client_secret,
   scopes: ['gist']
 }
+const GIST_DETAIL_SYNC_CONCURRENCY = 5
 
 let preSyncSnapshot = {
   activeGistTag: null,
@@ -268,10 +272,43 @@ function reSyncUserGists () {
   updateUserGists(userSession.profile.login, accessToken)
 }
 
+function downloadGistDetailsAfterListSync (gistList, token) {
+  if (!conf.get('gist:downloadAll')) {
+    return Promise.resolve({})
+  }
+
+  logger.info(`[sync] Downloading details for ${gistList.length} gists`)
+  return Promise.map(gistList, gist => {
+    return getGitHubApi(GET_SINGLE_GIST)(token, gist.id)
+      .then(details => {
+        return {
+          id: gist.id,
+          details: details
+        }
+      })
+  }, { concurrency: GIST_DETAIL_SYNC_CONCURRENCY })
+    .then((downloadedGists) => {
+      const detailsById = {}
+      downloadedGists.forEach(gist => {
+        detailsById[gist.id] = gist.details
+      })
+      return detailsById
+    })
+}
+
 function updateUserGists (userLoginId, token) {
   reduxStore.dispatch(updateGistSyncStatus('IN_PROGRESS'))
   return getGitHubApi(GET_ALL_GISTS)(token, userLoginId)
     .then((gistList) => {
+      return downloadGistDetailsAfterListSync(gistList, token)
+        .then(downloadedGistDetails => {
+          return {
+            downloadedGistDetails: downloadedGistDetails,
+            gistList: gistList
+          }
+        })
+    })
+    .then(({ gistList, downloadedGistDetails }) => {
       const preGists = reduxStore.getState().gists
       const gists = {}
       const rawGistTags = {}
@@ -316,13 +353,13 @@ function updateUserGists (userLoginId, token) {
         gists[gist.id] = {
           langs: langs,
           brief: gist,
-          details: null
+          details: downloadedGistDetails[gist.id] || null
         }
 
         // Keep the date for the unchanged gist, so that user doesn't need
         // to resync.
         const preGist = preGists[gist.id]
-        if (preGist && preGist.details && preGist.details.updated_at === gist.updated_at) {
+        if (!gists[gist.id].details && preGist && preGist.details && preGist.details.updated_at === gist.updated_at) {
           gists[gist.id] = Object.assign(gists[gist.id], { details: preGist.details })
         }
 

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -82,10 +82,7 @@ function getAllGistsV2 (token, userId) {
         logger.debug(TAG + '[V2] The header missing link property')
         logger.debug(TAG + JSON.stringify(res.headers))
         logger.debug(TAG + `The length of gistList is ${gistList.length}`)
-
-        // Falling back to getAllGistsV1 to deal with two-factor Authenticated clients
-        logger.debug(TAG + '[V2] Falling back to [V1]...')
-        return getAllGistsV1(token, userId)
+        return sortGistsByUpdatedAt(gistList)
       }
 
       const matches = res.headers.link.match(/page=[0-9]*/g)
@@ -96,7 +93,7 @@ function getAllGistsV2 (token, userId) {
       for (let i = 2; i <= maxPage; ++i) { requests.push(requestGists(token, userId, i, gistList)) }
       return Promise.all(requests)
         .then(() => {
-          return gistList.sort((g1, g2) => g2.updated_at.localeCompare(g1.updated_at))
+          return sortGistsByUpdatedAt(gistList)
         })
     })
     .catch(err => {
@@ -119,6 +116,10 @@ function requestGists (token, userId, page, gistList) {
 
 function parseBody (res, gistList) {
   for (const key in res) { if (Object.prototype.hasOwnProperty.call(res, key)) gistList.push(res[key]) }
+}
+
+function sortGistsByUpdatedAt (gistList) {
+  return gistList.sort((g1, g2) => g2.updated_at.localeCompare(g1.updated_at))
 }
 
 const EMPTY_PAGE_ERROR_MESSAGE = 'page empty (Not an error)'
@@ -178,8 +179,13 @@ function makeRangeArr (start, end) {
 
 const GISTS_PER_PAGE = 100
 function makeOptionForGetAllGists (token, userId, page) {
+  const shouldDownloadAllGists = conf && conf.get('gist:downloadAll')
+  const uri = shouldDownloadAllGists
+    ? `https://${gitHubHostApi}/gists`
+    : `https://${gitHubHostApi}/users/${userId}/gists`
+
   return {
-    uri: `https://${gitHubHostApi}/users/${userId}/gists`,
+    uri: uri,
     agent: proxyAgent,
     headers: {
       'User-Agent': userAgent,

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -26,6 +26,9 @@ module.exports = {
         "showInSnippetList": false,
         "colored": false
     },
+    "gist": {
+        "downloadAll": false
+    },
     "editor": {
         "tabSize": 4,
         "validateFilename": true

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -153,10 +153,10 @@ describe('GitHub API utility', () => {
     expect(result.map(gist => gist.id)).toEqual(['new', 'old'])
   })
 
-  it('falls back to the sequential gist request path when pagination headers are missing', async () => {
-    const { api, request } = await loadGitHubApi({
+  it('treats a missing pagination header as a complete single-page gist response', async () => {
+    const { api, request, requestPromise } = await loadGitHubApi({
       requestPromiseImpl: () => Promise.resolve({
-        body: [],
+        body: [{ id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }],
         headers: {}
       }),
       requestImpl: (options, callback) => {
@@ -169,11 +169,35 @@ describe('GitHub API utility', () => {
 
     const result = await api.getGitHubApi(api.GET_ALL_GISTS)('token-1', 'octo')
 
-    expect(request).toHaveBeenCalledTimes(2)
-    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({
+    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
       uri: 'https://api.github.com/users/octo/gists',
       qs: { per_page: 100, page: 1 }
-    }), expect.any(Function))
-    expect(result).toEqual([{ id: 'fallback', updated_at: '2022-01-01T00:00:00Z' }])
+    }))
+    expect(request).not.toHaveBeenCalled()
+    expect(result).toEqual([{ id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }])
+  })
+
+  it('uses the authenticated gists endpoint when downloadAll is enabled', async () => {
+    const { api, requestPromise } = await loadGitHubApi({
+      confValues: {
+        'gist:downloadAll': true
+      },
+      requestPromiseImpl: () => Promise.resolve({
+        body: [],
+        headers: {}
+      })
+    })
+
+    await api.getGitHubApi(api.GET_ALL_GISTS)('token-1', 'octo')
+
+    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
+      uri: 'https://api.github.com/gists',
+      headers: {
+        'User-Agent': 'hackjutsu-lepton-app',
+        Authorization: 'token token-1'
+      },
+      qs: { per_page: 100, page: 1 },
+      resolveWithFullResponse: true
+    }))
   })
 })


### PR DESCRIPTION
## Summary

- add a `gist.downloadAll` `.leptonrc` option, defaulting to `false`
- use the authenticated `/gists` endpoint when the option is enabled
- eagerly download each listed gist's full detail payload during sync when the option is enabled
- keep existing public-user gist sync behavior as the default
- treat a no-`Link` gist response as a complete single-page response instead of falling back to the legacy sequential path
- update GitHub API tests for the new single-page and authenticated-endpoint behavior

## Why

Issue #501 asks for a `.leptonrc` option to download all gists. The existing sync path always uses `/users/{user}/gists`, which only lists public gists for that user. Enabling `gist.downloadAll` switches to the authenticated-user endpoint while keeping the current behavior unchanged by default.

In this mode, startup sync also hydrates every discovered gist with `GET /gists/{id}` so file contents are already loaded in the current app session after sync completes.

Closes #501.

## Validation

- `npm run lint`
- `npm test` - 43 Vitest tests plus webpack development build
- `npm run test:smoke` - built the renderer, launched Electron with isolated config/user-data, and verified the login UI rendered
- launched Electron from scratch with isolated config/user-data and captured a success screenshot at `/private/tmp/lepton-issue-501-render.png`
- launched Electron with `gist.downloadAll: true`; log confirmed `Downloading details for 250 gists` before `updateGists`

## Notes

Webpack still emits existing Dart Sass legacy JS API deprecation warnings during builds.
