### PR TITLE
[codex] Apply configured proxy to Electron session

### DIFF
--- a/app/utilities/electronProxy/index.js
+++ b/app/utilities/electronProxy/index.js
@@ -1,0 +1,71 @@
+function getConfigValue (conf, key) {
+  if (!conf || typeof conf.get !== 'function') return undefined
+  return conf.get(key)
+}
+
+function normalizeElectronProxyRules (proxyRules) {
+  if (typeof proxyRules !== 'string') return ''
+
+  const trimmedRules = proxyRules.trim()
+  if (!trimmedRules) return ''
+
+  if (trimmedRules.indexOf('=') !== -1 || trimmedRules.indexOf(';') !== -1 || trimmedRules.indexOf(',') !== -1) {
+    return trimmedRules
+  }
+
+  if (trimmedRules.indexOf('socks://') === 0) {
+    return `socks5://${trimmedRules.substring('socks://'.length)}`
+  }
+
+  return trimmedRules
+}
+
+function createElectronProxyConfig (conf) {
+  if (!getConfigValue(conf, 'proxy:enable')) return null
+
+  const proxyAddress = getConfigValue(conf, 'proxy:address')
+  if (typeof proxyAddress !== 'string') return null
+
+  const proxyRules = proxyAddress.trim()
+  if (!proxyRules) return null
+
+  if (proxyRules.indexOf('pac+') === 0) {
+    return {
+      mode: 'pac_script',
+      pacScript: proxyRules.substring('pac+'.length)
+    }
+  }
+
+  return {
+    mode: 'fixed_servers',
+    proxyRules: normalizeElectronProxyRules(proxyRules),
+    proxyBypassRules: '<local>'
+  }
+}
+
+function applyElectronProxy ({ session, conf, logger = console }) {
+  const proxyConfig = createElectronProxyConfig(conf)
+  if (!proxyConfig) return Promise.resolve(false)
+
+  if (!session || !session.defaultSession || typeof session.defaultSession.setProxy !== 'function') {
+    logger.warn('[proxy] Electron session proxy API is unavailable')
+    return Promise.resolve(false)
+  }
+
+  return session.defaultSession.setProxy(proxyConfig)
+    .then(() => {
+      logger.info('[proxy] Electron session proxy enabled')
+      return true
+    })
+    .catch(error => {
+      const message = error && error.message ? error.message : error
+      logger.warn('[proxy] Failed to apply Electron session proxy: ' + message)
+      return false
+    })
+}
+
+module.exports = {
+  applyElectronProxy,
+  createElectronProxyConfig,
+  normalizeElectronProxyRules
+}

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ const appInfo = require('./package.json')
 const { createMainLogger } = require('./app/utilities/logging/mainLogger')
 const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
+const { applyElectronProxy } = require('./app/utilities/electronProxy')
 const { configureI18n, t } = require('./app/utilities/i18n')
 const electronLocalStorage = require('electron-json-storage-sync')
 const {
@@ -243,14 +244,20 @@ function createWindow (autoLogin) {
 }
 
 app.on('ready', () => {
-    applyStartAtLoginSetting({
-      app,
-      enabled: nconf.get('startAtLogin'),
-      logger
-    })
-    // createWindow()
+  applyStartAtLoginSetting({
+    app,
+    enabled: nconf.get('startAtLogin'),
+    logger
+  })
+  // createWindow()
+  applyElectronProxy({
+    session: electron.session,
+    conf: nconf,
+    logger
+  }).then(() => {
     checkForAppUpdates({ notify: true })
     createWindowAndAutoLogin()
+  })
 })
 
 app.on('window-all-closed', () => {

--- a/tests/utilities/electronProxy.test.js
+++ b/tests/utilities/electronProxy.test.js
@@ -1,0 +1,102 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  applyElectronProxy,
+  createElectronProxyConfig,
+  normalizeElectronProxyRules
+} = require('../../app/utilities/electronProxy')
+
+function createConf (values = {}) {
+  return {
+    get: (key) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : false
+  }
+}
+
+function createLogger () {
+  return {
+    info: vi.fn(),
+    warn: vi.fn()
+  }
+}
+
+describe('Electron proxy utility', () => {
+  it('skips Electron proxy config when disabled', () => {
+    expect(createElectronProxyConfig(createConf({
+      'proxy:enable': false,
+      'proxy:address': 'socks://localhost:1080'
+    }))).toBeNull()
+  })
+
+  it('builds fixed-server proxy config from .leptonrc proxy settings', () => {
+    expect(createElectronProxyConfig(createConf({
+      'proxy:enable': true,
+      'proxy:address': 'http://proxy.example.test:8080'
+    }))).toEqual({
+      mode: 'fixed_servers',
+      proxyRules: 'http://proxy.example.test:8080',
+      proxyBypassRules: '<local>'
+    })
+  })
+
+  it('normalizes Lepton socks shorthand for Chromium proxy rules', () => {
+    expect(normalizeElectronProxyRules('socks://localhost:1080'))
+      .toBe('socks5://localhost:1080')
+  })
+
+  it('preserves advanced Chromium proxy rule lists', () => {
+    expect(normalizeElectronProxyRules('http=proxy1:80;socks=socks-proxy:1080'))
+      .toBe('http=proxy1:80;socks=socks-proxy:1080')
+  })
+
+  it('maps proxy-agent PAC addresses to Electron PAC script mode', () => {
+    expect(createElectronProxyConfig(createConf({
+      'proxy:enable': true,
+      'proxy:address': 'pac+https://proxy.example.test/proxy.pac'
+    }))).toEqual({
+      mode: 'pac_script',
+      pacScript: 'https://proxy.example.test/proxy.pac'
+    })
+  })
+
+  it('applies Electron proxy config to the default session', async () => {
+    const setProxy = vi.fn(() => Promise.resolve())
+    const logger = createLogger()
+
+    await expect(applyElectronProxy({
+      session: { defaultSession: { setProxy } },
+      conf: createConf({
+        'proxy:enable': true,
+        'proxy:address': 'socks://localhost:1080'
+      }),
+      logger
+    })).resolves.toBe(true)
+
+    expect(setProxy).toHaveBeenCalledWith({
+      mode: 'fixed_servers',
+      proxyRules: 'socks5://localhost:1080',
+      proxyBypassRules: '<local>'
+    })
+    expect(logger.info).toHaveBeenCalledWith('[proxy] Electron session proxy enabled')
+  })
+
+  it('does not block startup when Electron proxy config fails', async () => {
+    const logger = createLogger()
+
+    await expect(applyElectronProxy({
+      session: {
+        defaultSession: {
+          setProxy: vi.fn(() => Promise.reject(new Error('bad proxy')))
+        }
+      },
+      conf: createConf({
+        'proxy:enable': true,
+        'proxy:address': 'http://proxy.example.test:8080'
+      }),
+      logger
+    })).resolves.toBe(false)
+
+    expect(logger.warn).toHaveBeenCalledWith('[proxy] Failed to apply Electron session proxy: bad proxy')
+  })
+})


### PR DESCRIPTION
## Summary

- Applies the existing `.leptonrc` proxy config to Electron's default browser session before update checks or app windows start.
- Adds a focused `electronProxy` helper that maps Lepton proxy settings into Electron `setProxy` config.
- Keeps the existing Node `proxy-agent` path for GitHub API requests, while covering Chromium traffic such as the GitHub OAuth login window.

## Why

Lepton already wires `proxy.enable` and `proxy.address` into Node-side GitHub API requests, including token exchange and gist CRUD. The OAuth login page is loaded by Electron/Chromium through a `BrowserWindow`, so it did not use that `proxy-agent` configuration. Users behind a proxy could still fail before reaching the API path.

Addresses #552.

## Validation

- `node -c main.js`
- `node -c app/utilities/electronProxy/index.js`
- `git diff --check`
- `npm run lint`
- `npm run test:unit`
- `npm run test:build`

`npm run test:build` passes with existing Sass legacy JS API deprecation warnings and the existing CodeMirror dynamic dependency warning.
