### PR TITLE
[codex] Fix Vue and cmd snippet highlighting

### DIFF
--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -74,10 +74,14 @@ export default class CodeArea extends Component {
     let language = lang || 'Other'
 
     // Adjust the language based on file extensions.
-    const filenameExtension = filename.split('.').pop()
+    const filenameExtension = filename.split('.').pop().toLowerCase()
     switch (filenameExtension) {
       case 'leptonrc':
         language = 'json'
+        break
+      case 'bat':
+      case 'cmd':
+        language = 'dos'
         break
       case 'zshrc':
         language = 'bash'
@@ -88,6 +92,9 @@ export default class CodeArea extends Component {
       case 'solidity':
       case 'sol':
         language = 'solidity'
+        break
+      case 'vue':
+        language = 'xml'
         break
       default:
       // intentionally left blank
@@ -101,7 +108,8 @@ export default class CodeArea extends Component {
       case 'Objective-C': return 'objectivec'
       case 'Objective-C++': return 'objectivec'
       case 'Visual Basic': return 'vbscript'
-      case 'Batchfile': return 'bat'
+      case 'Batchfile': return 'dos'
+      case 'Vue': return 'xml'
       default:
     }
 


### PR DESCRIPTION
## Summary
- map .vue files and GitHub Vue language metadata to highlight.js XML highlighting for rendered snippets
- map .cmd/.bat files and GitHub Batchfile metadata to highlight.js DOS highlighting
- make filename extension matching case-insensitive for these renderer language overrides

## Root cause
Rendered snippets use highlight.js language hints, while the editor uses CodeMirror modes. The installed highlight.js package does not expose a dedicated vue language, and the existing Batchfile mapping did not normalize to the renderer language used for DOS/cmd syntax.

Fixes #466.

## Validation
- npm run lint
- npm test