### PR TITLE
Silence optional account config warning

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -47,15 +47,18 @@ import {
 
 import { notifySuccess, notifyFailure } from './utilities/notifier'
 
+const path = require('path')
+const { createRequire } = require('module')
 const remote = require('@electron/remote')
 const logger = remote.getGlobal('logger')
+const appRequire = createRequire(path.join(remote.app.getAppPath(), 'app/index.js'))
 
 let Account = null
 try {
-  Account = require('../configs/account')
+  Account = appRequire('../configs/account')
 } catch (e) {
   if (e.code !== 'MODULE_NOT_FOUND') throw e
-  Account = require('../configs/accountDummy')
+  Account = appRequire('../configs/accountDummy')
 }
 
 // First instantiate the class


### PR DESCRIPTION
## Summary
- load the optional GitHub OAuth account config through Node's runtime require instead of a static webpack require
- keep the existing fallback to configs/accountDummy.js when local configs/account.js is absent
- remove the expected webpack warning for the gitignored configs/account.js file

## Why
configs/account.js is intentionally gitignored because it can contain local OAuth credentials. The app already treats it as optional at runtime, but webpack still saw require('../configs/account') as a static dependency and warned during every test/build when the file was absent.

That warning made successful builds look partially broken. Loading the optional file through a runtime require keeps the same app behavior while letting webpack compile the checked-in source cleanly.

## Verification
- npm run lint
- npm test
- npm run build
- npm start with XDG_CONFIG_HOME=/private/tmp/lepton-account-warning-config

## Notes
- npm test and npm run build now compile successfully without the previous Can't resolve '../configs/account' warning.
- The existing markdown-it-katex git+ssh URL deprecation warning remains during license generation.