### PR TITLE
Support colored tags in snippet views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,18 @@ npm run preversion
 ### Testing
 The `npm test` command runs webpack in development mode (essentially a build verification). There are no formal unit tests configured - the project relies on build-time checks and manual testing.
 
+### Rendering Verification
+For any Electron, React, layout, CSS, webpack, or dependency change that could affect the UI, always verify actual rendering before considering the work complete:
+
+```bash
+npm run build
+npm start
+```
+
+Confirm more than process startup. The app must visibly render the Lepton UI, not just log `updateUserSession ACTIVE`. Always capture a screenshot of the running app and show that screenshot in the chat when reporting rendering verification. If the window is blank or suspicious, inspect the renderer with Electron DevTools or a remote debugging port and verify DOM layout, visible text, and the renderer screenshot. Before relaunching, check for and stop duplicate Lepton/Electron instances so stale blank windows do not mask the current result.
+
+Document rendering verification in PR descriptions, including whether the app was launched locally and what was observed.
+
 ## Architecture
 
 ### Application Structure

--- a/app/containers/navigationPanel/index.js
+++ b/app/containers/navigationPanel/index.js
@@ -5,6 +5,7 @@ import { parseLangName as Resolved } from '../../utilities/parser'
 import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
 import UserPanel from '../userPanel'
+import { getNextActiveGistTag } from './tags'
 import {
   fetchSingleGist,
   selectGist,
@@ -42,9 +43,10 @@ class NavigationPanel extends Component {
   }
 
   handleClicked (key) {
-    const { selectGistTag, updateActiveGistAfterClicked, gists, gistTags } = this.props
-    selectGistTag(key)
-    updateActiveGistAfterClicked(gists, gistTags, key)
+    const { selectGistTag, updateActiveGistAfterClicked, gists, gistTags, activeGistTag } = this.props
+    const nextTag = getNextActiveGistTag(key, activeGistTag)
+    selectGistTag(nextTag)
+    updateActiveGistAfterClicked(gists, gistTags, nextTag)
   }
 
   renderPinnedTags () {
@@ -240,32 +242,22 @@ class NavigationPanel extends Component {
     })
     const orderedGistTags = [...customTags, ...langTags]
 
-    const tagsForPinRows = []
-    let i = 1
-    let row = []
+    const tagsForPin = []
     orderedGistTags.forEach(tag => {
-      row.push(
-        <td key={ tag }>
+      tagsForPin.push(
+        <div className='pin-tag-item' key={ tag }>
           <a
             onClick={ this.handleTagInPinnedTagsModalClicked.bind(this, tag) }
             className={ tmpPinnedTags.has(tag) ? 'gist-tag-pinned' : 'gist-tag-not-pinned' }>
               #{ tag.startsWith('lang@') ? Resolved(tag) : tag }
           </a>
-        </td>)
-      if (i++ % 5 === 0) {
-        tagsForPinRows.push(<tr key={ i }>{ row }</tr>)
-        row = []
-      }
+        </div>)
     })
 
-    row && tagsForPinRows.push(<tr key={ i }>{ row }</tr>)
-
     return (
-      <table className='pin-tag-table'>
-        <tbody>
-          { tagsForPinRows }
-        </tbody>
-      </table>
+      <div className='pin-tag-list'>
+        { tagsForPin }
+      </div>
     )
   }
 

--- a/app/containers/navigationPanel/index.scss
+++ b/app/containers/navigationPanel/index.scss
@@ -153,8 +153,24 @@
 }
 
 .pinned-tags-modal {
-  .pin-tag-table {
-    width: 100%;
+  .modal-dialog {
+    max-width: calc(100vw - 40px);
+  }
+
+  .modal-body {
+    max-height: calc(100vh - 180px);
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  .pin-tag-list {
+    display: grid;
+    gap: 6px 14px;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  }
+
+  .pin-tag-item {
+    min-width: 0;
   }
 
   .font-style-base {
@@ -164,15 +180,19 @@
 
   .gist-tag-not-pinned {
     @extend .font-style-base;
-    margin: 5px;
     cursor: pointer;
+    display: block;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
   }
 
   .gist-tag-pinned {
     @extend .font-style-base;
-    margin: 5px;
     color: rgb(3, 123, 183);
+    display: block;
     font-weight: bold;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
     cursor: pointer;
   }
 }

--- a/app/containers/navigationPanel/tags.js
+++ b/app/containers/navigationPanel/tags.js
@@ -1,0 +1,9 @@
+import { addLangPrefix as Prefixed } from '../../utilities/parser'
+
+export function getNextActiveGistTag (clickedTag, activeGistTag) {
+  if (clickedTag === activeGistTag) {
+    return Prefixed('All')
+  }
+
+  return clickedTag
+}

--- a/app/containers/navigationPanelDetails/index.js
+++ b/app/containers/navigationPanelDetails/index.js
@@ -7,7 +7,8 @@ import React, { Component } from 'react'
 import TagBadges from '../tagBadges'
 import {
   getRegularTagsForGist,
-  shouldUseColoredTags
+  shouldColorTags,
+  shouldShowTagsInSnippetList
 } from '../tagBadges/tags'
 
 import './index.scss'
@@ -51,7 +52,7 @@ class NavigationPanelDetails extends Component {
   }
 
   renderSnippetTags (gistId, customTags) {
-    if (!conf.get('snippet:showTagsInSnippetList')) {
+    if (!shouldShowTagsInSnippetList(conf)) {
       return null
     }
 
@@ -61,7 +62,7 @@ class NavigationPanelDetails extends Component {
       <TagBadges
         tags={ tags }
         className='snippet-thumnail-tags'
-        colored={ shouldUseColoredTags(conf.get('snippet:coloredTags')) } />
+        colored={ shouldColorTags(conf) } />
     )
   }
 

--- a/app/containers/navigationPanelDetails/index.js
+++ b/app/containers/navigationPanelDetails/index.js
@@ -4,6 +4,8 @@ import { descriptionParser } from '../../utilities/parser'
 import electronBridge from '../../utilities/electronBridge'
 import { selectGist, fetchSingleGist, updatescrollRequestStatus } from '../../actions'
 import React, { Component } from 'react'
+import TagBadges from '../tagBadges'
+import { getRegularTagsForGist } from '../tagBadges/tags'
 
 import './index.scss'
 
@@ -43,6 +45,16 @@ class NavigationPanelDetails extends Component {
       }
     }
     return 'snippet-thumnail'
+  }
+
+  renderSnippetTags (gistId, customTags) {
+    if (!conf.get('snippet:showTagsInSnippetList')) {
+      return null
+    }
+
+    const { gistTags } = this.props
+    const tags = getRegularTagsForGist(gistId, customTags, gistTags)
+    return <TagBadges tags={ tags } className='snippet-thumnail-tags' />
   }
 
   renderSnippetThumbnails () {
@@ -88,7 +100,7 @@ class NavigationPanelDetails extends Component {
       // for null, '' and undefined
       const rawDescription = gist.brief.description || firstFilename
 
-      const { title, description } = descriptionParser(rawDescription)
+      const { title, description, customTags } = descriptionParser(rawDescription)
       const thumbnailTitle = title.length > 0 ? title : description
       const gistId = gist.brief.id
       snippetThumbnails.push(
@@ -96,6 +108,7 @@ class NavigationPanelDetails extends Component {
           <div className={ this.decideSnippetListItemClass(gistId) }
             onClick={ this.handleClicked.bind(this, gistId) }>
             <div className='snippet-thumnail-description'>{ thumbnailTitle }</div>
+            { this.renderSnippetTags(gistId, customTags) }
           </div>
         </li>
       )

--- a/app/containers/navigationPanelDetails/index.js
+++ b/app/containers/navigationPanelDetails/index.js
@@ -5,7 +5,10 @@ import electronBridge from '../../utilities/electronBridge'
 import { selectGist, fetchSingleGist, updatescrollRequestStatus } from '../../actions'
 import React, { Component } from 'react'
 import TagBadges from '../tagBadges'
-import { getRegularTagsForGist } from '../tagBadges/tags'
+import {
+  getRegularTagsForGist,
+  shouldUseColoredTags
+} from '../tagBadges/tags'
 
 import './index.scss'
 
@@ -54,7 +57,12 @@ class NavigationPanelDetails extends Component {
 
     const { gistTags } = this.props
     const tags = getRegularTagsForGist(gistId, customTags, gistTags)
-    return <TagBadges tags={ tags } className='snippet-thumnail-tags' />
+    return (
+      <TagBadges
+        tags={ tags }
+        className='snippet-thumnail-tags'
+        colored={ shouldUseColoredTags(conf.get('snippet:coloredTags')) } />
+    )
   }
 
   renderSnippetThumbnails () {

--- a/app/containers/navigationPanelDetails/index.scss
+++ b/app/containers/navigationPanelDetails/index.scss
@@ -83,4 +83,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .snippet-thumnail-tags {
+    margin: 0 5px 5px;
+  }
 }

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -12,7 +12,7 @@ import React, { Component } from 'react'
 import TagBadges from '../tagBadges'
 import {
   getRegularTagsForGist,
-  shouldUseColoredTags
+  shouldColorTags
 } from '../tagBadges/tags'
 import {
   addLangPrefix as Prefixed,
@@ -436,7 +436,7 @@ class Snippet extends Component {
   renderSnippetDescription (gist) {
     const { title, description, customTags } = descriptionParser(gist.brief.description)
     const tags = getRegularTagsForGist(gist.brief.id, customTags, this.props.gistTags)
-    const useColoredTags = shouldUseColoredTags(conf.get('snippet:coloredTags'))
+    const useColoredTags = shouldColorTags(conf)
 
     const htmlForDescriptionSection = []
     if (title.length > 0) {

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -10,7 +10,10 @@ import Moment from 'moment'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
 import TagBadges from '../tagBadges'
-import { getRegularTagsForGist } from '../tagBadges/tags'
+import {
+  getRegularTagsForGist,
+  shouldUseColoredTags
+} from '../tagBadges/tags'
 import {
   addLangPrefix as Prefixed,
   descriptionParser,
@@ -433,6 +436,7 @@ class Snippet extends Component {
   renderSnippetDescription (gist) {
     const { title, description, customTags } = descriptionParser(gist.brief.description)
     const tags = getRegularTagsForGist(gist.brief.id, customTags, this.props.gistTags)
+    const useColoredTags = shouldUseColoredTags(conf.get('snippet:coloredTags'))
 
     const htmlForDescriptionSection = []
     if (title.length > 0) {
@@ -457,7 +461,12 @@ class Snippet extends Component {
             <div
               className='custom-tags-icon'
               dangerouslySetInnerHTML={{ __html: tagsIcon }} />
-            <TagBadges tags={ tags } className='snippet-detail-tags' />
+            { useColoredTags
+              ? <TagBadges
+                tags={ tags }
+                className='snippet-detail-tags'
+                colored={ useColoredTags } />
+              : <span className='custom-tags-text'>{ tags.join(', ') }</span> }
           </div>
           : null }
         <span className='update-date'>

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -9,6 +9,8 @@ import HumanReadableTime from 'human-readable-time'
 import Moment from 'moment'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
+import TagBadges from '../tagBadges'
+import { getRegularTagsForGist } from '../tagBadges/tags'
 import {
   addLangPrefix as Prefixed,
   descriptionParser,
@@ -430,6 +432,7 @@ class Snippet extends Component {
 
   renderSnippetDescription (gist) {
     const { title, description, customTags } = descriptionParser(gist.brief.description)
+    const tags = getRegularTagsForGist(gist.brief.id, customTags, this.props.gistTags)
 
     const htmlForDescriptionSection = []
     if (title.length > 0) {
@@ -449,13 +452,13 @@ class Snippet extends Component {
     )
     htmlForDescriptionSection.push(
       <div className='custom-tags-section' key='customTags'>
-        { customTags.length > 0
-          ? <span className='custom-tags'>
+        { tags.length > 0
+          ? <div className='custom-tags'>
             <div
               className='custom-tags-icon'
               dangerouslySetInnerHTML={{ __html: tagsIcon }} />
-            <span>{ customTags.substring('#tags:'.length) }</span>
-          </span>
+            <TagBadges tags={ tags } className='snippet-detail-tags' />
+          </div>
           : null }
         <span className='update-date'>
           { 'Last active ' + Moment(gist.brief.updated_at).fromNow() }

--- a/app/containers/snippet/index.scss
+++ b/app/containers/snippet/index.scss
@@ -274,6 +274,11 @@
     max-width: 70%;
   }
 
+  .custom-tags-text {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   .custom-tags-icon {
     display: inline-block;
     vertical-align: middle;

--- a/app/containers/snippet/index.scss
+++ b/app/containers/snippet/index.scss
@@ -268,11 +268,10 @@
 
   .custom-tags {
     float: left;
-
-    span {
-      display: inline-block;
-      vertical-align: middle;
-    }
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 70%;
   }
 
   .custom-tags-icon {
@@ -282,6 +281,11 @@
     width: 16px;
     margin-right: 2px;
     position: relative;
+  }
+
+  .snippet-detail-tags {
+    display: inline-flex;
+    min-width: 0;
   }
 
   .update-date {

--- a/app/containers/tagBadges/index.js
+++ b/app/containers/tagBadges/index.js
@@ -1,5 +1,8 @@
 import React from 'react'
-import { getTagBadgeClassName } from './tags'
+import {
+  getTagBadgeClassName,
+  getTagBadgeLabel
+} from './tags'
 
 import './index.scss'
 
@@ -14,7 +17,7 @@ export default function TagBadges ({ tags, className = '', colored = true }) {
     <div className={ classNames }>
       { tags.map(tag => (
         <span className={ getTagBadgeClassName(tag, colored) } key={ tag }>
-          { tag }
+          { getTagBadgeLabel(tag, colored) }
         </span>
       )) }
     </div>

--- a/app/containers/tagBadges/index.js
+++ b/app/containers/tagBadges/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { getTagColorClass } from './tags'
+
+import './index.scss'
+
+export default function TagBadges ({ tags, className = '' }) {
+  if (!tags || tags.length === 0) {
+    return null
+  }
+
+  const classNames = ['tag-badges', className].filter(Boolean).join(' ')
+  return (
+    <div className={ classNames }>
+      { tags.map(tag => (
+        <span className={ `tag-badge ${getTagColorClass(tag)}` } key={ tag }>
+          { tag }
+        </span>
+      )) }
+    </div>
+  )
+}

--- a/app/containers/tagBadges/index.js
+++ b/app/containers/tagBadges/index.js
@@ -1,18 +1,19 @@
 import React from 'react'
-import { getTagColorClass } from './tags'
+import { getTagBadgeClassName } from './tags'
 
 import './index.scss'
 
-export default function TagBadges ({ tags, className = '' }) {
+export default function TagBadges ({ tags, className = '', colored = true }) {
   if (!tags || tags.length === 0) {
     return null
   }
 
-  const classNames = ['tag-badges', className].filter(Boolean).join(' ')
+  const colorModeClassName = colored ? 'tag-badges-colored' : 'tag-badges-plain'
+  const classNames = ['tag-badges', colorModeClassName, className].filter(Boolean).join(' ')
   return (
     <div className={ classNames }>
       { tags.map(tag => (
-        <span className={ `tag-badge ${getTagColorClass(tag)}` } key={ tag }>
+        <span className={ getTagBadgeClassName(tag, colored) } key={ tag }>
           { tag }
         </span>
       )) }

--- a/app/containers/tagBadges/index.scss
+++ b/app/containers/tagBadges/index.scss
@@ -1,0 +1,43 @@
+.tag-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.tag-badge {
+  border-radius: 3px;
+  color: #fff;
+  display: inline-block;
+  font-size: 11px;
+  line-height: 1.3;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 2px 5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-badge-color-0 {
+  background-color: #2f80ed;
+}
+
+.tag-badge-color-1 {
+  background-color: #219653;
+}
+
+.tag-badge-color-2 {
+  background-color: #9b51e0;
+}
+
+.tag-badge-color-3 {
+  background-color: #f2994a;
+}
+
+.tag-badge-color-4 {
+  background-color: #eb5757;
+}
+
+.tag-badge-color-5 {
+  background-color: #00a3a3;
+}

--- a/app/containers/tagBadges/index.scss
+++ b/app/containers/tagBadges/index.scss
@@ -20,22 +20,17 @@
 }
 
 .tag-badges-plain {
-  gap: 0;
+  gap: 4px;
 }
 
 .tag-badge-plain {
   background-color: transparent;
   border-radius: 0;
-  color: inherit;
-  font-size: inherit;
-  font-style: inherit;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-style: italic;
   line-height: inherit;
   padding: 0;
-}
-
-.tag-badge-plain:not(:last-child)::after {
-  content: ', ';
-  white-space: pre;
 }
 
 .tag-badge-color-0 {

--- a/app/containers/tagBadges/index.scss
+++ b/app/containers/tagBadges/index.scss
@@ -10,12 +10,32 @@
   color: #fff;
   display: inline-block;
   font-size: 11px;
+  font-style: normal;
   line-height: 1.3;
   max-width: 100%;
   overflow: hidden;
   padding: 2px 5px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tag-badges-plain {
+  gap: 0;
+}
+
+.tag-badge-plain {
+  background-color: transparent;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+  font-style: inherit;
+  line-height: inherit;
+  padding: 0;
+}
+
+.tag-badge-plain:not(:last-child)::after {
+  content: ', ';
+  white-space: pre;
 }
 
 .tag-badge-color-0 {

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -1,0 +1,42 @@
+import { parseCustomTags } from '../../utilities/parser'
+
+const tagColorClasses = [
+  'tag-badge-color-0',
+  'tag-badge-color-1',
+  'tag-badge-color-2',
+  'tag-badge-color-3',
+  'tag-badge-color-4',
+  'tag-badge-color-5'
+]
+
+export function getTagColorClass (tag) {
+  const hash = tag.split('').reduce((memo, char) => {
+    return ((memo << 5) - memo) + char.charCodeAt(0)
+  }, 0)
+  const index = ((hash % tagColorClasses.length) + tagColorClasses.length) % tagColorClasses.length
+  return tagColorClasses[index]
+}
+
+export function getRegularTagsForGist (gistId, customTags, gistTags) {
+  const seenTags = new Set()
+  const tags = []
+  const pushTag = tag => {
+    const label = (tag || '').trim()
+    const normalizedLabel = label.toLowerCase()
+    if (label.length === 0 || seenTags.has(normalizedLabel)) {
+      return
+    }
+
+    seenTags.add(normalizedLabel)
+    tags.push(label)
+  }
+
+  parseCustomTags(customTags).forEach(pushTag)
+  Object.keys(gistTags || {})
+    .filter(tag => !tag.startsWith('lang@'))
+    .filter(tag => Array.isArray(gistTags[tag]) && gistTags[tag].includes(gistId))
+    .sort()
+    .forEach(pushTag)
+
+  return tags
+}

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -35,7 +35,7 @@ export function shouldShowTagsInSnippetList (conf) {
 }
 
 export function shouldColorTags (conf) {
-  return shouldUseColoredTags(getConfigValue(conf, 'tag:colored', true))
+  return shouldUseColoredTags(getConfigValue(conf, 'tag:colored', false))
 }
 
 export function getTagBadgeClassName (tag, colored = true) {

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -17,6 +17,20 @@ export function getTagColorClass (tag) {
   return tagColorClasses[index]
 }
 
+export function shouldUseColoredTags (value) {
+  return value !== false
+}
+
+export function getTagBadgeClassName (tag, colored = true) {
+  const classNames = ['tag-badge']
+  if (colored) {
+    classNames.push(getTagColorClass(tag))
+  } else {
+    classNames.push('tag-badge-plain')
+  }
+  return classNames.join(' ')
+}
+
 export function getRegularTagsForGist (gistId, customTags, gistTags) {
   const seenTags = new Set()
   const tags = []

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -21,6 +21,28 @@ export function shouldUseColoredTags (value) {
   return value !== false
 }
 
+function getConfigValue (conf, preferredKey, fallbackKey, defaultValue) {
+  if (!conf || typeof conf.get !== 'function') {
+    return defaultValue
+  }
+
+  const preferredValue = conf.get(preferredKey)
+  if (preferredValue !== undefined) {
+    return preferredValue
+  }
+
+  const fallbackValue = conf.get(fallbackKey)
+  return fallbackValue !== undefined ? fallbackValue : defaultValue
+}
+
+export function shouldShowTagsInSnippetList (conf) {
+  return getConfigValue(conf, 'tag:showInSnippetList', 'snippet:showTagsInSnippetList', false) === true
+}
+
+export function shouldColorTags (conf) {
+  return shouldUseColoredTags(getConfigValue(conf, 'tag:colored', 'snippet:coloredTags', true))
+}
+
 export function getTagBadgeClassName (tag, colored = true) {
   const classNames = ['tag-badge']
   if (colored) {

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -21,26 +21,21 @@ export function shouldUseColoredTags (value) {
   return value !== false
 }
 
-function getConfigValue (conf, preferredKey, fallbackKey, defaultValue) {
+function getConfigValue (conf, key, defaultValue) {
   if (!conf || typeof conf.get !== 'function') {
     return defaultValue
   }
 
-  const preferredValue = conf.get(preferredKey)
-  if (preferredValue !== undefined) {
-    return preferredValue
-  }
-
-  const fallbackValue = conf.get(fallbackKey)
-  return fallbackValue !== undefined ? fallbackValue : defaultValue
+  const value = conf.get(key)
+  return value !== undefined ? value : defaultValue
 }
 
 export function shouldShowTagsInSnippetList (conf) {
-  return getConfigValue(conf, 'tag:showInSnippetList', 'snippet:showTagsInSnippetList', false) === true
+  return getConfigValue(conf, 'tag:showInSnippetList', false) === true
 }
 
 export function shouldColorTags (conf) {
-  return shouldUseColoredTags(getConfigValue(conf, 'tag:colored', 'snippet:coloredTags', true))
+  return shouldUseColoredTags(getConfigValue(conf, 'tag:colored', true))
 }
 
 export function getTagBadgeClassName (tag, colored = true) {

--- a/app/containers/tagBadges/tags.js
+++ b/app/containers/tagBadges/tags.js
@@ -31,6 +31,10 @@ export function getTagBadgeClassName (tag, colored = true) {
   return classNames.join(' ')
 }
 
+export function getTagBadgeLabel (tag, colored = true) {
+  return colored ? tag : `#${tag}`
+}
+
 export function getRegularTagsForGist (gistId, customTags, gistTags) {
   const seenTags = new Set()
   const tags = []

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -20,7 +20,8 @@ module.exports = {
         "sortingReverse": true,
         "expanded": true,
         "newSnippetPrivate": false,
-        "showTagsInSnippetList": false
+        "showTagsInSnippetList": false,
+        "coloredTags": true
     },
     "editor": {
         "tabSize": 4,

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -23,7 +23,7 @@ module.exports = {
     },
     "tag": {
         "showInSnippetList": false,
-        "colored": true
+        "colored": false
     },
     "editor": {
         "tabSize": 4,

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -19,9 +19,11 @@ module.exports = {
         "sorting": "updated_at",
         "sortingReverse": true,
         "expanded": true,
-        "newSnippetPrivate": false,
-        "showTagsInSnippetList": false,
-        "coloredTags": true
+        "newSnippetPrivate": false
+    },
+    "tag": {
+        "showInSnippetList": false,
+        "colored": true
     },
     "editor": {
         "tabSize": 4,

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -19,7 +19,8 @@ module.exports = {
         "sorting": "updated_at",
         "sortingReverse": true,
         "expanded": true,
-        "newSnippetPrivate": false
+        "newSnippetPrivate": false,
+        "showTagsInSnippetList": false
     },
     "editor": {
         "tabSize": 4,

--- a/tests/containers/navigationPanel.test.js
+++ b/tests/containers/navigationPanel.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { addLangPrefix as Prefixed } from '../../app/utilities/parser'
+import { getNextActiveGistTag } from '../../app/containers/navigationPanel/tags'
+
+describe('navigation panel tag helpers', () => {
+  it('selects the clicked tag when it is not active', () => {
+    expect(getNextActiveGistTag('tmux', Prefixed('All'))).toBe('tmux')
+  })
+
+  it('deselects the active tag by falling back to All', () => {
+    expect(getNextActiveGistTag('tmux', 'tmux')).toBe(Prefixed('All'))
+  })
+
+  it('keeps All selected when All is clicked again', () => {
+    expect(getNextActiveGistTag(Prefixed('All'), Prefixed('All'))).toBe(Prefixed('All'))
+  })
+})

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -105,7 +105,7 @@ describe('tag badge helpers', () => {
   })
 
   it('reads tag color settings from the tag config section', () => {
-    expect(shouldColorTags(fakeConf({}))).toBe(true)
+    expect(shouldColorTags(fakeConf({}))).toBe(false)
     expect(shouldColorTags(fakeConf({
       'tag:colored': false
     }))).toBe(false)
@@ -113,7 +113,7 @@ describe('tag badge helpers', () => {
       'tag:colored': true
     }))).toBe(true)
     expect(shouldColorTags(fakeConf({
-      'snippet:coloredTags': false
-    }))).toBe(true)
+      'snippet:coloredTags': true
+    }))).toBe(false)
   })
 })

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -5,6 +5,8 @@ import {
   getRegularTagsForGist,
   getTagBadgeClassName,
   getTagBadgeLabel,
+  shouldColorTags,
+  shouldShowTagsInSnippetList,
   shouldUseColoredTags,
   getTagColorClass
 } from '../../app/containers/tagBadges/tags'
@@ -17,6 +19,12 @@ const tagBadgeStyles = readFileSync(
 function getStyleRule (selector) {
   const match = tagBadgeStyles.match(new RegExp(`${selector}\\s*\\{[^}]+\\}`))
   return match ? match[0] : ''
+}
+
+function fakeConf (values) {
+  return {
+    get: key => values[key]
+  }
 }
 
 describe('tag badge helpers', () => {
@@ -81,5 +89,33 @@ describe('tag badge helpers', () => {
     expect(plainTagRule).toContain('color: var(--text-secondary);')
     expect(plainTagRule).toContain('font-size: 12px;')
     expect(plainTagRule).toContain('font-style: italic;')
+  })
+
+  it('reads tag display settings from the tag config section', () => {
+    expect(shouldShowTagsInSnippetList(fakeConf({
+      'tag:showInSnippetList': true
+    }))).toBe(true)
+    expect(shouldShowTagsInSnippetList(fakeConf({
+      'tag:showInSnippetList': false,
+      'snippet:showTagsInSnippetList': true
+    }))).toBe(false)
+    expect(shouldShowTagsInSnippetList(fakeConf({
+      'snippet:showTagsInSnippetList': true
+    }))).toBe(true)
+    expect(shouldShowTagsInSnippetList(fakeConf({}))).toBe(false)
+  })
+
+  it('reads tag color settings from the tag config section', () => {
+    expect(shouldColorTags(fakeConf({}))).toBe(true)
+    expect(shouldColorTags(fakeConf({
+      'tag:colored': false
+    }))).toBe(false)
+    expect(shouldColorTags(fakeConf({
+      'tag:colored': true,
+      'snippet:coloredTags': false
+    }))).toBe(true)
+    expect(shouldColorTags(fakeConf({
+      'snippet:coloredTags': false
+    }))).toBe(false)
   })
 })

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getRegularTagsForGist,
   getTagBadgeClassName,
+  getTagBadgeLabel,
   shouldUseColoredTags,
   getTagColorClass
 } from '../../app/containers/tagBadges/tags'
@@ -58,5 +59,7 @@ describe('tag badge helpers', () => {
 
     expect(getTagBadgeClassName('tmux')).toMatch(/^tag-badge tag-badge-color-[0-5]$/)
     expect(getTagBadgeClassName('tmux', false)).toBe('tag-badge tag-badge-plain')
+    expect(getTagBadgeLabel('tmux')).toBe('tmux')
+    expect(getTagBadgeLabel('tmux', false)).toBe('#tmux')
   })
 })

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -7,6 +8,16 @@ import {
   shouldUseColoredTags,
   getTagColorClass
 } from '../../app/containers/tagBadges/tags'
+
+const tagBadgeStyles = readFileSync(
+  new URL('../../app/containers/tagBadges/index.scss', import.meta.url),
+  'utf8'
+)
+
+function getStyleRule (selector) {
+  const match = tagBadgeStyles.match(new RegExp(`${selector}\\s*\\{[^}]+\\}`))
+  return match ? match[0] : ''
+}
 
 describe('tag badge helpers', () => {
   it('combines description tags with matching regular gist tags', () => {
@@ -61,5 +72,14 @@ describe('tag badge helpers', () => {
     expect(getTagBadgeClassName('tmux', false)).toBe('tag-badge tag-badge-plain')
     expect(getTagBadgeLabel('tmux')).toBe('tmux')
     expect(getTagBadgeLabel('tmux', false)).toBe('#tmux')
+  })
+
+  it('keeps plain tag badges compatible with the original tag text style', () => {
+    const plainTagRule = getStyleRule('\\.tag-badge-plain')
+
+    expect(plainTagRule).toContain('background-color: transparent;')
+    expect(plainTagRule).toContain('color: var(--text-secondary);')
+    expect(plainTagRule).toContain('font-size: 12px;')
+    expect(plainTagRule).toContain('font-style: italic;')
   })
 })

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getRegularTagsForGist,
+  getTagColorClass
+} from '../../app/containers/tagBadges/tags'
+
+describe('tag badge helpers', () => {
+  it('combines description tags with matching regular gist tags', () => {
+    const gistTags = {
+      'lang@Shell': ['gist-1'],
+      SSH: ['gist-1'],
+      git: ['gist-1'],
+      k8s: ['gist-1'],
+      tmux: ['gist-1'],
+      zsh: ['gist-2']
+    }
+
+    expect(getRegularTagsForGist('gist-1', '#tags: tmux, ssh, Git', gistTags)).toEqual([
+      'tmux',
+      'ssh',
+      'Git',
+      'k8s'
+    ])
+  })
+
+  it('excludes language tags and non-matching gist tags', () => {
+    const gistTags = {
+      'lang@Markdown': ['gist-1'],
+      docs: ['gist-2'],
+      lepton: ['gist-1']
+    }
+
+    expect(getRegularTagsForGist('gist-1', '', gistTags)).toEqual(['lepton'])
+  })
+
+  it('handles missing or malformed tag indexes', () => {
+    const gistTags = {
+      lepton: null,
+      tmux: 'gist-1'
+    }
+
+    expect(getRegularTagsForGist('gist-1', undefined, gistTags)).toEqual([])
+    expect(getRegularTagsForGist('gist-1', '#tags: tmux', undefined)).toEqual(['tmux'])
+  })
+
+  it('returns stable badge color classes', () => {
+    expect(getTagColorClass('tmux')).toBe(getTagColorClass('tmux'))
+    expect(getTagColorClass('tmux')).toMatch(/^tag-badge-color-[0-5]$/)
+  })
+})

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   getRegularTagsForGist,
+  getTagBadgeClassName,
+  shouldUseColoredTags,
   getTagColorClass
 } from '../../app/containers/tagBadges/tags'
 
@@ -47,5 +49,14 @@ describe('tag badge helpers', () => {
   it('returns stable badge color classes', () => {
     expect(getTagColorClass('tmux')).toBe(getTagColorClass('tmux'))
     expect(getTagColorClass('tmux')).toMatch(/^tag-badge-color-[0-5]$/)
+  })
+
+  it('uses colored badge classes unless color rendering is disabled', () => {
+    expect(shouldUseColoredTags(undefined)).toBe(true)
+    expect(shouldUseColoredTags(true)).toBe(true)
+    expect(shouldUseColoredTags(false)).toBe(false)
+
+    expect(getTagBadgeClassName('tmux')).toMatch(/^tag-badge tag-badge-color-[0-5]$/)
+    expect(getTagBadgeClassName('tmux', false)).toBe('tag-badge tag-badge-plain')
   })
 })

--- a/tests/containers/tagBadges.test.js
+++ b/tests/containers/tagBadges.test.js
@@ -96,12 +96,11 @@ describe('tag badge helpers', () => {
       'tag:showInSnippetList': true
     }))).toBe(true)
     expect(shouldShowTagsInSnippetList(fakeConf({
-      'tag:showInSnippetList': false,
-      'snippet:showTagsInSnippetList': true
+      'tag:showInSnippetList': false
     }))).toBe(false)
     expect(shouldShowTagsInSnippetList(fakeConf({
       'snippet:showTagsInSnippetList': true
-    }))).toBe(true)
+    }))).toBe(false)
     expect(shouldShowTagsInSnippetList(fakeConf({}))).toBe(false)
   })
 
@@ -111,11 +110,10 @@ describe('tag badge helpers', () => {
       'tag:colored': false
     }))).toBe(false)
     expect(shouldColorTags(fakeConf({
-      'tag:colored': true,
-      'snippet:coloredTags': false
+      'tag:colored': true
     }))).toBe(true)
     expect(shouldColorTags(fakeConf({
       'snippet:coloredTags': false
-    }))).toBe(false)
+    }))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Implements the colored-tags feature request from #484.
- Adds a dedicated `.leptonrc` `tag` section:
  - `tag.showInSnippetList`: controls whether regular tags appear in the middle snippet-select panel. Default: `false`.
  - `tag.colored`: controls whether tags render as colored badges or plain tag text. Default: `false`.
- Shows regular/custom gist tags as colored badges in the snippet-select panel only when both `tag.showInSnippetList` and `tag.colored` are enabled.
- Uses the same colored tag badge rendering in the snippet detail panel when `tag.colored` is enabled.
- Keeps colored tag badges upright/non-italic so they match other badge styling.
- By default, middle-panel tags remain hidden and existing detail-panel tags remain plain italic gray text.
- When `tag.showInSnippetList` is `true` and `tag.colored` is `false`, snippet-list tags render as plain `#tag` text in italic gray.
- Keeps language tags out of regular tag badges.
- Allows clicking the currently selected regular tag again to return to `#All`.
- Fixes the shortcuts/pinned-tags modal overflow with a wrapping layout.

## Issue
Addresses #484: https://github.com/hackjutsu/Lepton/issues/484

## Verification
- Verified against `origin/master`: there were no existing `.leptonrc` tag display/color config keys before this PR.
- Rebased onto latest `origin/master` (`d9f291a`).
- `npm run lint`
- `npm test` - 8 test files, 42 tests passed.
- `npm run build`
- Unit coverage pins default hidden/uncolored behavior, disabled-color tag labels/classes, plain fallback SCSS, and new `tag` config lookup. Tests also confirm the abandoned PR-only `snippet.showTagsInSnippetList` and `snippet.coloredTags` names are ignored.
- Launched Electron locally with no tag settings in `.leptonrc`; verified defaults resolved to `tag.showInSnippetList: false` and `tag.colored: false`.
- Verified renderer via DevTools: 0 middle-panel tag rows, 0 tag badges, existing detail-panel tag remains plain italic gray text.
- Captured and shared rendered app screenshots in chat.
