### PR TITLE
[codex] Add Electron preload bridge

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,7 +1,8 @@
 import { getGitHubApi, GET_SINGLE_GIST } from '../utilities/githubApi'
 import { notifyFailure } from '../utilities/notifier'
-import { remote } from 'electron'
-const logger = remote.getGlobal('logger')
+import electronBridge from '../utilities/electronBridge'
+
+const logger = electronBridge.logger
 
 export const UPDATE_USER_SESSION = 'UPDATE_USER_SESSION'
 export const LOGOUT_USER_SESSION = 'LOGOUT_USER_SESSION'

--- a/app/containers/aboutPage/index.js
+++ b/app/containers/aboutPage/index.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Modal, Image } from 'react-bootstrap'
-import { remote, shell } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import { updateAboutModalStatus } from '../../actions'
 import defaultConfig from '../../../configs/defaultConfig'
 import appInfo from '../../../package.json'
@@ -14,16 +14,15 @@ import React, { Component } from 'react'
 
 import './index.scss'
 
-const conf = remote.getGlobal('conf')
-const logFilePath = remote.getGlobal('logFilePath')
-const configFilePath = remote.getGlobal('configFilePath')
+const conf = electronBridge.config
+const { configFilePath, logFilePath } = electronBridge.globals.getPaths()
 
 class AboutPage extends Component {
   openFileInEditor (filePath) {
     if (!fs.existsSync(filePath)) {
       fs.closeSync(fs.writeFileSync(filePath, JSON.stringify(defaultConfig, null, 2)))
     }
-    shell.openPath(filePath)
+    electronBridge.shell.openPath(filePath)
   }
 
   renderAboutSection () {

--- a/app/containers/appContainer/index.js
+++ b/app/containers/appContainer/index.js
@@ -1,7 +1,7 @@
 import { Alert } from 'react-bootstrap'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import { remote, shell } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import { updateUpdateAvailableBarStatus } from '../../actions/index'
 import AboutPage from '../aboutPage'
 import Dashboard from '../dashboard'
@@ -18,7 +18,7 @@ import ThemeManager from '../../utilities/themeManager'
 import './index.scss'
 import './scrollbar.scss'
 
-const conf = remote.getGlobal('conf')
+const conf = electronBridge.config
 const themeManager = new ThemeManager()
 themeManager.setTheme(conf.get('theme'))
 
@@ -93,12 +93,12 @@ class AppContainer extends Component {
 
   handleDownloadClicked () {
     const { newVersionInfo } = this.props
-    shell.openExternal(newVersionInfo.url)
+    electronBridge.shell.openExternal(newVersionInfo.url)
     this.dismissUpdateAlert()
   }
 
   handleReleaseNotesClicked () {
-    shell.openExternal('https://github.com/hackjutsu/Lepton/releases')
+    electronBridge.shell.openExternal('https://github.com/hackjutsu/Lepton/releases')
     this.dismissUpdateAlert()
   }
 

--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -4,15 +4,14 @@ import hljsDefineGraphQL from 'highlightjs-graphql'
 import Markdown from '../../utilities/markdown'
 import nb from '../../utilities/jupyterNotebook'
 import React, { Component } from 'react'
+import electronBridge from '../../utilities/electronBridge'
 
 import '../../utilities/vendor/prism/prism.scss'
 import './jupyterNotebook.scss'
 import './markdown.scss'
 
-const remote = require('@electron/remote')
-
-const logger = remote.getGlobal('logger')
-const conf = remote.getGlobal('conf')
+const logger = electronBridge.logger
+const conf = electronBridge.config
 
 // resolve syntax highlight style based on app theme
 if (conf.get('theme') === 'dark') {

--- a/app/containers/gistEditor/index.js
+++ b/app/containers/gistEditor/index.js
@@ -148,8 +148,9 @@ import 'codemirror/addon/display/placeholder'
 
 import './index.scss'
 
-import { remote } from 'electron'
-const conf = remote.getGlobal('conf')
+import electronBridge from '../../utilities/electronBridge'
+
+const conf = electronBridge.config
 
 const highlightTheme = conf.get('theme') === 'dark' ? 'one-dark' : 'github'
 const defaultOptions = Object.assign({}, {

--- a/app/containers/gistEditorForm/index.js
+++ b/app/containers/gistEditorForm/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { Field, FieldArray, reduxForm, formValueSelector } from 'redux-form'
-import { remote, ipcRenderer } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import { OverlayTrigger, Tooltip, Button, ListGroup, ListGroupItem, Panel } from 'react-bootstrap'
 import GistEditor from '../gistEditor'
 import React, { Component } from 'react'
@@ -13,8 +13,9 @@ import './index.scss'
 export const NEW_GIST = 'NEW_GIST'
 export const UPDATE_GIST = 'UPDATE_GIST'
 
-const conf = remote.getGlobal('conf')
-const logger = remote.getGlobal('logger')
+const conf = electronBridge.config
+const ipcRenderer = electronBridge.ipc
+const logger = electronBridge.logger
 
 const descriptionTips = '[title] description #tag1 #tag2'
 

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -1,7 +1,7 @@
 import { Alert, Button, Image, Modal, ProgressBar } from 'react-bootstrap'
 import Avatar from 'boring-avatars'
 import { connect } from 'react-redux'
-import { remote, ipcRenderer } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
 
 import dojocatImage from '../../utilities/octodex/dojocat.jpg'
@@ -10,8 +10,9 @@ import saritocatImage from '../../utilities/octodex/saritocat.png'
 
 import './index.scss'
 
-const conf = remote.getGlobal('conf')
-const logger = remote.getGlobal('logger')
+const conf = electronBridge.config
+const ipcRenderer = electronBridge.ipc
+const logger = electronBridge.logger
 
 const LoginModeEnum = { CREDENTIALS: 1, TOKEN: 2 }
 

--- a/app/containers/navigationPanel/index.js
+++ b/app/containers/navigationPanel/index.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Modal, Button } from 'react-bootstrap'
 import { parseLangName as Resolved } from '../../utilities/parser'
-import { remote } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
 import UserPanel from '../userPanel'
 import {
@@ -17,8 +17,8 @@ import plusIcon from './plus.svg'
 
 import './index.scss'
 
-const conf = remote.getGlobal('conf')
-const logger = remote.getGlobal('logger')
+const conf = electronBridge.config
+const logger = electronBridge.logger
 
 class NavigationPanel extends Component {
   constructor (props) {

--- a/app/containers/navigationPanelDetails/index.js
+++ b/app/containers/navigationPanelDetails/index.js
@@ -1,14 +1,14 @@
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { descriptionParser } from '../../utilities/parser'
-import { remote } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import { selectGist, fetchSingleGist, updatescrollRequestStatus } from '../../actions'
 import React, { Component } from 'react'
 
 import './index.scss'
 
-const logger = remote.getGlobal('logger')
-const conf = remote.getGlobal('conf')
+const logger = electronBridge.logger
+const conf = electronBridge.config
 
 class NavigationPanelDetails extends Component {
   componentDidUpdate () {

--- a/app/containers/searchPage/index.js
+++ b/app/containers/searchPage/index.js
@@ -1,7 +1,7 @@
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Modal } from 'react-bootstrap'
-import { remote } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
 import {
   addLangPrefix as Prefixed,
@@ -17,7 +17,7 @@ import {
 
 import './index.scss'
 
-const logger = remote.getGlobal('logger')
+const logger = electronBridge.logger
 
 class SearchPage extends Component {
   constructor (props) {

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { default as GistEditorForm, UPDATE_GIST } from '../gistEditorForm'
 import { Panel, Modal, Button, ProgressBar, Collapse } from 'react-bootstrap'
-import { remote, clipboard, ipcRenderer } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import Autolinker from 'autolinker'
 import CodeArea from '../codeArea'
 import HumanReadableTime from 'human-readable-time'
@@ -38,8 +38,10 @@ import secretIcon from './lock.svg'
 import tagsIcon from './tags.svg'
 import trashIcon from './ei-trash.svg'
 
-const conf = remote.getGlobal('conf')
-const logger = remote.getGlobal('logger')
+const clipboard = electronBridge.clipboard
+const conf = electronBridge.config
+const ipcRenderer = electronBridge.ipc
+const logger = electronBridge.logger
 
 const kIsExpanded = conf.get('snippet:expanded')
 const kTabLength = conf.get('editor:tabSize')

--- a/app/containers/userPanel/index.js
+++ b/app/containers/userPanel/index.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { default as GistEditorForm, NEW_GIST } from '../gistEditorForm'
 import { Image, Modal, Button, ProgressBar } from 'react-bootstrap'
-import { remote, ipcRenderer } from 'electron'
+import electronBridge from '../../utilities/electronBridge'
 import HumanReadableTime from 'human-readable-time'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
@@ -34,8 +34,9 @@ import newIcon from './new.svg'
 import privateinvestocatImage from '../../utilities/octodex/privateinvestocat.jpg'
 import syncIcon from './sync.svg'
 
-const conf = remote.getGlobal('conf')
-const logger = remote.getGlobal('logger')
+const conf = electronBridge.config
+const ipcRenderer = electronBridge.ipc
+const logger = electronBridge.logger
 
 let defaultImage = dojocatImage
 if (conf.get('enterprise:enable')) {
@@ -267,7 +268,7 @@ class UserPanel extends Component {
       profile: null
     })
     removeAccessToken()
-    remote.getCurrentWindow().setTitle('Lepton') // update the app title
+    electronBridge.window.setTitle('Lepton') // update the app title
     ipcRenderer.send('session-destroyed')
   }
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,10 +1,10 @@
-import { ipcRenderer } from 'electron'
 import React from 'react'
 import ReactDom from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import electronLocalStorage from 'electron-json-storage-sync'
+import electronBridge from './utilities/electronBridge'
 
 import './utilities/vendor/bootstrap/css/bootstrap.css'
 import AppContainer from './containers/appContainer'
@@ -50,8 +50,9 @@ import { notifySuccess, notifyFailure } from './utilities/notifier'
 const path = require('path')
 const { createRequire } = require('module')
 const remote = require('@electron/remote')
-const logger = remote.getGlobal('logger')
-const appRequire = createRequire(path.join(remote.app.getAppPath(), 'app/index.js'))
+const ipcRenderer = electronBridge.ipc
+const logger = electronBridge.logger
+const appRequire = createRequire(path.join(electronBridge.app.getAppPath(), 'app/index.js'))
 
 let Account = null
 try {
@@ -398,7 +399,7 @@ function initUserSession (token) {
       syncLocalPref(newProfile.login)
       logger.debug('-----> after syncLocalPref')
 
-      remote.getCurrentWindow().setTitle(`${newProfile.login} | Lepton`) // update the app title
+      electronBridge.window.setTitle(`${newProfile.login} | Lepton`) // update the app title
 
       logger.info('[Dispatch] updateUserSession ACTIVE')
       reduxStore.dispatch(updateUserSession({ activeStatus: 'ACTIVE', profile: newProfile }))
@@ -684,7 +685,7 @@ ipcRenderer.on('back-to-normal-mode', data => {
 })
 
 ipcRenderer.on('update-available', payload => {
-  const newVersionInfo = remote.getGlobal('newVersionInfo')
+  const newVersionInfo = electronBridge.globals.getUpdateInfo()
   if (electronLocalStorage.get('skipped-version').data === newVersionInfo.version) return
 
   reduxStore.dispatch(updateNewVersionInfo(newVersionInfo))

--- a/app/utilities/electronBridge/index.js
+++ b/app/utilities/electronBridge/index.js
@@ -1,0 +1,62 @@
+function createIpcBridge (ipcRenderer) {
+  if (!ipcRenderer) {
+    return {
+      emit: () => {},
+      on: () => () => {},
+      removeAllListeners: () => {},
+      send: () => {}
+    }
+  }
+
+  return {
+    emit: (channel, ...args) => ipcRenderer.emit(channel, ...args),
+    on: (channel, listener) => {
+      const wrapped = (event, ...args) => listener(...args)
+      ipcRenderer.on(channel, wrapped)
+      return () => ipcRenderer.removeListener(channel, wrapped)
+    },
+    removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
+    send: (channel, ...args) => ipcRenderer.send(channel, ...args)
+  }
+}
+
+function createFallbackBridge () {
+  const electron = require('electron')
+  const remote = electron.remote || require('@electron/remote')
+  const conf = remote.getGlobal('conf')
+  const logger = remote.getGlobal('logger')
+  const app = electron.app || remote.app
+
+  return {
+    app: {
+      getAppPath: () => app.getAppPath(),
+      getPath: (name) => app.getPath(name)
+    },
+    clipboard: electron.clipboard || { writeText: () => {} },
+    config: {
+      get: (key) => conf.get(key)
+    },
+    globals: {
+      getPaths: () => ({
+        configFilePath: remote.getGlobal('configFilePath'),
+        logFilePath: remote.getGlobal('logFilePath')
+      }),
+      getUpdateInfo: () => remote.getGlobal('newVersionInfo')
+    },
+    ipc: createIpcBridge(electron.ipcRenderer),
+    logger,
+    shell: electron.shell || {
+      openExternal: () => {},
+      openPath: () => {}
+    },
+    window: {
+      setTitle: (title) => remote.getCurrentWindow().setTitle(title)
+    }
+  }
+}
+
+const bridge = typeof window !== 'undefined' && window.lepton
+  ? window.lepton
+  : createFallbackBridge()
+
+export default bridge

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -1,5 +1,5 @@
 import { Promise } from 'bluebird'
-import { remote } from 'electron'
+import electronBridge from '../electronBridge'
 import { notifyFailure } from '../notifier'
 import ProxyAgent from 'proxy-agent'
 import ReqPromise from 'request-promise'
@@ -7,8 +7,8 @@ import Request from 'request'
 
 const TAG = '[REST] '
 const kTimeoutUnit = 10 * 1000 // ms
-const logger = remote.getGlobal('logger')
-const conf = remote.getGlobal('conf')
+const logger = electronBridge.logger
+const conf = electronBridge.config
 const userAgent = 'hackjutsu-lepton-app'
 let gitHubHostApi = 'api.github.com'
 

--- a/app/utilities/notifier/index.js
+++ b/app/utilities/notifier/index.js
@@ -1,6 +1,6 @@
-import { remote } from 'electron'
+import electronBridge from '../electronBridge'
 
-const conf = remote.getGlobal('conf')
+const conf = electronBridge.config
 
 export function notifySuccess (title, message = '') {
   const showSuccessNotifications = conf.get('notifications:success')

--- a/app/utilities/store/index.js
+++ b/app/utilities/store/index.js
@@ -1,12 +1,21 @@
-const electron = require('electron')
 const path = require('path')
 const fs = require('fs')
+
+function getUserDataPath () {
+  if (typeof window !== 'undefined' && window.lepton) {
+    return window.lepton.app.getPath('userData')
+  }
+
+  const electron = require('electron')
+  const remote = electron.remote || require('@electron/remote')
+  return (electron.app || remote.app).getPath('userData')
+}
 
 class Store {
   constructor (opts) {
     // Renderer process has to get `app` module via `remote`, whereas the main process can get it directly
     // app.getPath('userData') will return a string of the user's app data directory path.
-    const userDataPath = (electron.app || electron.remote.app).getPath('userData')
+    const userDataPath = getUserDataPath()
     // We'll use the `configName` property to set the file name and path.join to bring it all together as a string
     this.path = path.join(userDataPath, opts.configName + '.json')
 

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ autoUpdater.autoDownload = nconf.get('autoUpdate')
 
 initGlobalConfigs()
 initGlobalLogger()
+setUpBridgeIpcHandlers()
 
 logger.info(`\n\n----- ${appInfo.name} v${appInfo.version} ${os.platform()}-----\n`)
 
@@ -66,6 +67,7 @@ function createWindow (autoLogin) {
   const webPreferences = {
     nodeIntegration: true,
     enableRemoteModule: true,
+    preload: path.join(__dirname, 'preload.js'),
     // https://github.com/electron/electron/blob/main/docs/tutorial/context-isolation.md
     // TODO: migrate and enable context isolation
     contextIsolation: false
@@ -298,6 +300,79 @@ function setUpApplicationMenu () {
   let template = [...mainMenuTemplate, gistMenu]
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
+}
+
+function setUpBridgeIpcHandlers () {
+  const loggerMethods = new Set(['debug', 'error', 'info', 'warn'])
+  const appPathNames = new Set(['appData', 'home', 'temp', 'userData'])
+
+  function isAllowedConfigKey (key) {
+    if (typeof key !== 'string' || key.length === 0) return false
+    const rootKey = key.split(':')[0]
+    return Object.prototype.hasOwnProperty.call(defaultConfig, rootKey)
+  }
+
+  function isMainWindowSender (event) {
+    return mainWindow && !mainWindow.isDestroyed() && event.sender === mainWindow.webContents
+  }
+
+  ipcMain.on('lepton:config:get', (event, key) => {
+    if (!isAllowedConfigKey(key)) {
+      logger.warn(`[bridge] Rejected config read for "${key}"`)
+      event.returnValue = undefined
+      return
+    }
+    event.returnValue = nconf.get(key)
+  })
+
+  ipcMain.on('lepton:app:get-app-path', (event) => {
+    event.returnValue = app.getAppPath()
+  })
+
+  ipcMain.on('lepton:app:get-path', (event, name) => {
+    if (!appPathNames.has(name)) {
+      logger.warn(`[bridge] Rejected app path read for "${name}"`)
+      event.returnValue = undefined
+      return
+    }
+    event.returnValue = app.getPath(name)
+  })
+
+  ipcMain.on('lepton:paths:get', (event) => {
+    event.returnValue = {
+      configFilePath: global.configFilePath,
+      logFilePath: global.logFilePath
+    }
+  })
+
+  ipcMain.on('lepton:update-info:get', (event) => {
+    event.returnValue = global.newVersionInfo
+  })
+
+  ipcMain.on('lepton:logger:log', (event, method, args = []) => {
+    if (!loggerMethods.has(method) || typeof logger[method] !== 'function') return
+    logger[method](...args)
+  })
+
+  ipcMain.on('lepton:shell:open-external', (event, url) => {
+    if (!isMainWindowSender(event) || typeof url !== 'string') return
+    electron.shell.openExternal(url)
+  })
+
+  ipcMain.handle('lepton:shell:open-path', (event, filePath) => {
+    if (!isMainWindowSender(event) || typeof filePath !== 'string') return ''
+    return electron.shell.openPath(filePath)
+  })
+
+  ipcMain.on('lepton:window:set-title', (event, title) => {
+    if (!isMainWindowSender(event) || typeof title !== 'string') return
+    mainWindow.setTitle(title)
+  })
+
+  ipcMain.on('lepton:clipboard:write-text', (event, value) => {
+    if (!isMainWindowSender(event) || typeof value !== 'string') return
+    electron.clipboard.writeText(value)
+  })
 }
 
 function setUpTouchBar() {

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,66 @@
+const { contextBridge, ipcRenderer } = require('electron')
+
+const LOG_METHODS = ['debug', 'error', 'info', 'warn']
+
+function serializeLogArg (arg) {
+  if (arg instanceof Error) {
+    const serialized = {
+      message: arg.message,
+      name: arg.name,
+      stack: arg.stack
+    }
+    Object.keys(arg).forEach(key => {
+      serialized[key] = arg[key]
+    })
+    return serialized
+  }
+  return arg
+}
+
+function sendLog (method, args) {
+  ipcRenderer.send('lepton:logger:log', method, Array.from(args).map(serializeLogArg))
+}
+
+const leptonApi = {
+  app: {
+    getAppPath: () => ipcRenderer.sendSync('lepton:app:get-app-path'),
+    getPath: (name) => ipcRenderer.sendSync('lepton:app:get-path', name)
+  },
+  clipboard: {
+    writeText: (value) => ipcRenderer.send('lepton:clipboard:write-text', value)
+  },
+  config: {
+    get: (key) => ipcRenderer.sendSync('lepton:config:get', key)
+  },
+  globals: {
+    getUpdateInfo: () => ipcRenderer.sendSync('lepton:update-info:get'),
+    getPaths: () => ipcRenderer.sendSync('lepton:paths:get')
+  },
+  ipc: {
+    emit: (channel, ...args) => ipcRenderer.emit(channel, ...args),
+    on: (channel, listener) => {
+      const wrapped = (event, ...args) => listener(...args)
+      ipcRenderer.on(channel, wrapped)
+      return () => ipcRenderer.removeListener(channel, wrapped)
+    },
+    removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
+    send: (channel, ...args) => ipcRenderer.send(channel, ...args)
+  },
+  logger: LOG_METHODS.reduce((api, method) => {
+    api[method] = (...args) => sendLog(method, args)
+    return api
+  }, {}),
+  shell: {
+    openExternal: (url) => ipcRenderer.send('lepton:shell:open-external', url),
+    openPath: (filePath) => ipcRenderer.invoke('lepton:shell:open-path', filePath)
+  },
+  window: {
+    setTitle: (title) => ipcRenderer.send('lepton:window:set-title', title)
+  }
+}
+
+if (process.contextIsolated) {
+  contextBridge.exposeInMainWorld('lepton', leptonApi)
+} else {
+  window.lepton = leptonApi
+}

--- a/tests/reducers/core.test.js
+++ b/tests/reducers/core.test.js
@@ -1,21 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('electron', () => {
-  const logger = {
-    debug: () => {},
-    error: () => {},
-    info: () => {}
-  }
-  const conf = {
-    get: () => false
-  }
-
-  return {
-    remote: {
-      getGlobal: (key) => key === 'logger' ? logger : conf
+vi.mock('../../app/utilities/electronBridge', () => ({
+  default: {
+    config: {
+      get: () => false
+    },
+    logger: {
+      debug: () => {},
+      error: () => {},
+      info: () => {}
     }
   }
-})
+}))
 
 import {
   logoutUserSession,

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -27,9 +27,10 @@ async function loadGitHubApi ({
     proxyAgentInstances.push(this)
   })
 
-  vi.doMock('electron', () => ({
-    remote: {
-      getGlobal: (key) => key === 'logger' ? logger : createConf(confValues)
+  vi.doMock('../../app/utilities/electronBridge', () => ({
+    default: {
+      config: createConf(confValues),
+      logger
     }
   }))
   vi.doMock('proxy-agent', () => ({
@@ -54,7 +55,7 @@ async function loadGitHubApi ({
 }
 
 afterEach(() => {
-  vi.doUnmock('electron')
+  vi.doUnmock('../../app/utilities/electronBridge')
   vi.doUnmock('proxy-agent')
   vi.doUnmock('request')
   vi.doUnmock('request-promise')


### PR DESCRIPTION
## Summary

Adds a preload-backed Electron bridge as the next step toward removing unsafe renderer access to Electron APIs.

- Adds root `preload.js` and renderer `electronBridge` helper.
- Adds main-process IPC handlers for config/path/update metadata reads, logging, shell/file opens, clipboard writes, and window title updates.
- Migrates low-risk renderer call sites away from direct `remote`, `shell`, `clipboard`, and `ipcRenderer` imports.
- Updates tests to mock the bridge boundary instead of Electron directly.

## Why

This creates the boundary needed before disabling `nodeIntegration`, `enableRemoteModule`, and `contextIsolation: false`. OAuth still uses `@electron/remote` and should move to the main process in the next modernization PR.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`

## Notes

This PR intentionally keeps the OAuth auth-window flow on `@electron/remote`; flipping Electron security settings should wait until auth is migrated into the main process.