### PR TITLE
[codex] Move OAuth flow to main process

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -52,7 +52,6 @@ import { configureI18n, t } from './utilities/i18n'
 
 const path = require('path')
 const { createRequire } = require('module')
-const remote = require('@electron/remote')
 const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 const conf = electronBridge.config
@@ -94,75 +93,46 @@ function launchAuthWindow (token) {
     return
   }
 
-  const webPreferences = {
-    nodeIntegration: false,
-    spellcheck: false
-  }
-
-  let authWindow = new remote.BrowserWindow({
-    parent: remote.getGlobal('mainWindow'),
-    width: 400,
-    height: 600,
-    show: false,
-    webPreferences
-  })
-  const githubUrl = 'https://github.com/login/oauth/authorize?'
-  const authUrl = githubUrl + 'client_id=' + CONFIG_OPTIONS.client_id + '&scope=' + CONFIG_OPTIONS.scopes
-  const options = { extraHeaders: 'pragma: no-cache\n' }
-
-  logger.debug('loading authUrl ' + authUrl)
-  authWindow.loadURL(authUrl, options)
-  authWindow.show()
-
   updateAuthWindowStatusOn()
 
-  function handleCallback (url) {
-    const rawCode = /code=([^&]*)/.exec(url) || null
-    const code = (rawCode && rawCode.length > 1) ? rawCode[1] : null
-    const error = /\?error=(.+)$/.exec(url)
-
-    if (code || error) {
-      // Close the browser if code found or error
-      authWindow.webContents.session.clearStorageData([], () => {})
-      authWindow.destroy()
+  electronBridge.auth.startGitHubLogin({
+    clientId: CONFIG_OPTIONS.client_id,
+    scopes: CONFIG_OPTIONS.scopes
+  })
+    .then(handleAuthResult)
+    .catch((err) => {
       updateAuthWindowStatusOff()
-    }
+      logger.error('Failed to launch GitHub auth window: ' + err.message)
+      notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
+    })
+}
 
-    // If there is a code, proceed to get token from github
-    if (code) {
-      logger.info('[Dispatch] updateUserSession IN_PROGRESS')
-      reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
+function handleAuthResult (result) {
+  updateAuthWindowStatusOff()
 
-      getGitHubApi(EXCHANGE_ACCESS_TOKEN)(
-        CONFIG_OPTIONS.client_id, CONFIG_OPTIONS.client_secret, code)
-        .then((payload) => {
-          logger.debug('-----> calling initUserSession with new token ' + payload.access_token)
-          return initUserSession(payload.access_token)
-        })
-        .catch((err) => {
-          logger.error('Failed: ' + JSON.stringify(err.error))
-          notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
-        })
-    } else if (error) {
-      logger.error('Oops! Something went wrong and we couldn\'t' +
-        'log you in using Github. Please try again.')
-    }
+  if (!result || result.status === 'closed') {
+    return
   }
 
-  // Handle the response from GitHub - See Update from 4/12/2015
-  authWindow.webContents.on('will-navigate', (event, url) => {
-    handleCallback(url)
-  })
+  if (result.status === 'success' && result.code) {
+    logger.info('[Dispatch] updateUserSession IN_PROGRESS')
+    reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
 
-  authWindow.webContents.on('did-get-redirect-request', (event, oldUrl, newUrl) => {
-    handleCallback(newUrl)
-  })
+    getGitHubApi(EXCHANGE_ACCESS_TOKEN)(
+      CONFIG_OPTIONS.client_id, CONFIG_OPTIONS.client_secret, result.code)
+      .then((payload) => {
+        logger.debug('-----> calling initUserSession with new token ' + payload.access_token)
+        return initUserSession(payload.access_token)
+      })
+      .catch((err) => {
+        logger.error('Failed: ' + JSON.stringify(err.error))
+        notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
+      })
+    return
+  }
 
-  // Reset the authWindow on close
-  authWindow.on('close', () => {
-    updateAuthWindowStatusOff()
-    authWindow = null
-  }, false)
+  logger.error('Oops! Something went wrong and we couldn\'t' +
+    'log you in using Github. Please try again.')
 }
 
 function setSyncTime (time) {

--- a/app/utilities/auth/githubOAuth.js
+++ b/app/utilities/auth/githubOAuth.js
@@ -1,0 +1,62 @@
+const GITHUB_OAUTH_URL = 'https://github.com/login/oauth/authorize'
+
+function normalizeScopes (scopes = []) {
+  if (Array.isArray(scopes)) {
+    return scopes.filter(Boolean).join(' ')
+  }
+
+  if (typeof scopes === 'string') {
+    return scopes
+  }
+
+  return ''
+}
+
+function buildGitHubOAuthUrl ({ clientId, scopes }) {
+  const params = new URLSearchParams()
+  params.set('client_id', clientId)
+
+  const scope = normalizeScopes(scopes)
+  if (scope) {
+    params.set('scope', scope)
+  }
+
+  return `${GITHUB_OAUTH_URL}?${params.toString()}`
+}
+
+function parseGitHubOAuthCallback (callbackUrl) {
+  if (typeof callbackUrl !== 'string') {
+    return null
+  }
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(callbackUrl)
+  } catch (err) {
+    return null
+  }
+
+  const code = parsedUrl.searchParams.get('code')
+  if (code) {
+    return {
+      status: 'success',
+      code
+    }
+  }
+
+  const error = parsedUrl.searchParams.get('error')
+  if (error) {
+    return {
+      status: 'error',
+      error,
+      errorDescription: parsedUrl.searchParams.get('error_description')
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  buildGitHubOAuthUrl,
+  parseGitHubOAuthCallback
+}

--- a/app/utilities/electronBridge/index.js
+++ b/app/utilities/electronBridge/index.js
@@ -1,72 +1,55 @@
-function createIpcBridge (ipcRenderer) {
-  if (!ipcRenderer) {
-    return {
-      emit: () => {},
-      on: () => () => {},
-      removeAllListeners: () => {},
-      send: () => {}
-    }
-  }
-
+function createIpcBridge () {
   return {
-    emit: (channel, ...args) => ipcRenderer.emit(channel, ...args),
-    on: (channel, listener) => {
-      const wrapped = (event, ...args) => listener(...args)
-      ipcRenderer.on(channel, wrapped)
-      return () => ipcRenderer.removeListener(channel, wrapped)
-    },
-    removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
-    send: (channel, ...args) => ipcRenderer.send(channel, ...args)
+    emit: () => {},
+    on: () => () => {},
+    removeAllListeners: () => {},
+    send: () => {}
   }
 }
 
-function createFallbackBridge () {
-  const electron = require('electron')
-  const remote = electron.remote || require('@electron/remote')
-  const conf = remote.getGlobal('conf')
-  const logger = remote.getGlobal('logger')
-  const app = electron.app || remote.app
+function unavailableBridgeMethod () {
+  throw new Error('Electron bridge is unavailable. Renderer code must use the preload bridge.')
+}
 
+function createUnavailableBridge () {
   return {
     app: {
-      getAppPath: () => app.getAppPath(),
-      getPath: (name) => app.getPath(name)
+      getAppPath: unavailableBridgeMethod,
+      getPath: unavailableBridgeMethod
     },
     auth: {
-      startGitHubLogin: () => Promise.resolve({
-        status: 'error',
-        error: 'auth-bridge-unavailable'
-      })
+      startGitHubLogin: unavailableBridgeMethod
     },
-    clipboard: electron.clipboard || { writeText: () => {} },
+    clipboard: {
+      writeText: unavailableBridgeMethod
+    },
     config: {
-      get: (key) => conf.get(key),
-      set: (key, value) => {
-        conf.set(key, value)
-        return Promise.resolve(value)
-      }
+      get: unavailableBridgeMethod,
+      set: unavailableBridgeMethod
     },
     globals: {
-      getPaths: () => ({
-        configFilePath: remote.getGlobal('configFilePath'),
-        logFilePath: remote.getGlobal('logFilePath')
-      }),
-      getUpdateInfo: () => remote.getGlobal('newVersionInfo')
+      getPaths: unavailableBridgeMethod,
+      getUpdateInfo: unavailableBridgeMethod
     },
-    ipc: createIpcBridge(electron.ipcRenderer),
-    logger,
-    shell: electron.shell || {
-      openExternal: () => {},
-      openPath: () => {}
+    ipc: createIpcBridge(),
+    logger: {
+      debug: () => {},
+      error: () => {},
+      info: () => {},
+      warn: () => {}
+    },
+    shell: {
+      openExternal: unavailableBridgeMethod,
+      openPath: unavailableBridgeMethod
     },
     window: {
-      setTitle: (title) => remote.getCurrentWindow().setTitle(title)
+      setTitle: unavailableBridgeMethod
     }
   }
 }
 
 const bridge = typeof window !== 'undefined' && window.lepton
   ? window.lepton
-  : createFallbackBridge()
+  : createUnavailableBridge()
 
 export default bridge

--- a/app/utilities/electronBridge/index.js
+++ b/app/utilities/electronBridge/index.js
@@ -32,6 +32,12 @@ function createFallbackBridge () {
       getAppPath: () => app.getAppPath(),
       getPath: (name) => app.getPath(name)
     },
+    auth: {
+      startGitHubLogin: () => Promise.resolve({
+        status: 'error',
+        error: 'auth-bridge-unavailable'
+      })
+    },
     clipboard: electron.clipboard || { writeText: () => {} },
     config: {
       get: (key) => conf.get(key),

--- a/app/utilities/store/index.js
+++ b/app/utilities/store/index.js
@@ -6,14 +6,12 @@ function getUserDataPath () {
     return window.lepton.app.getPath('userData')
   }
 
-  const electron = require('electron')
-  const remote = electron.remote || require('@electron/remote')
-  return (electron.app || remote.app).getPath('userData')
+  throw new Error('Store requires the preload bridge to resolve the userData path.')
 }
 
 class Store {
   constructor (opts) {
-    // Renderer process has to get `app` module via `remote`, whereas the main process can get it directly
+    // Renderer process gets the app data path through the preload bridge.
     // app.getPath('userData') will return a string of the user's app data directory path.
     const userDataPath = getUserDataPath()
     // We'll use the `configName` property to set the file name and path.join to bring it all together as a string

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-require('@electron/remote/main').initialize()
 const os = require('os')
 const electron = require('electron')
 const nconf = require('nconf')
@@ -23,6 +22,10 @@ const appInfo = require('./package.json')
 const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
 const { configureI18n, t } = require('./app/utilities/i18n')
+const {
+  buildGitHubOAuthUrl,
+  parseGitHubOAuthCallback
+} = require('./app/utilities/auth/githubOAuth')
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger
@@ -43,6 +46,7 @@ for (const key of Object.getOwnPropertyNames(defaultConfig)) {
 
 let mainWindow = null
 let miniWindow = null
+let authFlow = null
 let operationType = 0;
 
 const shortcuts = nconf.get('shortcuts')
@@ -69,7 +73,7 @@ function createWindow (autoLogin) {
 
   const webPreferences = {
     nodeIntegration: true,
-    enableRemoteModule: true,
+    enableRemoteModule: false,
     preload: path.join(__dirname, 'preload.js'),
     // https://github.com/electron/electron/blob/main/docs/tutorial/context-isolation.md
     // TODO: migrate and enable context isolation
@@ -419,6 +423,139 @@ function setUpBridgeIpcHandlers () {
     if (!isMainWindowSender(event) || typeof value !== 'string') return
     electron.clipboard.writeText(value)
   })
+
+  ipcMain.handle('lepton:auth:start-github-login', (event, authOptions = {}) => {
+    if (!isMainWindowSender(event)) {
+      return {
+        status: 'error',
+        error: 'invalid-sender'
+      }
+    }
+
+    return startGitHubAuthFlow(authOptions)
+  })
+}
+
+function startGitHubAuthFlow ({ clientId, scopes } = {}) {
+  if (authFlow) {
+    if (authFlow.authWindow && !authFlow.authWindow.isDestroyed()) {
+      authFlow.authWindow.focus()
+    }
+    return authFlow.promise
+  }
+
+  if (typeof clientId !== 'string' || clientId.length === 0) {
+    return Promise.resolve({
+      status: 'error',
+      error: 'missing-client-id'
+    })
+  }
+
+  const authWindow = new BrowserWindow({
+    parent: mainWindow,
+    width: 400,
+    height: 600,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      enableRemoteModule: false,
+      contextIsolation: true,
+      spellcheck: false
+    }
+  })
+
+  let resolveAuthFlow
+  const promise = new Promise(resolve => {
+    resolveAuthFlow = resolve
+  })
+  authFlow = {
+    authWindow,
+    promise,
+    resolve: resolveAuthFlow
+  }
+
+  const authUrl = buildGitHubOAuthUrl({ clientId, scopes })
+  const options = { extraHeaders: 'pragma: no-cache\n' }
+
+  function handleAuthNavigation (event, callbackUrl) {
+    const result = parseGitHubOAuthCallback(callbackUrl)
+    if (!result) return
+
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault()
+    }
+
+    finishGitHubAuthFlow(result)
+  }
+
+  authWindow.webContents.on('will-navigate', (event, callbackUrl) => {
+    handleAuthNavigation(event, callbackUrl)
+  })
+
+  authWindow.webContents.on('will-redirect', (event, callbackUrl) => {
+    handleAuthNavigation(event, callbackUrl)
+  })
+
+  authWindow.webContents.on('did-get-redirect-request', (event, oldUrl, newUrl) => {
+    handleAuthNavigation(event, newUrl)
+  })
+
+  authWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
+    if (errorCode === -3) return
+    logger.error('[auth] OAuth window failed to load: ' + errorDescription)
+    finishGitHubAuthFlow({
+      status: 'error',
+      error: 'load-failed',
+      errorDescription
+    })
+  })
+
+  authWindow.once('closed', () => {
+    if (authFlow && authFlow.authWindow === authWindow) {
+      finishGitHubAuthFlow({
+        status: 'closed'
+      }, {
+        destroyWindow: false
+      })
+    }
+  })
+
+  logger.debug('loading authUrl ' + authUrl)
+  authWindow.loadURL(authUrl, options)
+    .catch(err => {
+      logger.error('[auth] OAuth window failed to load: ' + err.message)
+      finishGitHubAuthFlow({
+        status: 'error',
+        error: 'load-failed',
+        errorDescription: err.message
+      })
+    })
+  authWindow.show()
+
+  return promise
+}
+
+function finishGitHubAuthFlow (result, options = {}) {
+  if (!authFlow) return
+
+  const { authWindow, resolve } = authFlow
+  authFlow = null
+  resolve(result)
+
+  if (options.destroyWindow === false || !authWindow || authWindow.isDestroyed()) return
+
+  try {
+    authWindow.webContents.session.clearStorageData({}, () => {
+      if (!authWindow.isDestroyed()) {
+        authWindow.destroy()
+      }
+    })
+  } catch (err) {
+    logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
+    if (!authWindow.isDestroyed()) {
+      authWindow.destroy()
+    }
+  }
 }
 
 function setUpTouchBar() {

--- a/main.js
+++ b/main.js
@@ -75,8 +75,7 @@ function createWindow (autoLogin) {
     nodeIntegration: true,
     enableRemoteModule: false,
     preload: path.join(__dirname, 'preload.js'),
-    // https://github.com/electron/electron/blob/main/docs/tutorial/context-isolation.md
-    // TODO: migrate and enable context isolation
+    // TODO: enable context isolation once the renderer bundle no longer depends on runtime require.
     contextIsolation: false
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.10.1-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@electron/remote": "^1.1.0",
         "autolinker": "^3.14.1",
         "bluebird": "^3.5.3",
         "boring-avatars": "^1.5.8",
@@ -1894,14 +1893,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@electron/remote": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-1.1.0.tgz",
-      "integrity": "sha512-yr8gZTkIgJYKbFqExI4QZqMSjn1kL/us9Dl46+TH1EZdhgRtsJ6HDfdsIxu0QEc6Hv+DMAXs69rgquH+8FDk4w==",
-      "peerDependencies": {
-        "electron": ">= 10.0.0-beta.1"
       }
     },
     "node_modules/@electron/universal": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@electron/remote": "^1.1.0",
     "autolinker": "^3.14.1",
     "bluebird": "^3.5.3",
     "boring-avatars": "^1.5.8",

--- a/preload.js
+++ b/preload.js
@@ -26,6 +26,9 @@ const leptonApi = {
     getAppPath: () => ipcRenderer.sendSync('lepton:app:get-app-path'),
     getPath: (name) => ipcRenderer.sendSync('lepton:app:get-path', name)
   },
+  auth: {
+    startGitHubLogin: (options) => ipcRenderer.invoke('lepton:auth:start-github-login', options)
+  },
   clipboard: {
     writeText: (value) => ipcRenderer.send('lepton:clipboard:write-text', value)
   },

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -105,16 +105,16 @@ async function getRendererState (window) {
   `, true)
 }
 
-async function captureFailureScreenshot (window) {
+async function captureScreenshot (window, fileName, log = console.log) {
   if (!window || window.isDestroyed()) return
 
   const artifactDir = process.env.LEPTON_SMOKE_ARTIFACT_DIR
   if (!artifactDir) return
 
-  const screenshotPath = path.join(artifactDir, 'electron-render-smoke-failure.png')
+  const screenshotPath = path.join(artifactDir, fileName)
   const image = await window.capturePage()
   fs.writeFileSync(screenshotPath, image.toPNG())
-  console.error(`Saved smoke-test screenshot to ${screenshotPath}`)
+  log(`Saved smoke-test screenshot to ${screenshotPath}`)
 }
 
 function assertRendererState (state) {
@@ -147,10 +147,11 @@ async function main () {
     await waitForRendererLoad(window)
     await waitForLoginUi(window)
     assertRendererState(await getRendererState(window))
+    await captureScreenshot(window, 'electron-render-smoke-success.png')
     console.log('electron render smoke test passed')
     app.exit(0)
   } catch (err) {
-    await captureFailureScreenshot(window)
+    await captureScreenshot(window, 'electron-render-smoke-failure.png', console.error)
     console.error(err)
     app.exit(1)
   }

--- a/tests/utilities/githubOAuth.test.js
+++ b/tests/utilities/githubOAuth.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import githubOAuth from '../../app/utilities/auth/githubOAuth'
+
+const {
+  buildGitHubOAuthUrl,
+  parseGitHubOAuthCallback
+} = githubOAuth
+
+describe('GitHub OAuth utility', () => {
+  it('builds the GitHub OAuth authorize URL', () => {
+    const url = buildGitHubOAuthUrl({
+      clientId: 'client-id',
+      scopes: ['gist', 'repo']
+    })
+
+    expect(url).toBe('https://github.com/login/oauth/authorize?client_id=client-id&scope=gist+repo')
+  })
+
+  it('parses successful callback codes', () => {
+    expect(parseGitHubOAuthCallback('https://example.test/callback?code=auth-code&state=one'))
+      .toEqual({
+        status: 'success',
+        code: 'auth-code'
+      })
+  })
+
+  it('parses callback errors', () => {
+    expect(parseGitHubOAuthCallback('https://example.test/callback?error=access_denied&error_description=nope'))
+      .toEqual({
+        status: 'error',
+        error: 'access_denied',
+        errorDescription: 'nope'
+      })
+  })
+
+  it('ignores URLs without OAuth callback data', () => {
+    expect(parseGitHubOAuthCallback('https://github.com/login')).toBeNull()
+    expect(parseGitHubOAuthCallback('not a url')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Moves the GitHub OAuth popup flow out of the renderer and into the Electron main process, then removes the remaining `@electron/remote` compatibility fallback paths from the renderer bridge.

- Adds a preload-backed `auth.startGitHubLogin` bridge method.
- Creates and owns the GitHub OAuth `BrowserWindow` in `main.js`, including callback parsing, duplicate-window handling, storage cleanup, and closed/error results.
- Removes direct `@electron/remote` usage from `app/index.js` and disables `enableRemoteModule` on the main app window.
- Removes the renderer bridge/store fallback paths that loaded `@electron/remote`, and drops `@electron/remote` from package metadata.
- Adds a small GitHub OAuth URL/callback utility with unit coverage.
- Updates the Electron smoke harness to save a success screenshot artifact when rendering verification passes.

## Why

The previous modernization introduced the preload bridge but left OAuth as the remaining renderer-created `BrowserWindow`. Moving that flow to main and removing remote fallbacks closes the main `@electron/remote` dependency path while keeping the change scoped enough to verify through the existing smoke safety net.

## Validation

- `PATH=/Users/onyx/.nvm/versions/node/v24.11.1/bin:$PATH npm run lint`
- `PATH=/Users/onyx/.nvm/versions/node/v24.11.1/bin:$PATH npm test`
- `PATH=/Users/onyx/.nvm/versions/node/v24.11.1/bin:$PATH npm run test:smoke`
- `git diff --check`

Rendering verification: the Electron smoke test launched the app with isolated config/user-data paths, verified the login UI DOM and visible text, and saved a success screenshot at `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-I5Bl8N/electron-render-smoke-success.png`. The observed frame showed the localized Login modal with the GitHub Login button.

## Notes

Webpack still emits existing Dart Sass legacy JS API deprecation warnings during builds. The main app window intentionally keeps `nodeIntegration: true` and `contextIsolation: false` for now because the renderer bundle still externalizes dependencies and expects runtime `require`; the OAuth popup remains isolated. The next hardening step is to bundle or bridge those renderer Node dependencies, then flip `contextIsolation: true` and eventually `nodeIntegration: false`.