### PR TITLE
[codex] Add start at login config

### DIFF
--- a/app/utilities/startAtLogin/index.js
+++ b/app/utilities/startAtLogin/index.js
@@ -1,0 +1,46 @@
+function isStartAtLoginSupported (platform) {
+  return platform === 'darwin' || platform === 'win32'
+}
+
+function normalizeStartAtLoginValue (value) {
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase() === 'true'
+  }
+  return value === true
+}
+
+function applyStartAtLoginSetting ({ app, enabled, logger = console, platform = process.platform }) {
+  const openAtLogin = normalizeStartAtLoginValue(enabled)
+
+  if (!isStartAtLoginSupported(platform)) {
+    if (openAtLogin) {
+      logger.warn(`[startup] startAtLogin is not supported on ${platform}`)
+    }
+    return false
+  }
+
+  if (!app || typeof app.setLoginItemSettings !== 'function') {
+    logger.warn('[startup] app.setLoginItemSettings is unavailable')
+    return false
+  }
+
+  if (!openAtLogin && typeof app.getLoginItemSettings === 'function') {
+    const currentSettings = app.getLoginItemSettings()
+    if (currentSettings && currentSettings.openAtLogin === false) {
+      logger.info('[startup] startAtLogin already disabled')
+      return true
+    }
+  }
+
+  app.setLoginItemSettings({
+    openAtLogin
+  })
+  logger.info(`[startup] startAtLogin ${openAtLogin ? 'enabled' : 'disabled'}`)
+  return true
+}
+
+module.exports = {
+  applyStartAtLoginSetting,
+  isStartAtLoginSupported,
+  normalizeStartAtLoginValue
+}

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -1,6 +1,7 @@
 module.exports = {
     "theme": "light",
     "autoUpdate": false,
+    "startAtLogin": false,
     "avatar": {
         "type": "github",
         "boringAvatarVariant": "beam"

--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ const isDev = require('electron-is-dev')
 const defaultConfig = require('./configs/defaultConfig')
 const appInfo = require('./package.json')
 const { installLoggerRedaction } = require('./app/utilities/logging/redact')
+const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger
@@ -199,6 +200,11 @@ function createWindow (autoLogin) {
 }
 
 app.on('ready', () => {
+    applyStartAtLoginSetting({
+      app,
+      enabled: nconf.get('startAtLogin'),
+      logger
+    })
     // createWindow()
     autoUpdater.checkForUpdatesAndNotify()
     createWindowAndAutoLogin()

--- a/tests/utilities/startAtLogin.test.js
+++ b/tests/utilities/startAtLogin.test.js
@@ -1,0 +1,140 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  applyStartAtLoginSetting,
+  isStartAtLoginSupported,
+  normalizeStartAtLoginValue
+} = require('../../app/utilities/startAtLogin')
+
+function createLogger () {
+  return {
+    info: vi.fn(),
+    warn: vi.fn()
+  }
+}
+
+describe('start at login utility', () => {
+  it('supports Electron login items on macOS and Windows', () => {
+    expect(isStartAtLoginSupported('darwin')).toBe(true)
+    expect(isStartAtLoginSupported('win32')).toBe(true)
+    expect(isStartAtLoginSupported('linux')).toBe(false)
+  })
+
+  it('applies the configured login item setting', () => {
+    const app = {
+      getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
+      setLoginItemSettings: vi.fn()
+    }
+    const logger = createLogger()
+
+    const result = applyStartAtLoginSetting({
+      app,
+      enabled: true,
+      logger,
+      platform: 'win32'
+    })
+
+    expect(result).toBe(true)
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true
+    })
+    expect(logger.info).toHaveBeenCalledWith('[startup] startAtLogin enabled')
+  })
+
+  it('removes the login item when disabled', () => {
+    const app = {
+      getLoginItemSettings: vi.fn(() => ({ openAtLogin: true })),
+      setLoginItemSettings: vi.fn()
+    }
+
+    applyStartAtLoginSetting({
+      app,
+      enabled: false,
+      logger: createLogger(),
+      platform: 'darwin'
+    })
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: false
+    })
+  })
+
+  it('skips redundant login item writes when already disabled', () => {
+    const app = {
+      getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
+      setLoginItemSettings: vi.fn()
+    }
+    const logger = createLogger()
+
+    const result = applyStartAtLoginSetting({
+      app,
+      enabled: false,
+      logger,
+      platform: 'darwin'
+    })
+
+    expect(result).toBe(true)
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith('[startup] startAtLogin already disabled')
+  })
+
+  it('skips unsupported platforms', () => {
+    const app = {
+      setLoginItemSettings: vi.fn()
+    }
+    const logger = createLogger()
+
+    const result = applyStartAtLoginSetting({
+      app,
+      enabled: true,
+      logger,
+      platform: 'linux'
+    })
+
+    expect(result).toBe(false)
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith('[startup] startAtLogin is not supported on linux')
+  })
+
+  it('quietly skips unsupported platforms when disabled', () => {
+    const app = {
+      setLoginItemSettings: vi.fn()
+    }
+    const logger = createLogger()
+
+    const result = applyStartAtLoginSetting({
+      app,
+      enabled: false,
+      logger,
+      platform: 'linux'
+    })
+
+    expect(result).toBe(false)
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('skips unavailable Electron login item APIs', () => {
+    const logger = createLogger()
+
+    const result = applyStartAtLoginSetting({
+      app: {},
+      enabled: true,
+      logger,
+      platform: 'win32'
+    })
+
+    expect(result).toBe(false)
+    expect(logger.warn).toHaveBeenCalledWith('[startup] app.setLoginItemSettings is unavailable')
+  })
+
+  it('normalizes string config values safely', () => {
+    expect(normalizeStartAtLoginValue(true)).toBe(true)
+    expect(normalizeStartAtLoginValue(false)).toBe(false)
+    expect(normalizeStartAtLoginValue('true')).toBe(true)
+    expect(normalizeStartAtLoginValue('false')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `.leptonrc`-driven startup toggle for issue #551.

- Adds `startAtLogin: false` to the default configuration.
- Applies the setting in the Electron main process on app ready.
- Uses Electron login item APIs on macOS and Windows, while leaving unsupported platforms quiet unless startup is explicitly requested.
- Adds focused unit coverage for supported platforms, disabled/enabled behavior, string normalization, and missing API handling.

Closes #551.

## Validation

- `npm ci` from the lockfile
- `npm run lint`
- `npm test` - 42 Vitest tests plus webpack development build
- `npm run test:smoke` - Electron launched locally and rendered the login UI
- `git diff --check`

## Notes

- Rebased onto `origin/master` at `94b547e`.
- `npm ci` completed with an engine warning because the local host is Node 25 while the repo declares Node 24.
- Webpack still emits existing Dart Sass legacy JS API deprecation warnings.
