### PR TITLE
[codex] Add i18n framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,19 @@ Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact pat
 - Shortcuts
 - Enterprise
 - Notifications
+- Interface language (`i18n.locale`: `en`, `es`, `ja`, `zh-Hans`, or `zh-Hant`)
 
 Check out the [configuration docs](https://github.com/hackjutsu/Lepton/wiki/Configuration) to explore different customization options.
+
+Example:
+
+```json
+{
+  "i18n": {
+    "locale": "ja"
+  }
+}
+```
 
 ## Tech Stack
 ![Based on](./docs/img/erb-logo.png)

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,6 +1,7 @@
 import { getGitHubApi, GET_SINGLE_GIST } from '../utilities/githubApi'
 import { notifyFailure } from '../utilities/notifier'
 import electronBridge from '../utilities/electronBridge'
+import { t } from '../utilities/i18n'
 
 const logger = electronBridge.logger
 
@@ -233,7 +234,7 @@ export function fetchSingleGist (oldGist, id) {
       })
       .catch((err) => {
         logger.error('The request has failed: ' + err)
-        notifyFailure('Sync failed', 'Please check your network condition. 01')
+        notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '01' }))
       })
   }
 }

--- a/app/containers/aboutPage/index.js
+++ b/app/containers/aboutPage/index.js
@@ -11,6 +11,7 @@ import ContributorInfo from '../../../.all-contributorsrc'
 import logoDarkImage from './logo-dark.png'
 import logoLightImage from './logo-light.png'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 
 import './index.scss'
 
@@ -48,7 +49,7 @@ class AboutPage extends Component {
       </div>,
       <div key ='Evil icons@1.9.0' className='license-item'>
         <div className='license-project'>Evil icons@1.9.0</div>
-        <div className='license-type'>License: MIT</div>
+        <div className='license-type'>{ t('about.licenseType', { license: 'MIT' }) }</div>
       </div>
     )
     Object.keys(LicenseInfo).forEach(item => {
@@ -60,7 +61,7 @@ class AboutPage extends Component {
           <div className='license-project'>
             { item }
           </div>
-          <div className='license-type'>License: { LicenseInfo[item].licenses }</div>
+          <div className='license-type'>{ t('about.licenseType', { license: LicenseInfo[item].licenses }) }</div>
         </div>
       )
     })
@@ -73,20 +74,20 @@ class AboutPage extends Component {
           <Image className='logo' src={ logoImage } rounded/>
           <div>{ appInfo.name + ' v' + appInfo.version }</div>
           <a className='logo-sub' href='https://github.com/hackjutsu/Lepton'>GitHub</a>
-          <a className='logo-sub' href='https://github.com/hackjutsu/Lepton/issues'>Feedback</a>
-          <a className='logo-sub' href='https://github.com/hackjutsu/Lepton/blob/master/LICENSE'>License</a>
+          <a className='logo-sub' href='https://github.com/hackjutsu/Lepton/issues'>{ t('about.feedback') }</a>
+          <a className='logo-sub' href='https://github.com/hackjutsu/Lepton/blob/master/LICENSE'>{ t('about.license') }</a>
         </div>
         <div className='setting-title-clickable' onClick={ this.openFileInEditor.bind(this, configFilePath) }>
-            Configurations
+          { t('about.configurations') }
         </div>
         <div className='one-line-section'>{ configFilePath }</div>
-        <div className='setting-title-clickable' onClick={ this.openFileInEditor.bind(this, logFilePath) }>Logs</div>
+        <div className='setting-title-clickable' onClick={ this.openFileInEditor.bind(this, logFilePath) }>{ t('about.logs') }</div>
         <div className='one-line-section'>{ logFilePath }</div>
-        <div className='setting-title'>Contributors</div>
+        <div className='setting-title'>{ t('about.contributors') }</div>
         <div className='contributor-section'>
           { contributorList }
         </div>
-        <div className='setting-title'>Acknowledgement</div>
+        <div className='setting-title'>{ t('about.acknowledgement') }</div>
         <div className='license-section'>
           { licenseList }
         </div>
@@ -115,7 +116,7 @@ class AboutPage extends Component {
         show={ this.props.aboutModalStatus === 'ON' }
         onHide={ this.handleCloseButtonClicked.bind(this) }>
         <Modal.Header closeButton>
-          <Modal.Title>About</Modal.Title>
+          <Modal.Title>{ t('about.title') }</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           { this.renderSettingModalBody() }

--- a/app/containers/appContainer/index.js
+++ b/app/containers/appContainer/index.js
@@ -14,6 +14,7 @@ import SearchPage from '../searchPage'
 import SnippetPanel from '../snippetPanel'
 import { Pane, SplitPane } from 'react-split-pane'
 import ThemeManager from '../../utilities/themeManager'
+import { t } from '../../utilities/i18n'
 
 import './index.scss'
 import './scrollbar.scss'
@@ -114,13 +115,13 @@ class AppContainer extends Component {
       <div>
         { updateAvailableBarStatus === 'ON'
           ? <Alert bsStyle='warning' onDismiss={ this.dismissUpdateAlert.bind(this) }>
-            { `New version ${newVersionInfo.version} is available!  ` }
-            <a className='customized-button' onClick={ this.handleSkipClicked.bind(this) }>#skip</a>
+            { t('update.available', { version: newVersionInfo.version }) + '  ' }
+            <a className='customized-button' onClick={ this.handleSkipClicked.bind(this) }>{ t('update.skip') }</a>
             { newVersionInfo.url
-              ? <a className='customized-button' onClick={ this.handleReleaseNotesClicked.bind(this) }>#release</a>
-              : <a className='customized-button' onClick={ this.handleReleaseNotesClicked.bind(this) }>#download</a> }
+              ? <a className='customized-button' onClick={ this.handleReleaseNotesClicked.bind(this) }>{ t('update.release') }</a>
+              : <a className='customized-button' onClick={ this.handleReleaseNotesClicked.bind(this) }>{ t('update.download') }</a> }
             { newVersionInfo.url
-              ? <a className='customized-button' onClick={ this.handleDownloadClicked.bind(this) }>#download</a>
+              ? <a className='customized-button' onClick={ this.handleDownloadClicked.bind(this) }>{ t('update.download') }</a>
               : null }
           </Alert>
           : null }

--- a/app/containers/dashboard/index.js
+++ b/app/containers/dashboard/index.js
@@ -4,6 +4,7 @@ import { Modal, Image } from 'react-bootstrap'
 import { Radar } from 'react-chartjs'
 import { updateDashboardModalStatus } from '../../actions'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 
 import robotocatImage from '../../utilities/octodex/robotocat.png'
 
@@ -28,7 +29,7 @@ class Dashboard extends Component {
       <div className='dashboard-section'>
         <Image className='octocat' src={ robotocatImage } rounded/>
         <div className='greeting'>
-          Not enough data. Try creating gists of more than two languages. Happy Coding!
+          { t('dashboard.notEnoughData') }
         </div>
       </div>
     )
@@ -41,7 +42,7 @@ class Dashboard extends Component {
       labels: labels,
       datasets: [
         {
-          label: 'My Language Stats',
+          label: t('dashboard.statsLabel'),
           fillColor: 'rgba(81,192,191,0.2)',
           strokeColor: 'rgba(81,192,191,1)',
           pointColor: 'rgba(81,192,191,1)',
@@ -67,11 +68,11 @@ class Dashboard extends Component {
   }
 
   renderCompliments (lang) {
-    if (lang === 'Other') return 'Hmm... Looks like you are learning a mysterious language.'
+    if (lang === 'Other') return t('dashboard.mysteriousLanguage')
     return (
       <div>
-        <div className='compliment-word'> Well done! You are on the road to </div>
-        <div className='compliment-word'><b> { `${lang}  Master!` } </b></div>
+        <div className='compliment-word'> { t('dashboard.complimentPrefix') } </div>
+        <div className='compliment-word'><b> { t('dashboard.complimentMaster', { language: lang }) } </b></div>
       </div>
     )
   }
@@ -97,7 +98,7 @@ class Dashboard extends Component {
         show={ this.props.dashboardModalStatus === 'ON' }
         onHide={ this.handleCloseButtonClicked.bind(this) }>
         <Modal.Header closeButton>
-          <Modal.Title>Dashboard</Modal.Title>
+          <Modal.Title>{ t('dashboard.title') }</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           { this.renderSettingModalBody() }

--- a/app/containers/gistEditorForm/index.js
+++ b/app/containers/gistEditorForm/index.js
@@ -4,6 +4,7 @@ import electronBridge from '../../utilities/electronBridge'
 import { OverlayTrigger, Tooltip, Button, ListGroup, ListGroupItem, Panel } from 'react-bootstrap'
 import GistEditor from '../gistEditor'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 import validFilename from 'valid-filename'
 
 import tipsIcon from './ei-question.svg'
@@ -17,11 +18,7 @@ const conf = electronBridge.config
 const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 
-const descriptionTips = '[title] description #tag1 #tag2'
-
-const tooltip = (
-  <Tooltip id='tooltip'>{ descriptionTips }</Tooltip>
-)
+const getDescriptionTips = () => t('editor.descriptionPlaceholder')
 
 class GistEditorFormImpl extends Component {
   componentWillMount () {
@@ -70,14 +67,14 @@ class GistEditorFormImpl extends Component {
             type='submit'
             bsStyle='default'
             disabled={ submitting }>
-            Submit
+            { t('editor.submit') }
           </Button>
           <Button
             className='gist-editor-control-button'
             onClick={ handleCancel }
             bsStyle='default'
             disabled={ submitting }>
-              Cancel
+            { t('editor.cancel') }
           </Button>
         </div>
       </form>
@@ -85,19 +82,19 @@ class GistEditorFormImpl extends Component {
   }
 }
 
-const valideNotEmptyContent = value => value ? null : 'required'
+const valideNotEmptyContent = value => value ? null : t('editor.required')
 
 const validateFilename = value => {
   // empty filename is not allowed
   if (!value) {
-    return 'required'
+    return t('editor.required')
   }
 
   // validate filename according to the .leptonrc configs
   if (!conf.get('editor').validateFilename) {
     logger.info('[Filename Validation] According to the config, filename validation has been skipped')
   } else if (!validFilename(value)) {
-    return 'invalid filename'
+    return t('editor.invalidFilename')
   }
 }
 
@@ -115,15 +112,15 @@ const renderDescriptionField = ({ input, type, meta: { touched, error, warning }
       className='gist-editor-input-area'
       { ...input }
       type={ type }
-      placeholder={ descriptionTips }/>
+      placeholder={ getDescriptionTips() }/>
     { touched && ((error && <span className='error-msg'>{ error }</span>) ||
         (warning && <span className='error-msg'>{ warning }</span>)) }
-    <OverlayTrigger placement="top" overlay={ tooltip }>
+    <OverlayTrigger placement="top" overlay={ <Tooltip id='tooltip'>{ getDescriptionTips() }</Tooltip> }>
       <a className='tips' href='#'>
         <div
           className='tips-icon'
           dangerouslySetInnerHTML={{ __html: tipsIcon }} />
-        <span>tips</span>
+        <span>{ t('editor.tips') }</span>
       </a>
     </OverlayTrigger>
   </div>
@@ -147,11 +144,11 @@ function renderGistFileHeader (member, fields, index) {
         name={ `${member}.filename` }
         type='text'
         component={ renderTitleInputField }
-        placeholder='file name... (e.g. snippet.js)'
+        placeholder={ t('editor.filenamePlaceholder') }
         validate={ validateFilename }/>
       <a href='#'
         className={ fields.length === 1 ? 'gist-editor-customized-tag-hidden' : 'gist-editor-customized-tag' }
-        onClick={ () => fields.remove(index) }>#remove</a>
+        onClick={ () => fields.remove(index) }>{ t('editor.removeFile') }</a>
     </div>
   )
 }
@@ -176,11 +173,11 @@ const renderGistFiles = ({ fields, formStyle, filenameList }) => (
       <a href='#'
         className='gist-editor-customized-tag'
         onClick={ () => fields.push({}) }>
-        #add file
+        { t('editor.addFile') }
       </a>
       <div className='gist-editor-privacy-checkbox'>
         <Field name='private' id='private' component='input' type='checkbox' disabled={ formStyle === UPDATE_GIST }/>
-         &nbsp;secret
+         &nbsp;{ t('editor.secret') }
       </div>
     </div>
   </ListGroup>

--- a/app/containers/gistEditorForm/index.scss
+++ b/app/containers/gistEditorForm/index.scss
@@ -43,7 +43,8 @@
 
   .gist-editor-input-area {
     @extend .font-style-base;
-    flex: 1 1 95%;
+    flex: 1 1 auto;
+    min-width: 0;
     padding: 5px 10px;
     border: solid 1px;
     border-color: var(--border-color);
@@ -112,6 +113,12 @@
     font-size: 12px;
     font-weight: bold;
     color: #B0580E;
+  }
+
+  .gist-editor-name .error-msg {
+    flex: 0 0 40px;
+    margin-right: 8px;
+    white-space: nowrap;
   }
 
   .tips {

--- a/app/containers/languageSelector/index.js
+++ b/app/containers/languageSelector/index.js
@@ -1,0 +1,52 @@
+import electronBridge from '../../utilities/electronBridge'
+import React, { Component } from 'react'
+import { getLocale, getSupportedLocales, t } from '../../utilities/i18n'
+
+const logger = electronBridge.logger
+
+class LanguageSelector extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      locale: getLocale()
+    }
+  }
+
+  handleLanguageChanged (event) {
+    const locale = event.target.value
+    const { onBeforeChange, onChangeFailed } = this.props
+    this.setState({ locale })
+    Promise.resolve(onBeforeChange ? onBeforeChange(locale) : null)
+      .then(() => electronBridge.config.set('i18n:locale', locale))
+      .catch(error => {
+        logger.error(t('i18n.saveFailed'), error)
+        this.setState({ locale: getLocale() })
+        if (onChangeFailed) {
+          onChangeFailed(error)
+        }
+      })
+  }
+
+  render () {
+    const { className, compact } = this.props
+    const labelClassName = `${className || ''}${compact ? ' language-selector-compact' : ''}`.trim()
+    return (
+      <label className={ labelClassName }>
+        <span>{ compact ? '🌐' : t('i18n.language') }</span>
+        <select
+          className='form-control'
+          data-role='language-selector'
+          value={ this.state.locale }
+          onChange={ this.handleLanguageChanged.bind(this) }>
+          { getSupportedLocales().map(locale => (
+            <option key={ locale.code } value={ locale.code }>
+              { locale.name }
+            </option>
+          )) }
+        </select>
+      </label>
+    )
+  }
+}
+
+export default LanguageSelector

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -2,7 +2,9 @@ import { Alert, Button, Image, Modal, ProgressBar } from 'react-bootstrap'
 import Avatar from 'boring-avatars'
 import { connect } from 'react-redux'
 import electronBridge from '../../utilities/electronBridge'
+import LanguageSelector from '../languageSelector'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 
 import dojocatImage from '../../utilities/octodex/dojocat.jpg'
 import privateinvestocatImage from '../../utilities/octodex/privateinvestocat.jpg'
@@ -21,7 +23,8 @@ class LoginPage extends Component {
     super(props)
     this.state = {
       inputTokenValue: '',
-      loginMode: LoginModeEnum.CREDENTIALS
+      loginMode: LoginModeEnum.CREDENTIALS,
+      languageChanging: false
     }
   }
 
@@ -42,6 +45,7 @@ class LoginPage extends Component {
   componentWillUnmount () {
     logger.debug('-----> Removing listener for auto-login signal')
     ipcRenderer.removeAllListeners('auto-login')
+    clearTimeout(this.languageChangeTimer)
   }
 
   handleLoginClicked () {
@@ -76,7 +80,7 @@ class LoginPage extends Component {
     const { authWindowStatus, loggedInUserInfo, userSessionStatus } = this.props
     const { loginMode } = this.state
     const loggedInUserName = loggedInUserInfo ? loggedInUserInfo.profile : null
-    const welcomeMessage = 'Lepton is FREE. Like us on GitHub! ⭐'
+    const welcomeMessage = t('login.welcome')
 
     if (userSessionStatus === 'IN_PROGRESS') {
       return (
@@ -102,7 +106,7 @@ class LoginPage extends Component {
               className='modal-button'
               bsStyle="default"
               onClick={ this.handleContinueButtonClicked.bind(this, token) }>
-              { loggedInUserName ? `Continue as ${loggedInUserName}` : 'HAPPY CODING' }
+              { loggedInUserName ? t('login.continueAs', { username: loggedInUserName }) : t('login.happyCoding') }
             </Button>
             : this.renderTokenLoginSection(false, userSessionStatus)}
         </div>
@@ -127,6 +131,28 @@ class LoginPage extends Component {
     return null
   }
 
+  renderLanguageSelector () {
+    return (
+      <LanguageSelector
+        className='login-language-selector'
+        compact
+        onBeforeChange={ this.handleLanguageChanging.bind(this) }
+        onChangeFailed={ this.handleLanguageChangeFailed.bind(this) }
+      />
+    )
+  }
+
+  handleLanguageChanging () {
+    this.setState({ languageChanging: true })
+    return new Promise(resolve => {
+      this.languageChangeTimer = setTimeout(resolve, 180)
+    })
+  }
+
+  handleLanguageChangeFailed () {
+    this.setState({ languageChanging: false })
+  }
+
   updateInputValue (evt) {
     this.setState({
       inputTokenValue: evt.target.value
@@ -137,17 +163,17 @@ class LoginPage extends Component {
     return (
       <div>
         { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">Token invalid</Alert>
+          ? <Alert bsStyle="warning" className="login-alert">{ t('login.tokenInvalid') }</Alert>
           : null
         }
         <Button
           autoFocus
           className={ authWindowStatus === 'OFF' ? 'modal-button' : 'modal-button-disabled' }
           onClick={ this.handleLoginClicked.bind(this) }>
-            GitHub Login
+          { t('login.githubLogin') }
         </Button>
         <div className="login-page-text-link">
-          <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>Switch to token?</a>
+          <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>{ t('login.switchToToken') }</a>
         </div>
       </div>
     )
@@ -157,12 +183,12 @@ class LoginPage extends Component {
     return (
       <form>
         { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">Token invalid</Alert>
+          ? <Alert bsStyle="warning" className="login-alert">{ t('login.tokenInvalid') }</Alert>
           : null
         }
         <input
           className="form-control"
-          placeholder="scope: gist"
+          placeholder={ t('login.tokenPlaceholder') }
           value={ this.state.inputTokenValue }
           onChange={ this.updateInputValue.bind(this) }
         />
@@ -170,11 +196,11 @@ class LoginPage extends Component {
           autoFocus
           className='modal-button'
           onClick={ this.handleTokenLoginButtonClicked.bind(this, this.state.inputTokenValue) }>
-            Token Login
+          { t('login.tokenLogin') }
         </Button>
         { showLoginSwitch
           ? <div className="login-page-text-link">
-            <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>Switch to credentials?</a>
+            <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>{ t('login.switchToCredentials') }</a>
           </div>
           : null}
       </form>
@@ -220,11 +246,16 @@ class LoginPage extends Component {
   }
 
   render () {
+    const className = this.state.languageChanging
+      ? 'login-modal login-modal-language-changing'
+      : 'login-modal'
+
     return (
-      <div className='login-modal'>
+      <div className={ className }>
         <Modal.Dialog bsSize='small'>
           <Modal.Header>
-            <Modal.Title>Login</Modal.Title>
+            <Modal.Title>{ t('login.title') }</Modal.Title>
+            { this.renderLanguageSelector() }
           </Modal.Header>
           <Modal.Body>
             { this.renderLoginModalBody() }

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -13,8 +13,53 @@
   }
 
   .modal-content {
+    animation: login-modal-fade-in 180ms ease-out;
     margin-top: 100px;
     min-height: 400px;
+    opacity: 1;
+    transition: opacity 180ms ease-in;
+  }
+
+  &.login-modal-language-changing .modal-content {
+    opacity: 0;
+  }
+
+  .modal-header {
+    position: relative;
+  }
+
+  .login-language-selector {
+    -webkit-app-region: no-drag;
+    display: block;
+    height: 24px;
+    position: absolute;
+    right: 18px;
+    top: 20px;
+    width: 24px;
+  }
+
+  .login-language-selector span {
+    align-items: center;
+    color: #555;
+    display: flex;
+    filter: grayscale(1);
+    font-size: 16px;
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    opacity: .72;
+    width: 24px;
+  }
+
+  .login-language-selector select {
+    cursor: pointer;
+    height: 24px;
+    left: 0;
+    opacity: 0;
+    padding: 0;
+    position: absolute;
+    top: 0;
+    width: 24px;
   }
 
   .profile-image-modal {
@@ -55,5 +100,15 @@
 
   .login-alert {
     margin-bottom: 5px !important;
+  }
+}
+
+@keyframes login-modal-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }

--- a/app/containers/navigationPanel/index.js
+++ b/app/containers/navigationPanel/index.js
@@ -4,6 +4,7 @@ import { Modal, Button } from 'react-bootstrap'
 import { parseLangName as Resolved } from '../../utilities/parser'
 import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 import UserPanel from '../userPanel'
 import { getNextActiveGistTag } from './tags'
 import {
@@ -153,7 +154,7 @@ class NavigationPanel extends Component {
       <div className='gist-tag-section'>
         <div className='starred-tag-section'>
           <div className='tag-section-content'>
-            <a className='gist-tag' href={ `https://gist.${gitHubHost}/${userSession.profile.login}/starred` }>#starred</a>
+            <a className='gist-tag' href={ `https://gist.${gitHubHost}/${userSession.profile.login}/starred` }>{ t('navigation.starred') }</a>
           </div>
         </div>
         <div className='tag-section-list'>
@@ -167,7 +168,7 @@ class NavigationPanel extends Component {
             <a href='#'
               className='tag-section-title'
               onClick={this.handleSectionClick.bind(this, 0)}>
-              Languages</a>
+              { t('navigation.languages') }</a>
             <div className='tag-section-content'>
               { this.renderLangTags() }
             </div>
@@ -183,7 +184,7 @@ class NavigationPanel extends Component {
               <a href='#'
                 onClick={this.handleSectionClick.bind(this, 1)}
                 className='tag-section-title'>
-                Pinned
+                { t('navigation.pinned') }
               </a>
               <a className='configure-tag' onClick={ this.handleConfigurePinnedTagClicked.bind(this) }>
                 <div dangerouslySetInnerHTML={{ __html: plusIcon }} />
@@ -201,7 +202,7 @@ class NavigationPanel extends Component {
                 : 'tag-section tag-section-hidden'}>
             <a href='#'
               onClick={this.handleSectionClick.bind(this, 2)}
-              className='tag-section-title'>Tags</a>
+              className='tag-section-title'>{ t('navigation.tags') }</a>
             <div className='tag-section-content'>
               { this.renderCustomTags() }
             </div>
@@ -284,14 +285,14 @@ class NavigationPanel extends Component {
         show={ pinnedTagsModalStatus === 'ON' }
         onHide={ this.closePinnedTagsModal.bind(this) }>
         <Modal.Header closeButton>
-          <Modal.Title>Shortcuts</Modal.Title>
+          <Modal.Title>{ t('navigation.shortcuts') }</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           { this.renderAllTagsForPin() }
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={ this.closePinnedTagsModal.bind(this) }>Cancel</Button>
-          <Button bsStyle="default" onClick={ this.handlePinnedTagSaved.bind(this) }>Save</Button>
+          <Button onClick={ this.closePinnedTagsModal.bind(this) }>{ t('navigation.cancel') }</Button>
+          <Button bsStyle="default" onClick={ this.handlePinnedTagSaved.bind(this) }>{ t('navigation.save') }</Button>
         </Modal.Footer>
       </Modal>
     )

--- a/app/containers/searchPage/index.js
+++ b/app/containers/searchPage/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Modal } from 'react-bootstrap'
 import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 import {
   addLangPrefix as Prefixed,
   descriptionParser,
@@ -151,7 +152,7 @@ class SearchPage extends Component {
     if (inputValue.length > 0 && searchResults.length === 0) {
       return (
         <div className='not-found-msg'>
-          No result found...
+          { t('search.noResults') }
         </div>
       )
     }
@@ -192,7 +193,7 @@ class SearchPage extends Component {
         <input
           type="text"
           className='search-box'
-          placeholder='Search for description, tags, file names...'
+          placeholder={ t('search.placeholder') }
           autoFocus
           value={ this.state.inputValue }
           onChange={ this.updateInputValue.bind(this) }

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -9,6 +9,7 @@ import HumanReadableTime from 'human-readable-time'
 import Moment from 'moment'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 import TagBadges from '../tagBadges'
 import {
   getRegularTagsForGist,
@@ -85,11 +86,11 @@ class Snippet extends Component {
       .catch(err => {
         logger.error('Failed to delete the gist ' + activeGist)
         logger.error(JSON.stringify(err))
-        notifyFailure('Deletion failed', 'Please check your network condition. 02')
+        notifyFailure(t('notification.deletionFailed'), t('notification.networkFailure', { code: '02' }))
       })
       .then(data => {
         logger.info('The gist ' + activeGist + ' has been deleted.')
-        notifySuccess('The gist has been deleted')
+        notifySuccess(t('notification.gistDeleted'))
 
         // For performance purpose, we should perform an internal update, like what
         // we're doing for creating/edit gists. However, since delete is an infrequent
@@ -107,13 +108,13 @@ class Snippet extends Component {
       <div className='static-modal'>
         <Modal show={ this.props.gistDeleteModalStatus === 'ON' } bsSize='small' keyboard={ true }>
           <Modal.Header>
-            <Modal.Title>Delete the gist?</Modal.Title>
+            <Modal.Title>{ t('snippet.deleteConfirmTitle') }</Modal.Title>
           </Modal.Header>
           <Modal.Footer>
-            <Button onClick={ this.closeDeleteModal.bind(this) }>cancel</Button>
+            <Button onClick={ this.closeDeleteModal.bind(this) }>{ t('editor.cancel') }</Button>
             <Button
               bsStyle='danger'
-              onClick={ this.handleDeleteClicked.bind(this) }>delete</Button>
+              onClick={ this.handleDeleteClicked.bind(this) }>{ t('snippet.deleteAction') }</Button>
           </Modal.Footer>
         </Modal>
       </div>
@@ -163,7 +164,7 @@ class Snippet extends Component {
       description,
       processedFiles)
       .catch((err) => {
-        notifyFailure('Gist update failed')
+        notifyFailure(t('notification.gistUpdateFailed'))
         logger.error(JSON.stringify(err))
       })
       .then((response) => {
@@ -286,7 +287,7 @@ class Snippet extends Component {
       filename: filenameRecords
     })
 
-    notifySuccess('Gist updated', HumanReadableTime(new Date()))
+    notifySuccess(t('notification.gistUpdated'), HumanReadableTime(new Date()))
   }
 
   renderGistEditorModalBody (description, fileArray, isPrivate) {
@@ -316,7 +317,7 @@ class Snippet extends Component {
         show={ this.props.gistEditModalStatus === 'ON' }
         onHide={ this.closeGistEditorModal.bind(this)}>
         <Modal.Header closeButton>
-          <Modal.Title>Edit</Modal.Title>
+          <Modal.Title>{ t('snippet.edit') }</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           { this.renderGistEditorModalBody(description, fileArray, isPrivate) }
@@ -337,12 +338,12 @@ class Snippet extends Component {
   handleCopyGistLinkClicked (snippet, file) {
     const link = snippet.details.html_url + '#file-' + file.filename.replace(/\./g, '-').toLowerCase()
     clipboard.writeText(link)
-    notifySuccess('Copied', 'The link has been copied to the clipboard.')
+    notifySuccess(t('notification.copied'), t('notification.linkCopied'))
   }
 
   handleCopyGistFileClicked (gist) {
     clipboard.writeText(gist.content)
-    notifySuccess('Copied', 'The content has been copied to the clipboard.')
+    notifySuccess(t('notification.copied'), t('notification.contentCopied'))
   }
 
   showRawModalModal (gist) {
@@ -364,7 +365,7 @@ class Snippet extends Component {
         <Modal.Header closeButton>
           <Modal.Title>
             { gistRawModal.file }
-            <a className='copy-raw-link' href='#' onClick={ this.handleCopyRawLinkClicked.bind(this, gistRawModal.link) }>LINK</a>
+            <a className='copy-raw-link' href='#' onClick={ this.handleCopyRawLinkClicked.bind(this, gistRawModal.link) }>{ t('snippet.link') }</a>
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
@@ -384,7 +385,7 @@ class Snippet extends Component {
 
   handleCopyRawLinkClicked (url) {
     clipboard.writeText(url)
-    notifySuccess('Copied', 'The raw file link has been copied to the clipboard.')
+    notifySuccess(t('notification.copied'), t('notification.rawLinkCopied'))
   }
 
   renderPanelHeader (activeSnippet) {
@@ -393,34 +394,34 @@ class Snippet extends Component {
         <div className='line'>
           <div className='header-title'>
             { activeSnippet.brief.public
-              ? 'public gist'
+              ? t('snippet.publicGist')
               : [
                 <div key='icon'className='secret-icon' dangerouslySetInnerHTML={{ __html: secretIcon }} />,
-                <span key='description' >secret gist</span>
+                <span key='description' >{ t('snippet.secretGist') }</span>
               ]
             }
           </div>
           <div className='header-controls'>
             <a className='snippet-control'
-              title='Edit'
+              title={ t('snippet.edit') }
               href='#'
               onClick={ this.showGistEditorModal.bind(this) }>
               <div dangerouslySetInnerHTML={{ __html: editIcon }} />
             </a>
             <a className='snippet-control'
-              title='Open in Web'
+              title={ t('snippet.openInWeb') }
               href={ activeSnippet.brief.html_url }>
               <div dangerouslySetInnerHTML={{ __html: openInWebIcon }} />
             </a>
             <a className='snippet-control'
-              title='Revisions'
+              title={ t('snippet.revisions') }
               href={ activeSnippet.brief.html_url + '/revisions' }>
               <div dangerouslySetInnerHTML={{ __html: eyeIcon }} />
             </a>
             {
               this.props.immersiveMode === 'OFF'
                 ? <a className='snippet-control'
-                  title='Delete'
+                  title={ t('snippet.delete') }
                   href='#'
                   onClick={ this.showDeleteModal.bind(this) }>
                   <div dangerouslySetInnerHTML={{ __html: trashIcon }} />
@@ -470,7 +471,7 @@ class Snippet extends Component {
           </div>
           : null }
         <span className='update-date'>
-          { 'Last active ' + Moment(gist.brief.updated_at).fromNow() }
+          { t('snippet.lastActive', { time: Moment(gist.brief.updated_at).fromNow() }) }
         </span>
       </div>)
 
@@ -537,19 +538,19 @@ class Snippet extends Component {
                   href='#'
                   className='file-header-control'
                   onClick={ this.handleCopyGistLinkClicked.bind(this, activeSnippet, gistFile) }>
-                  SHARE
+                  { t('snippet.share') }
                 </a>
                 <a
                   href='#'
                   className='file-header-control'
                   onClick={ this.showRawModalModal.bind(this, gistFile) }>
-                  RAW
+                  { t('snippet.raw') }
                 </a>
                 <a
                   href='#'
                   className='file-header-control'
                   onClick={ this.handleCopyGistFileClicked.bind(this, gistFile) }>
-                  COPY
+                  { t('snippet.copy') }
                 </a>
               </div>
             </div>

--- a/app/containers/snippetPanel/index.js
+++ b/app/containers/snippetPanel/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { Well } from 'react-bootstrap'
 import React, { Component } from 'react'
 import Snippet from '../snippet'
+import { t } from '../../utilities/i18n'
 
 import './index.scss'
 
@@ -9,7 +10,7 @@ class SnippetPanel extends Component {
   renderEmptySnippetSection () {
     // This happens when the user has no gists
     return (
-      <Well className='welcome-section'>Click <b>#new</b> on the left panel to create a gist.</Well>
+      <Well className='welcome-section'>{ t('welcome.emptySnippet') }</Well>
     )
   }
 

--- a/app/containers/userPanel/index.js
+++ b/app/containers/userPanel/index.js
@@ -6,6 +6,7 @@ import electronBridge from '../../utilities/electronBridge'
 import HumanReadableTime from 'human-readable-time'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
+import { t } from '../../utilities/i18n'
 import {
   addLangPrefix as Prefixed,
   descriptionParser,
@@ -79,7 +80,7 @@ class UserPanel extends Component {
 
     return getGitHubApi(CREATE_SINGLE_GIST)(this.props.accessToken, description, processedFiles, isPublic)
       .catch((err) => {
-        notifyFailure('Gist creation failed')
+        notifyFailure(t('notification.gistCreationFailed'))
         logger.error(JSON.stringify(err))
       })
       .then((response) => {
@@ -164,7 +165,7 @@ class UserPanel extends Component {
       filename: filenameRecords
     })
 
-    notifySuccess('Gist created', HumanReadableTime(new Date()))
+    notifySuccess(t('notification.gistCreated'), HumanReadableTime(new Date()))
   }
 
   renderGistEditorModalBody () {
@@ -195,7 +196,7 @@ class UserPanel extends Component {
         show={ this.props.gistNewModalStatus === 'ON' }
         onHide={ this.closeGistEditorModal.bind(this)}>
         <Modal.Header closeButton>
-          <Modal.Title>New</Modal.Title>
+          <Modal.Title>{ t('userPanel.new') }</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           { this.renderGistEditorModalBody.bind(this)() }
@@ -214,7 +215,7 @@ class UserPanel extends Component {
           <div
             className='user-panel-icon'
             dangerouslySetInnerHTML={{ __html: logoutIcon }} />
-          <span>Logout</span>
+          <span>{ t('userPanel.logout') }</span>
         </a>
         <br/>
         <a href='#'
@@ -223,7 +224,7 @@ class UserPanel extends Component {
           <div
             className='user-panel-icon'
             dangerouslySetInnerHTML={{ __html: newIcon }} />
-          <span>New</span>
+          <span>{ t('userPanel.new') }</span>
         </a>
         <br/>
         <a href='#'
@@ -232,7 +233,7 @@ class UserPanel extends Component {
           <div
             className='user-panel-icon'
             dangerouslySetInnerHTML={{ __html: syncIcon }} />
-          <span>Sync</span>
+          <span>{ t('userPanel.sync') }</span>
         </a>
         <div className='customized-tag-small'>{ this.props.syncTime }</div>
       </div>
@@ -306,13 +307,13 @@ class UserPanel extends Component {
       <div className='static-modal'>
         <Modal show={ this.props.logoutModalStatus === 'ON' } bsSize='small'>
           <Modal.Header>
-            <Modal.Title>Confirm logout?</Modal.Title>
+            <Modal.Title>{ t('userPanel.confirmLogout') }</Modal.Title>
           </Modal.Header>
           <Modal.Footer>
-            <Button onClick={ this.handleLogoutModalCancelClicked.bind(this) }>cancel</Button>
+            <Button onClick={ this.handleLogoutModalCancelClicked.bind(this) }>{ t('editor.cancel') }</Button>
             <Button
               bsStyle='danger'
-              onClick={ this.handleLogoutModalConfirmClicked.bind(this) }>logout</Button>
+              onClick={ this.handleLogoutModalConfirmClicked.bind(this) }>{ t('userPanel.logoutAction') }</Button>
           </Modal.Footer>
         </Modal>
       </div>

--- a/app/index.js
+++ b/app/index.js
@@ -48,6 +48,7 @@ import {
 } from './actions/index'
 
 import { notifySuccess, notifyFailure } from './utilities/notifier'
+import { configureI18n, t } from './utilities/i18n'
 
 const path = require('path')
 const { createRequire } = require('module')
@@ -56,6 +57,7 @@ const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 const conf = electronBridge.config
 const appRequire = createRequire(path.join(electronBridge.app.getAppPath(), 'app/index.js'))
+configureI18n(electronBridge.config.get('i18n:locale'))
 
 let Account = null
 try {
@@ -139,7 +141,7 @@ function launchAuthWindow (token) {
         })
         .catch((err) => {
           logger.error('Failed: ' + JSON.stringify(err.error))
-          notifyFailure('Sync failed', 'Please check your network condition. 03')
+          notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
         })
     } else if (error) {
       logger.error('Oops! Something went wrong and we couldn\'t' +
@@ -399,12 +401,12 @@ function updateUserGists (userLoginId, token) {
       // clean up the snapshot for the previous state
       clearSyncSnapshot()
 
-      notifySuccess('Sync succeeds', humanReadableSyncTime)
+      notifySuccess(t('notification.syncSucceeds'), humanReadableSyncTime)
 
       reduxStore.dispatch(updateGistSyncStatus('DONE'))
     })
     .catch(err => {
-      notifyFailure('Sync failed', 'Please check your network condition. 04')
+      notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '04' }))
       logger.error('The request has failed: ' + err)
       reduxStore.dispatch(updateGistSyncStatus('DONE'))
       throw err
@@ -454,7 +456,7 @@ function initUserSession (token) {
         logger.info('[Dispatch] updateUserSession INACTIVE')
         reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
       }
-      notifyFailure('Sync failed', 'Please check your network condition. 00')
+      notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '00' }))
     })
 }
 /** End: User session management **/

--- a/app/utilities/electronBridge/index.js
+++ b/app/utilities/electronBridge/index.js
@@ -34,7 +34,11 @@ function createFallbackBridge () {
     },
     clipboard: electron.clipboard || { writeText: () => {} },
     config: {
-      get: (key) => conf.get(key)
+      get: (key) => conf.get(key),
+      set: (key, value) => {
+        conf.set(key, value)
+        return Promise.resolve(value)
+      }
     },
     globals: {
       getPaths: () => ({

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -1,6 +1,7 @@
 import { Promise } from 'bluebird'
 import electronBridge from '../electronBridge'
 import { notifyFailure } from '../notifier'
+import { t } from '../i18n'
 import ProxyAgent from 'proxy-agent'
 import ReqPromise from 'request-promise'
 import Request from 'request'
@@ -136,7 +137,7 @@ function getAllGistsV1 (token, userId) {
       .catch(err => {
         if (err !== EMPTY_PAGE_ERROR_MESSAGE) {
           logger.error(err)
-          notifyFailure('Sync failed', 'Please check your network condition. 05')
+          notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '05' }))
         }
       })
       .finally(() => {

--- a/app/utilities/i18n/index.js
+++ b/app/utilities/i18n/index.js
@@ -1,0 +1,83 @@
+const en = require('./locales/en')
+const es = require('./locales/es')
+const fr = require('./locales/fr')
+const ja = require('./locales/ja')
+const ko = require('./locales/ko')
+const zhHans = require('./locales/zh-Hans')
+const zhHant = require('./locales/zh-Hant')
+
+const DEFAULT_LOCALE = 'en'
+const catalogs = {
+  en,
+  es,
+  fr,
+  ja,
+  ko,
+  'zh-Hans': zhHans,
+  'zh-Hant': zhHant
+}
+
+const supportedLocales = [
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Español' },
+  { code: 'fr', name: 'Français' },
+  { code: 'ja', name: '日本語' },
+  { code: 'ko', name: '한국어' },
+  { code: 'zh-Hans', name: '简体中文' },
+  { code: 'zh-Hant', name: '繁體中文' }
+]
+
+let activeLocale = DEFAULT_LOCALE
+
+function normalizeLocale (locale) {
+  if (typeof locale !== 'string') return DEFAULT_LOCALE
+  const trimmedLocale = locale.trim()
+  return Object.prototype.hasOwnProperty.call(catalogs, trimmedLocale)
+    ? trimmedLocale
+    : DEFAULT_LOCALE
+}
+
+function configureI18n (locale) {
+  activeLocale = normalizeLocale(locale)
+  return activeLocale
+}
+
+function readPath (catalog, key) {
+  if (!catalog || typeof key !== 'string') return undefined
+  return key.split('.').reduce((value, segment) => {
+    if (!value || !Object.prototype.hasOwnProperty.call(value, segment)) {
+      return undefined
+    }
+    return value[segment]
+  }, catalog)
+}
+
+function interpolate (message, values) {
+  if (typeof message !== 'string') return message
+  return message.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (match, name) => {
+    if (!values || !Object.prototype.hasOwnProperty.call(values, name)) return match
+    return String(values[name])
+  })
+}
+
+function t (key, values) {
+  const activeMessage = readPath(catalogs[activeLocale], key)
+  const fallbackMessage = readPath(catalogs[DEFAULT_LOCALE], key)
+  const message = activeMessage !== undefined ? activeMessage : fallbackMessage
+  return interpolate(message !== undefined ? message : key, values)
+}
+
+function getLocale () {
+  return activeLocale
+}
+
+function getSupportedLocales () {
+  return supportedLocales.map(locale => Object.assign({}, locale))
+}
+
+module.exports = {
+  configureI18n,
+  getLocale,
+  getSupportedLocales,
+  t
+}

--- a/app/utilities/i18n/locales/en.js
+++ b/app/utilities/i18n/locales/en.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: 'Acknowledgement',
+    configurations: 'Configurations',
+    contributors: 'Contributors',
+    feedback: 'Feedback',
+    license: 'License',
+    licenseType: 'License: {{license}}',
+    logs: 'Logs',
+    title: 'About'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}} Master!',
+    complimentPrefix: 'Well done! You are on the road to',
+    mysteriousLanguage: 'Hmm... Looks like you are learning a mysterious language.',
+    notEnoughData: 'Not enough data. Try creating gists of more than two languages. Happy Coding!',
+    statsLabel: 'My Language Stats',
+    title: 'Dashboard'
+  },
+  dialog: {
+    close: 'Close',
+    minimize: 'Minimize',
+    minimizeToTray: 'Minimize to tray',
+    neverMind: 'Never Mind',
+    quit: 'Quit',
+    quitConfirm: 'Are you sure?',
+    quitTitle: 'Quit'
+  },
+  editor: {
+    addFile: '#add file',
+    cancel: 'Cancel',
+    descriptionPlaceholder: '[title] description #tag1 #tag2',
+    filenamePlaceholder: 'file name... (e.g. snippet.js)',
+    invalidFilename: 'invalid filename',
+    removeFile: '#remove',
+    required: 'required',
+    secret: 'secret',
+    submit: 'Submit',
+    tips: 'tips'
+  },
+  login: {
+    continueAs: 'Continue as {{username}}',
+    githubLogin: 'GitHub Login',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: 'Switch to credentials?',
+    switchToToken: 'Switch to token?',
+    title: 'Login',
+    tokenInvalid: 'Token invalid',
+    tokenLogin: 'Token Login',
+    tokenPlaceholder: 'scope: gist',
+    welcome: 'Lepton is FREE. Like us on GitHub!'
+  },
+  i18n: {
+    language: 'Language',
+    saveFailed: 'Failed to update language setting'
+  },
+  menu: {
+    about: 'About',
+    backToNormalMode: 'Back to Normal Mode',
+    bringAllToFront: 'Bring All to Front',
+    close: 'Close',
+    dashboard: 'Dashboard',
+    deleteGist: 'Delete Gist',
+    edit: 'Edit',
+    editGist: 'Edit Gist',
+    exitEditor: 'Exit Editor',
+    gist: 'Gist',
+    immersiveMode: 'Immersive Mode',
+    learnMore: 'Learn More',
+    minimize: 'Minimize',
+    newGist: 'New Gist',
+    openWindow: 'Open Window',
+    quit: 'Quit',
+    search: 'Search',
+    speech: 'Speech',
+    submitGist: 'Submit Gist',
+    syncGist: 'Sync Gist',
+    toggleDeveloperTools: 'Toggle Developer Tools',
+    view: 'View',
+    zoom: 'Zoom'
+  },
+  navigation: {
+    cancel: 'Cancel',
+    languages: 'Languages',
+    pinned: 'Pinned',
+    save: 'Save',
+    shortcuts: 'Shortcuts',
+    starred: '#starred',
+    tags: 'Tags'
+  },
+  notification: {
+    contentCopied: 'The content has been copied to the clipboard.',
+    copied: 'Copied',
+    deletionFailed: 'Deletion failed',
+    gistCreated: 'Gist created',
+    gistCreationFailed: 'Gist creation failed',
+    gistDeleted: 'The gist has been deleted',
+    gistUpdateFailed: 'Gist update failed',
+    gistUpdated: 'Gist updated',
+    linkCopied: 'The link has been copied to the clipboard.',
+    networkFailure: 'Please check your network condition. {{code}}',
+    rawLinkCopied: 'The raw file link has been copied to the clipboard.',
+    syncFailed: 'Sync failed',
+    syncSucceeds: 'Sync succeeds'
+  },
+  search: {
+    noResults: 'No result found...',
+    placeholder: 'Search for description, tags, file names...'
+  },
+  snippet: {
+    copy: 'COPY',
+    delete: 'Delete',
+    deleteAction: 'delete',
+    deleteConfirmTitle: 'Delete the gist?',
+    edit: 'Edit',
+    lastActive: 'Last active {{time}}',
+    link: 'LINK',
+    openInWeb: 'Open in Web',
+    publicGist: 'public gist',
+    raw: 'RAW',
+    revisions: 'Revisions',
+    secretGist: 'secret gist',
+    share: 'SHARE'
+  },
+  touchBar: {
+    edit: 'Edit',
+    immersive: 'Immersive',
+    new: 'New',
+    search: 'Search',
+    sync: 'Sync'
+  },
+  update: {
+    available: 'New version {{version}} is available!',
+    download: '#download',
+    release: '#release',
+    skip: '#skip'
+  },
+  userPanel: {
+    confirmLogout: 'Confirm logout?',
+    logout: 'Logout',
+    logoutAction: 'logout',
+    new: 'New',
+    sync: 'Sync'
+  },
+  welcome: {
+    emptySnippet: 'Click #new on the left panel to create a gist.'
+  }
+}

--- a/app/utilities/i18n/locales/es.js
+++ b/app/utilities/i18n/locales/es.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: 'Agradecimientos',
+    configurations: 'Configuraciones',
+    contributors: 'Colaboradores',
+    feedback: 'Comentarios',
+    license: 'Licencia',
+    licenseType: 'Licencia: {{license}}',
+    logs: 'Registros',
+    title: 'Acerca de'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: 'Maestro de {{language}}!',
+    complimentPrefix: 'Bien hecho! Vas camino a ser',
+    mysteriousLanguage: 'Hmm... Parece que estas aprendiendo un lenguaje misterioso.',
+    notEnoughData: 'No hay suficientes datos. Prueba crear gists de mas de dos lenguajes. Happy Coding!',
+    statsLabel: 'Mis estadisticas de lenguajes',
+    title: 'Panel'
+  },
+  dialog: {
+    close: 'Cerrar',
+    minimize: 'Minimizar',
+    minimizeToTray: 'Minimizar a la bandeja',
+    neverMind: 'Cancelar',
+    quit: 'Salir',
+    quitConfirm: 'Estas seguro?',
+    quitTitle: 'Salir'
+  },
+  editor: {
+    addFile: '#agregar archivo',
+    cancel: 'Cancelar',
+    descriptionPlaceholder: '[titulo] descripcion #etiqueta1 #etiqueta2',
+    filenamePlaceholder: 'nombre de archivo... (ej. snippet.js)',
+    invalidFilename: 'nombre de archivo invalido',
+    removeFile: '#eliminar',
+    required: 'obligatorio',
+    secret: 'secreto',
+    submit: 'Enviar',
+    tips: 'consejos'
+  },
+  login: {
+    continueAs: 'Continuar como {{username}}',
+    githubLogin: 'Iniciar sesion con GitHub',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: 'Cambiar a credenciales?',
+    switchToToken: 'Cambiar a token?',
+    title: 'Iniciar sesion',
+    tokenInvalid: 'Token invalido',
+    tokenLogin: 'Iniciar sesion con token',
+    tokenPlaceholder: 'scope: gist',
+    welcome: 'Lepton es gratis. Apoyanos en GitHub!'
+  },
+  i18n: {
+    language: 'Idioma',
+    saveFailed: 'No se pudo actualizar el idioma'
+  },
+  menu: {
+    about: 'Acerca de',
+    backToNormalMode: 'Volver al modo normal',
+    bringAllToFront: 'Traer todo al frente',
+    close: 'Cerrar',
+    dashboard: 'Panel',
+    deleteGist: 'Eliminar Gist',
+    edit: 'Editar',
+    editGist: 'Editar Gist',
+    exitEditor: 'Salir del editor',
+    gist: 'Gist',
+    immersiveMode: 'Modo inmersivo',
+    learnMore: 'Mas informacion',
+    minimize: 'Minimizar',
+    newGist: 'Nuevo Gist',
+    openWindow: 'Abrir ventana',
+    quit: 'Salir',
+    search: 'Buscar',
+    speech: 'Voz',
+    submitGist: 'Enviar Gist',
+    syncGist: 'Sincronizar Gist',
+    toggleDeveloperTools: 'Alternar herramientas de desarrollo',
+    view: 'Ver',
+    zoom: 'Zoom'
+  },
+  navigation: {
+    cancel: 'Cancelar',
+    languages: 'Lenguajes',
+    pinned: 'Fijados',
+    save: 'Guardar',
+    shortcuts: 'Accesos directos',
+    starred: '#favoritos',
+    tags: 'Etiquetas'
+  },
+  notification: {
+    contentCopied: 'El contenido se copio al portapapeles.',
+    copied: 'Copiado',
+    deletionFailed: 'No se pudo eliminar',
+    gistCreated: 'Gist creado',
+    gistCreationFailed: 'No se pudo crear el Gist',
+    gistDeleted: 'El Gist se elimino',
+    gistUpdateFailed: 'No se pudo actualizar el Gist',
+    gistUpdated: 'Gist actualizado',
+    linkCopied: 'El enlace se copio al portapapeles.',
+    networkFailure: 'Revisa tu conexion de red. {{code}}',
+    rawLinkCopied: 'El enlace del archivo RAW se copio al portapapeles.',
+    syncFailed: 'La sincronizacion fallo',
+    syncSucceeds: 'Sincronizacion completada'
+  },
+  search: {
+    noResults: 'No se encontraron resultados...',
+    placeholder: 'Buscar descripcion, etiquetas, nombres de archivo...'
+  },
+  snippet: {
+    copy: 'COPIAR',
+    delete: 'Eliminar',
+    deleteAction: 'eliminar',
+    deleteConfirmTitle: 'Eliminar este Gist?',
+    edit: 'Editar',
+    lastActive: 'Ultima actividad {{time}}',
+    link: 'ENLACE',
+    openInWeb: 'Abrir en la web',
+    publicGist: 'gist publico',
+    raw: 'RAW',
+    revisions: 'Revisiones',
+    secretGist: 'gist secreto',
+    share: 'COMPARTIR'
+  },
+  touchBar: {
+    edit: 'Editar',
+    immersive: 'Inmersivo',
+    new: 'Nuevo',
+    search: 'Buscar',
+    sync: 'Sincronizar'
+  },
+  update: {
+    available: 'La nueva version {{version}} esta disponible!',
+    download: '#descargar',
+    release: '#version',
+    skip: '#omitir'
+  },
+  userPanel: {
+    confirmLogout: 'Confirmar cierre de sesion?',
+    logout: 'Cerrar sesion',
+    logoutAction: 'cerrar sesion',
+    new: 'Nuevo',
+    sync: 'Sincronizar'
+  },
+  welcome: {
+    emptySnippet: 'Haz clic en #new en el panel izquierdo para crear un gist.'
+  }
+}

--- a/app/utilities/i18n/locales/fr.js
+++ b/app/utilities/i18n/locales/fr.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: 'Remerciements',
+    configurations: 'Parametres',
+    contributors: 'Contributeurs',
+    feedback: 'Retour',
+    license: 'Licence',
+    licenseType: 'Licence : {{license}}',
+    logs: 'Journaux',
+    title: 'A propos'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: 'Maitre {{language}} !',
+    complimentPrefix: 'Bien joue ! Vous etes en route vers',
+    mysteriousLanguage: 'Hmm... On dirait que vous apprenez un langage mysterieux.',
+    notEnoughData: 'Pas assez de donnees. Creez des gists dans plus de deux langages. Happy Coding!',
+    statsLabel: 'Mes stats de langages',
+    title: 'Tableau de bord'
+  },
+  dialog: {
+    close: 'Fermer',
+    minimize: 'Reduire',
+    minimizeToTray: 'Reduire dans la zone de notification',
+    neverMind: 'Annuler',
+    quit: 'Quitter',
+    quitConfirm: 'Etes-vous sur ?',
+    quitTitle: 'Quitter'
+  },
+  editor: {
+    addFile: '#ajouter fichier',
+    cancel: 'Annuler',
+    descriptionPlaceholder: '[titre] description #tag1 #tag2',
+    filenamePlaceholder: 'nom du fichier... (ex. snippet.js)',
+    invalidFilename: 'nom de fichier invalide',
+    removeFile: '#retirer',
+    required: 'obligatoire',
+    secret: 'prive',
+    submit: 'Envoyer',
+    tips: 'astuces'
+  },
+  login: {
+    continueAs: 'Continuer avec {{username}}',
+    githubLogin: 'Connexion GitHub',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: 'Passer aux identifiants ?',
+    switchToToken: 'Passer au jeton ?',
+    title: 'Connexion',
+    tokenInvalid: 'Jeton invalide',
+    tokenLogin: 'Connexion par jeton',
+    tokenPlaceholder: 'scope: gist',
+    welcome: 'Lepton est gratuit. Soutenez-nous sur GitHub !'
+  },
+  i18n: {
+    language: 'Langue',
+    saveFailed: 'Impossible de mettre a jour la langue'
+  },
+  menu: {
+    about: 'A propos',
+    backToNormalMode: 'Retour au mode normal',
+    bringAllToFront: 'Tout ramener au premier plan',
+    close: 'Fermer',
+    dashboard: 'Tableau de bord',
+    deleteGist: 'Supprimer le Gist',
+    edit: 'Modifier',
+    editGist: 'Modifier le Gist',
+    exitEditor: 'Quitter l editeur',
+    gist: 'Gist',
+    immersiveMode: 'Mode immersif',
+    learnMore: 'En savoir plus',
+    minimize: 'Reduire',
+    newGist: 'Nouveau Gist',
+    openWindow: 'Ouvrir la fenetre',
+    quit: 'Quitter',
+    search: 'Rechercher',
+    speech: 'Parole',
+    submitGist: 'Envoyer le Gist',
+    syncGist: 'Synchroniser le Gist',
+    toggleDeveloperTools: 'Basculer les outils de developpement',
+    view: 'Affichage',
+    zoom: 'Zoom'
+  },
+  navigation: {
+    cancel: 'Annuler',
+    languages: 'Langages',
+    pinned: 'Epingles',
+    save: 'Enregistrer',
+    shortcuts: 'Raccourcis',
+    starred: '#favoris',
+    tags: 'Etiquettes'
+  },
+  notification: {
+    contentCopied: 'Le contenu a ete copie dans le presse-papiers.',
+    copied: 'Copie',
+    deletionFailed: 'Suppression echouee',
+    gistCreated: 'Gist cree',
+    gistCreationFailed: 'Creation du Gist echouee',
+    gistDeleted: 'Le gist a ete supprime',
+    gistUpdateFailed: 'Mise a jour du Gist echouee',
+    gistUpdated: 'Gist mis a jour',
+    linkCopied: 'Le lien a ete copie dans le presse-papiers.',
+    networkFailure: 'Veuillez verifier votre connexion. {{code}}',
+    rawLinkCopied: 'Le lien du fichier RAW a ete copie dans le presse-papiers.',
+    syncFailed: 'Synchronisation echouee',
+    syncSucceeds: 'Synchronisation reussie'
+  },
+  search: {
+    noResults: 'Aucun resultat...',
+    placeholder: 'Rechercher descriptions, tags, noms de fichiers...'
+  },
+  snippet: {
+    copy: 'COPIER',
+    delete: 'Supprimer',
+    deleteAction: 'supprimer',
+    deleteConfirmTitle: 'Supprimer ce gist ?',
+    edit: 'Modifier',
+    lastActive: 'Derniere activite {{time}}',
+    link: 'LIEN',
+    openInWeb: 'Ouvrir dans le web',
+    publicGist: 'gist public',
+    raw: 'RAW',
+    revisions: 'Historique',
+    secretGist: 'gist secret',
+    share: 'PARTAGER'
+  },
+  touchBar: {
+    edit: 'Modifier',
+    immersive: 'Immersif',
+    new: 'Nouveau',
+    search: 'Rechercher',
+    sync: 'Synchroniser'
+  },
+  update: {
+    available: 'Nouvelle version {{version}} disponible !',
+    download: '#telecharger',
+    release: '#version',
+    skip: '#ignorer'
+  },
+  userPanel: {
+    confirmLogout: 'Confirmer la deconnexion ?',
+    logout: 'Deconnexion',
+    logoutAction: 'deconnexion',
+    new: 'Nouveau',
+    sync: 'Synchroniser'
+  },
+  welcome: {
+    emptySnippet: 'Cliquez sur #new dans le panneau gauche pour creer un gist.'
+  }
+}

--- a/app/utilities/i18n/locales/ja.js
+++ b/app/utilities/i18n/locales/ja.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: '謝辞',
+    configurations: '設定',
+    contributors: '貢献者',
+    feedback: 'フィードバック',
+    license: 'ライセンス',
+    licenseType: 'ライセンス: {{license}}',
+    logs: 'ログ',
+    title: 'Leptonについて'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}}マスター！',
+    complimentPrefix: 'すばらしいです！あなたは次を目指しています',
+    mysteriousLanguage: 'うーん... 謎めいた言語を学んでいるようです。',
+    notEnoughData: 'データが不足しています。3種類以上の言語でGistを作成してみてください。Happy Coding!',
+    statsLabel: '言語統計',
+    title: 'ダッシュボード'
+  },
+  dialog: {
+    close: '閉じる',
+    minimize: '最小化',
+    minimizeToTray: 'トレイに最小化',
+    neverMind: 'キャンセル',
+    quit: '終了',
+    quitConfirm: 'よろしいですか？',
+    quitTitle: '終了'
+  },
+  editor: {
+    addFile: '#ファイルを追加',
+    cancel: 'キャンセル',
+    descriptionPlaceholder: '[タイトル] 説明 #タグ1 #タグ2',
+    filenamePlaceholder: 'ファイル名...（例: snippet.js）',
+    invalidFilename: '無効なファイル名',
+    removeFile: '#削除',
+    required: '必須',
+    secret: 'シークレット',
+    submit: '送信',
+    tips: 'ヒント'
+  },
+  login: {
+    continueAs: '{{username}}として続行',
+    githubLogin: 'GitHubでログイン',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: '認証情報に切り替えますか？',
+    switchToToken: 'トークンに切り替えますか？',
+    title: 'ログイン',
+    tokenInvalid: 'トークンが無効です',
+    tokenLogin: 'トークンでログイン',
+    tokenPlaceholder: 'scope: gist',
+    welcome: 'Leptonは無料です。GitHubで応援してください！'
+  },
+  i18n: {
+    language: '言語',
+    saveFailed: '言語設定を更新できませんでした'
+  },
+  menu: {
+    about: 'Leptonについて',
+    backToNormalMode: '通常モードに戻る',
+    bringAllToFront: 'すべてを前面に表示',
+    close: '閉じる',
+    dashboard: 'ダッシュボード',
+    deleteGist: 'Gistを削除',
+    edit: '編集',
+    editGist: 'Gistを編集',
+    exitEditor: 'エディターを終了',
+    gist: 'Gist',
+    immersiveMode: '集中モード',
+    learnMore: '詳しく見る',
+    minimize: '最小化',
+    newGist: '新規Gist',
+    openWindow: 'ウィンドウを開く',
+    quit: '終了',
+    search: '検索',
+    speech: 'スピーチ',
+    submitGist: 'Gistを送信',
+    syncGist: 'Gistを同期',
+    toggleDeveloperTools: '開発者ツールを切り替え',
+    view: '表示',
+    zoom: 'ズーム'
+  },
+  navigation: {
+    cancel: 'キャンセル',
+    languages: '言語',
+    pinned: 'ピン留め',
+    save: '保存',
+    shortcuts: 'ショートカット',
+    starred: '#スター付き',
+    tags: 'タグ'
+  },
+  notification: {
+    contentCopied: '内容をクリップボードにコピーしました。',
+    copied: 'コピーしました',
+    deletionFailed: '削除に失敗しました',
+    gistCreated: 'Gistを作成しました',
+    gistCreationFailed: 'Gistの作成に失敗しました',
+    gistDeleted: 'Gistを削除しました',
+    gistUpdateFailed: 'Gistの更新に失敗しました',
+    gistUpdated: 'Gistを更新しました',
+    linkCopied: 'リンクをクリップボードにコピーしました。',
+    networkFailure: 'ネットワーク状態を確認してください。{{code}}',
+    rawLinkCopied: 'RAWファイルのリンクをクリップボードにコピーしました。',
+    syncFailed: '同期に失敗しました',
+    syncSucceeds: '同期しました'
+  },
+  search: {
+    noResults: '結果が見つかりません...',
+    placeholder: '説明、タグ、ファイル名を検索...'
+  },
+  snippet: {
+    copy: 'コピー',
+    delete: '削除',
+    deleteAction: '削除',
+    deleteConfirmTitle: 'このGistを削除しますか？',
+    edit: '編集',
+    lastActive: '最終更新 {{time}}',
+    link: 'リンク',
+    openInWeb: 'Webで開く',
+    publicGist: '公開Gist',
+    raw: 'RAW',
+    revisions: '履歴',
+    secretGist: 'シークレットGist',
+    share: '共有'
+  },
+  touchBar: {
+    edit: '編集',
+    immersive: '集中',
+    new: '新規',
+    search: '検索',
+    sync: '同期'
+  },
+  update: {
+    available: '新しいバージョン {{version}} が利用できます！',
+    download: '#ダウンロード',
+    release: '#リリース',
+    skip: '#スキップ'
+  },
+  userPanel: {
+    confirmLogout: 'ログアウトしますか？',
+    logout: 'ログアウト',
+    logoutAction: 'ログアウト',
+    new: '新規',
+    sync: '同期'
+  },
+  welcome: {
+    emptySnippet: '左パネルの#newをクリックしてGistを作成してください。'
+  }
+}

--- a/app/utilities/i18n/locales/ko.js
+++ b/app/utilities/i18n/locales/ko.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: '감사의 말',
+    configurations: '설정',
+    contributors: '기여자',
+    feedback: '피드백',
+    license: '라이선스',
+    licenseType: '라이선스: {{license}}',
+    logs: '로그',
+    title: '정보'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}} 마스터!',
+    complimentPrefix: '좋아요! 이제',
+    mysteriousLanguage: '흠... 신비한 언어를 배우고 있는 것 같아요.',
+    notEnoughData: '데이터가 부족합니다. 두 가지가 넘는 언어의 Gist를 만들어 보세요. Happy Coding!',
+    statsLabel: '내 언어 통계',
+    title: '대시보드'
+  },
+  dialog: {
+    close: '닫기',
+    minimize: '최소화',
+    minimizeToTray: '트레이로 최소화',
+    neverMind: '취소',
+    quit: '종료',
+    quitConfirm: '정말로 진행할까요?',
+    quitTitle: '종료'
+  },
+  editor: {
+    addFile: '#파일 추가',
+    cancel: '취소',
+    descriptionPlaceholder: '[제목] 설명 #태그1 #태그2',
+    filenamePlaceholder: '파일 이름... (예: snippet.js)',
+    invalidFilename: '잘못된 파일 이름',
+    removeFile: '#제거',
+    required: '필수',
+    secret: '비공개',
+    submit: '제출',
+    tips: '팁'
+  },
+  login: {
+    continueAs: '{{username}}로 계속',
+    githubLogin: 'GitHub 로그인',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: '계정 로그인으로 전환?',
+    switchToToken: '토큰으로 전환?',
+    title: '로그인',
+    tokenInvalid: '토큰이 유효하지 않습니다',
+    tokenLogin: '토큰 로그인',
+    tokenPlaceholder: 'scope: gist',
+    welcome: 'Lepton은 무료입니다. GitHub에서 응원해 주세요!'
+  },
+  i18n: {
+    language: '언어',
+    saveFailed: '언어 설정을 업데이트하지 못했습니다'
+  },
+  menu: {
+    about: '정보',
+    backToNormalMode: '일반 모드로 돌아가기',
+    bringAllToFront: '모두 앞으로 가져오기',
+    close: '닫기',
+    dashboard: '대시보드',
+    deleteGist: 'Gist 삭제',
+    edit: '편집',
+    editGist: 'Gist 편집',
+    exitEditor: '편집기 종료',
+    gist: 'Gist',
+    immersiveMode: '몰입 모드',
+    learnMore: '자세히 보기',
+    minimize: '최소화',
+    newGist: '새 Gist',
+    openWindow: '창 열기',
+    quit: '종료',
+    search: '검색',
+    speech: '말하기',
+    submitGist: 'Gist 제출',
+    syncGist: 'Gist 동기화',
+    toggleDeveloperTools: '개발자 도구 전환',
+    view: '보기',
+    zoom: '확대/축소'
+  },
+  navigation: {
+    cancel: '취소',
+    languages: '언어',
+    pinned: '고정됨',
+    save: '저장',
+    shortcuts: '바로가기',
+    starred: '#별표',
+    tags: '태그'
+  },
+  notification: {
+    contentCopied: '내용이 클립보드에 복사되었습니다.',
+    copied: '복사됨',
+    deletionFailed: '삭제 실패',
+    gistCreated: 'Gist가 생성되었습니다',
+    gistCreationFailed: 'Gist 생성 실패',
+    gistDeleted: 'Gist가 삭제되었습니다',
+    gistUpdateFailed: 'Gist 업데이트 실패',
+    gistUpdated: 'Gist가 업데이트되었습니다',
+    linkCopied: '링크가 클립보드에 복사되었습니다.',
+    networkFailure: '네트워크 상태를 확인하세요. {{code}}',
+    rawLinkCopied: 'RAW 파일 링크가 클립보드에 복사되었습니다.',
+    syncFailed: '동기화 실패',
+    syncSucceeds: '동기화 성공'
+  },
+  search: {
+    noResults: '결과가 없습니다...',
+    placeholder: '설명, 태그, 파일 이름 검색...'
+  },
+  snippet: {
+    copy: '복사',
+    delete: '삭제',
+    deleteAction: '삭제',
+    deleteConfirmTitle: '이 Gist를 삭제할까요?',
+    edit: '편집',
+    lastActive: '마지막 활동 {{time}}',
+    link: '링크',
+    openInWeb: '웹에서 열기',
+    publicGist: '공개 gist',
+    raw: 'RAW',
+    revisions: '수정 기록',
+    secretGist: '비공개 gist',
+    share: '공유'
+  },
+  touchBar: {
+    edit: '편집',
+    immersive: '몰입',
+    new: '새로 만들기',
+    search: '검색',
+    sync: '동기화'
+  },
+  update: {
+    available: '새 버전 {{version}}을 사용할 수 있습니다!',
+    download: '#다운로드',
+    release: '#릴리스',
+    skip: '#건너뛰기'
+  },
+  userPanel: {
+    confirmLogout: '로그아웃할까요?',
+    logout: '로그아웃',
+    logoutAction: '로그아웃',
+    new: '새로 만들기',
+    sync: '동기화'
+  },
+  welcome: {
+    emptySnippet: '왼쪽 패널의 #new를 클릭해 Gist를 만드세요.'
+  }
+}

--- a/app/utilities/i18n/locales/zh-Hans.js
+++ b/app/utilities/i18n/locales/zh-Hans.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: '致谢',
+    configurations: '配置',
+    contributors: '贡献者',
+    feedback: '反馈',
+    license: '许可证',
+    licenseType: '许可证: {{license}}',
+    logs: '日志',
+    title: '关于'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}} 大师！',
+    complimentPrefix: '做得好！你正在成为',
+    mysteriousLanguage: '嗯... 看起来你正在学习一种神秘的语言。',
+    notEnoughData: '数据不足。请尝试创建超过两种语言的 Gist。Happy Coding!',
+    statsLabel: '我的语言统计',
+    title: '仪表盘'
+  },
+  dialog: {
+    close: '关闭',
+    minimize: '最小化',
+    minimizeToTray: '最小化到托盘',
+    neverMind: '取消',
+    quit: '退出',
+    quitConfirm: '确定吗？',
+    quitTitle: '退出'
+  },
+  editor: {
+    addFile: '#添加文件',
+    cancel: '取消',
+    descriptionPlaceholder: '[标题] 描述 #标签1 #标签2',
+    filenamePlaceholder: '文件名...（例如 snippet.js）',
+    invalidFilename: '无效文件名',
+    removeFile: '#移除',
+    required: '必填',
+    secret: '私密',
+    submit: '提交',
+    tips: '提示'
+  },
+  login: {
+    continueAs: '以 {{username}} 继续',
+    githubLogin: '使用 GitHub 登录',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: '切换到凭据？',
+    switchToToken: '切换到令牌？',
+    title: '登录',
+    tokenInvalid: '令牌无效',
+    tokenLogin: '使用令牌登录',
+    tokenPlaceholder: 'scope: gist',
+    welcome: '点赞支持免费开源项目 ⭐'
+  },
+  i18n: {
+    language: '语言',
+    saveFailed: '无法更新语言设置'
+  },
+  menu: {
+    about: '关于',
+    backToNormalMode: '返回普通模式',
+    bringAllToFront: '全部置于前台',
+    close: '关闭',
+    dashboard: '仪表盘',
+    deleteGist: '删除 Gist',
+    edit: '编辑',
+    editGist: '编辑 Gist',
+    exitEditor: '退出编辑器',
+    gist: 'Gist',
+    immersiveMode: '沉浸模式',
+    learnMore: '了解更多',
+    minimize: '最小化',
+    newGist: '新建 Gist',
+    openWindow: '打开窗口',
+    quit: '退出',
+    search: '搜索',
+    speech: '语音',
+    submitGist: '提交 Gist',
+    syncGist: '同步 Gist',
+    toggleDeveloperTools: '切换开发者工具',
+    view: '视图',
+    zoom: '缩放'
+  },
+  navigation: {
+    cancel: '取消',
+    languages: '语言',
+    pinned: '置顶',
+    save: '保存',
+    shortcuts: '快捷方式',
+    starred: '#已收藏',
+    tags: '标签'
+  },
+  notification: {
+    contentCopied: '内容已复制到剪贴板。',
+    copied: '已复制',
+    deletionFailed: '删除失败',
+    gistCreated: 'Gist 已创建',
+    gistCreationFailed: 'Gist 创建失败',
+    gistDeleted: 'Gist 已删除',
+    gistUpdateFailed: 'Gist 更新失败',
+    gistUpdated: 'Gist 已更新',
+    linkCopied: '链接已复制到剪贴板。',
+    networkFailure: '请检查网络连接。{{code}}',
+    rawLinkCopied: 'RAW 文件链接已复制到剪贴板。',
+    syncFailed: '同步失败',
+    syncSucceeds: '同步成功'
+  },
+  search: {
+    noResults: '未找到结果...',
+    placeholder: '搜索描述、标签、文件名...'
+  },
+  snippet: {
+    copy: '复制',
+    delete: '删除',
+    deleteAction: '删除',
+    deleteConfirmTitle: '删除这个 Gist？',
+    edit: '编辑',
+    lastActive: '最后活跃 {{time}}',
+    link: '链接',
+    openInWeb: '在网页中打开',
+    publicGist: '公开 gist',
+    raw: 'RAW',
+    revisions: '修订记录',
+    secretGist: '私密 gist',
+    share: '分享'
+  },
+  touchBar: {
+    edit: '编辑',
+    immersive: '沉浸',
+    new: '新建',
+    search: '搜索',
+    sync: '同步'
+  },
+  update: {
+    available: '新版本 {{version}} 可用！',
+    download: '#下载',
+    release: '#发布',
+    skip: '#跳过'
+  },
+  userPanel: {
+    confirmLogout: '确认退出登录？',
+    logout: '退出登录',
+    logoutAction: '退出登录',
+    new: '新建',
+    sync: '同步'
+  },
+  welcome: {
+    emptySnippet: '点击左侧面板中的 #new 来创建 Gist。'
+  }
+}

--- a/app/utilities/i18n/locales/zh-Hant.js
+++ b/app/utilities/i18n/locales/zh-Hant.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: '致謝',
+    configurations: '設定',
+    contributors: '貢獻者',
+    feedback: '回饋',
+    license: '授權',
+    licenseType: '授權: {{license}}',
+    logs: '記錄',
+    title: '關於'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}} 大師！',
+    complimentPrefix: '做得好！你正在成為',
+    mysteriousLanguage: '嗯... 看起來你正在學習一種神祕的語言。',
+    notEnoughData: '資料不足。請嘗試建立超過兩種語言的 Gist。Happy Coding!',
+    statsLabel: '我的語言統計',
+    title: '儀表板'
+  },
+  dialog: {
+    close: '關閉',
+    minimize: '最小化',
+    minimizeToTray: '最小化到系統匣',
+    neverMind: '取消',
+    quit: '結束',
+    quitConfirm: '確定嗎？',
+    quitTitle: '結束'
+  },
+  editor: {
+    addFile: '#新增檔案',
+    cancel: '取消',
+    descriptionPlaceholder: '[標題] 描述 #標籤1 #標籤2',
+    filenamePlaceholder: '檔案名稱...（例如 snippet.js）',
+    invalidFilename: '無效的檔案名稱',
+    removeFile: '#移除',
+    required: '必填',
+    secret: '私密',
+    submit: '提交',
+    tips: '提示'
+  },
+  login: {
+    continueAs: '以 {{username}} 繼續',
+    githubLogin: '使用 GitHub 登入',
+    happyCoding: 'HAPPY CODING',
+    switchToCredentials: '切換到憑證？',
+    switchToToken: '切換到權杖？',
+    title: '登入',
+    tokenInvalid: '權杖無效',
+    tokenLogin: '使用權杖登入',
+    tokenPlaceholder: 'scope: gist',
+    welcome: '点赞支持免费开源项目 ⭐'
+  },
+  i18n: {
+    language: '語言',
+    saveFailed: '無法更新語言設定'
+  },
+  menu: {
+    about: '關於',
+    backToNormalMode: '返回一般模式',
+    bringAllToFront: '全部移到最前',
+    close: '關閉',
+    dashboard: '儀表板',
+    deleteGist: '刪除 Gist',
+    edit: '編輯',
+    editGist: '編輯 Gist',
+    exitEditor: '離開編輯器',
+    gist: 'Gist',
+    immersiveMode: '沉浸模式',
+    learnMore: '了解更多',
+    minimize: '最小化',
+    newGist: '新增 Gist',
+    openWindow: '開啟視窗',
+    quit: '結束',
+    search: '搜尋',
+    speech: '語音',
+    submitGist: '提交 Gist',
+    syncGist: '同步 Gist',
+    toggleDeveloperTools: '切換開發者工具',
+    view: '檢視',
+    zoom: '縮放'
+  },
+  navigation: {
+    cancel: '取消',
+    languages: '語言',
+    pinned: '釘選',
+    save: '儲存',
+    shortcuts: '捷徑',
+    starred: '#已加星號',
+    tags: '標籤'
+  },
+  notification: {
+    contentCopied: '內容已複製到剪貼簿。',
+    copied: '已複製',
+    deletionFailed: '刪除失敗',
+    gistCreated: 'Gist 已建立',
+    gistCreationFailed: 'Gist 建立失敗',
+    gistDeleted: 'Gist 已刪除',
+    gistUpdateFailed: 'Gist 更新失敗',
+    gistUpdated: 'Gist 已更新',
+    linkCopied: '連結已複製到剪貼簿。',
+    networkFailure: '請檢查網路連線。{{code}}',
+    rawLinkCopied: 'RAW 檔案連結已複製到剪貼簿。',
+    syncFailed: '同步失敗',
+    syncSucceeds: '同步成功'
+  },
+  search: {
+    noResults: '找不到結果...',
+    placeholder: '搜尋描述、標籤、檔案名稱...'
+  },
+  snippet: {
+    copy: '複製',
+    delete: '刪除',
+    deleteAction: '刪除',
+    deleteConfirmTitle: '刪除此 Gist？',
+    edit: '編輯',
+    lastActive: '最後活動 {{time}}',
+    link: '連結',
+    openInWeb: '在網頁中開啟',
+    publicGist: '公開 gist',
+    raw: 'RAW',
+    revisions: '修訂記錄',
+    secretGist: '私密 gist',
+    share: '分享'
+  },
+  touchBar: {
+    edit: '編輯',
+    immersive: '沉浸',
+    new: '新增',
+    search: '搜尋',
+    sync: '同步'
+  },
+  update: {
+    available: '新版本 {{version}} 可用！',
+    download: '#下載',
+    release: '#發布',
+    skip: '#略過'
+  },
+  userPanel: {
+    confirmLogout: '確認登出？',
+    logout: '登出',
+    logoutAction: '登出',
+    new: '新增',
+    sync: '同步'
+  },
+  welcome: {
+    emptySnippet: '點擊左側面板中的 #new 來建立 Gist。'
+  }
+}

--- a/app/utilities/menu/mainMenu.js
+++ b/app/utilities/menu/mainMenu.js
@@ -1,177 +1,181 @@
 const electron = require('electron')
-const app = electron.app
+const app = electron.app || { getName: () => 'Lepton' }
 
-const template = [
-  {
-    label: 'Edit',
-    submenu: [
-      {
-        role: 'undo'
-      },
-      {
-        role: 'redo'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'cut'
-      },
-      {
-        role: 'copy'
-      },
-      {
-        role: 'paste'
-      },
-      {
-        role: 'pasteandmatchstyle'
-      },
-      {
-        role: 'delete'
-      },
-      {
-        role: 'selectall'
-      }
-    ]
-  },
-  {
-    label: 'View',
-    submenu: [
-      // {
-      //   label: 'Reload',
-      //   accelerator: 'CmdOrCtrl+R',
-      //   click (item, focusedWindow) {
-      //     if (focusedWindow) focusedWindow.reload()
-      //   }
-      // },
-      {
-        label: 'Toggle Developer Tools',
-        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-        click (item, focusedWindow) {
-          if (focusedWindow) focusedWindow.webContents.toggleDevTools()
-        }
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'resetzoom'
-      },
-      {
-        role: 'zoomin',
-        accelerator: 'CmdOrCtrl+='
-      },
-      {
-        role: 'zoomout'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'togglefullscreen'
-      }
-    ]
-  },
-  {
-    role: 'window',
-    submenu: [
-      {
-        role: 'minimize'
-      },
-      {
-        role: 'close'
-      }
-    ]
-  },
-  {
-    role: 'help',
-    submenu: [
-      {
-        label: 'Learn More',
-        click () { require('electron').shell.openExternal('http://hackjutsu.com/Lepton') }
-      }
-    ]
-  }
-]
-
-if (process.platform === 'darwin') {
-  const name = app.getName()
-  template.unshift({
-    label: name,
-    submenu: [
-      {
-        role: 'about'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'services',
-        submenu: []
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'hide'
-      },
-      {
-        role: 'hideothers'
-      },
-      {
-        role: 'unhide'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'quit'
-      }
-    ]
-  })
-  // Edit menu.
-  template[1].submenu.push(
+function buildMainMenuTemplate (t) {
+  const template = [
     {
-      type: 'separator'
-    },
-    {
-      label: 'Speech',
+      label: t('menu.edit'),
       submenu: [
         {
-          role: 'startspeaking'
+          role: 'undo'
         },
         {
-          role: 'stopspeaking'
+          role: 'redo'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'cut'
+        },
+        {
+          role: 'copy'
+        },
+        {
+          role: 'paste'
+        },
+        {
+          role: 'pasteandmatchstyle'
+        },
+        {
+          role: 'delete'
+        },
+        {
+          role: 'selectall'
+        }
+      ]
+    },
+    {
+      label: t('menu.view'),
+      submenu: [
+        // {
+        //   label: 'Reload',
+        //   accelerator: 'CmdOrCtrl+R',
+        //   click (item, focusedWindow) {
+        //     if (focusedWindow) focusedWindow.reload()
+        //   }
+        // },
+        {
+          label: t('menu.toggleDeveloperTools'),
+          accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+          click (item, focusedWindow) {
+            if (focusedWindow) focusedWindow.webContents.toggleDevTools()
+          }
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'resetzoom'
+        },
+        {
+          role: 'zoomin',
+          accelerator: 'CmdOrCtrl+='
+        },
+        {
+          role: 'zoomout'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'togglefullscreen'
+        }
+      ]
+    },
+    {
+      role: 'window',
+      submenu: [
+        {
+          role: 'minimize'
+        },
+        {
+          role: 'close'
+        }
+      ]
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: t('menu.learnMore'),
+          click () { require('electron').shell.openExternal('http://hackjutsu.com/Lepton') }
         }
       ]
     }
-  )
-  // Window menu.
-  template[3].submenu = [
-    {
-      label: 'Close',
-      accelerator: 'CmdOrCtrl+W',
-      role: 'close'
-    },
-    {
-      label: 'Minimize',
-      accelerator: 'CmdOrCtrl+M',
-      role: 'minimize'
-    },
-    {
-      label: 'Zoom',
-      role: 'zoom'
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Bring All to Front',
-      role: 'front'
-    }
   ]
+
+  if (process.platform === 'darwin') {
+    const name = app.getName()
+    template.unshift({
+      label: name,
+      submenu: [
+        {
+          role: 'about'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'services',
+          submenu: []
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'hide'
+        },
+        {
+          role: 'hideothers'
+        },
+        {
+          role: 'unhide'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          role: 'quit'
+        }
+      ]
+    })
+    // Edit menu.
+    template[1].submenu.push(
+      {
+        type: 'separator'
+      },
+      {
+        label: t('menu.speech'),
+        submenu: [
+          {
+            role: 'startspeaking'
+          },
+          {
+            role: 'stopspeaking'
+          }
+        ]
+      }
+    )
+    // Window menu.
+    template[3].submenu = [
+      {
+        label: t('menu.close'),
+        accelerator: 'CmdOrCtrl+W',
+        role: 'close'
+      },
+      {
+        label: t('menu.minimize'),
+        accelerator: 'CmdOrCtrl+M',
+        role: 'minimize'
+      },
+      {
+        label: t('menu.zoom'),
+        role: 'zoom'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: t('menu.bringAllToFront'),
+        role: 'front'
+      }
+    ]
+  }
+
+  return template
 }
 
 module.exports = {
-  mainMenuTemplate: template
+  buildMainMenuTemplate
 }

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -2,6 +2,9 @@ module.exports = {
     "theme": "light",
     "autoUpdate": false,
     "startAtLogin": false,
+    "i18n": {
+        "locale": "en"
+    },
     "avatar": {
         "type": "github",
         "boringAvatarVariant": "beam"

--- a/main.js
+++ b/main.js
@@ -22,12 +22,14 @@ const defaultConfig = require('./configs/defaultConfig')
 const appInfo = require('./package.json')
 const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
+const { configureI18n, t } = require('./app/utilities/i18n')
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger
-autoUpdater.autoDownload = nconf.get('autoUpdate')
 
 initGlobalConfigs()
+configureI18n(nconf.get('i18n:locale'))
+autoUpdater.autoDownload = nconf.get('autoUpdate')
 initGlobalLogger()
 setUpBridgeIpcHandlers()
 
@@ -141,11 +143,11 @@ function createWindow (autoLogin) {
     if (operationType == 0) {
       const choice = dialog.showMessageBoxSync(mainWindow, {
         type: 'info',
-        title: 'Quit',
+        title: t('dialog.quitTitle'),
         defaultId: 0,
         cancelId: 0,
-        message: 'Are you sure?',
-        buttons: ['Nerver Mind', 'Minimize to disk', 'Quit']
+        message: t('dialog.quitConfirm'),
+        buttons: [t('dialog.neverMind'), t('dialog.minimizeToTray'), t('dialog.quit')]
       })
       if (choice === 1) {
         if (miniWindow) {
@@ -242,68 +244,68 @@ app.on('activate', () => mainWindow && mainWindow.show())
 
 function setUpApplicationMenu () {
   // Create the Application's main menu
-  let { mainMenuTemplate } = require('./app/utilities/menu/mainMenu')
+  let { buildMainMenuTemplate } = require('./app/utilities/menu/mainMenu')
   let gistMenu = {
-    label: 'Gist',
+    label: t('menu.gist'),
     submenu: [
       {
-        label: 'New Gist',
+        label: t('menu.newGist'),
         accelerator: shortcuts.keyNewGist,
         click: (item, mainWindow) => mainWindow && mainWindow.send('new-gist')
       },
       {
-        label: 'Edit Gist',
+        label: t('menu.editGist'),
         accelerator: shortcuts.keyEditGist,
         click: (item, mainWindow) => mainWindow && mainWindow.send('edit-gist')
       },
       {
-        label: 'Delete Gist',
+        label: t('menu.deleteGist'),
         accelerator: shortcuts.keyDeleteGist,
         click: (item, mainWindow) => mainWindow && mainWindow.send('delete-gist-check')
       },
       {
-        label: 'Submit Gist',
+        label: t('menu.submitGist'),
         accelerator: shortcuts.keySubmitGist,
         click: (item, mainWindow) => mainWindow && mainWindow.send('submit-gist')
       },
       {
-        label: 'Sync Gist',
+        label: t('menu.syncGist'),
         accelerator: shortcuts.keySyncGists,
         click: (item, mainWindow) => mainWindow && mainWindow.send('sync-gists')
       },
       {
-        label: 'Exit Editor',
+        label: t('menu.exitEditor'),
         accelerator: shortcuts.keyEditorExit,
         click: (item, mainWindow) => mainWindow && mainWindow.send('exit-editor')
       },
       {
-        label: 'Immersive Mode',
+        label: t('menu.immersiveMode'),
         accelerator: shortcuts.keyImmersiveMode,
         click: (item, mainWindow) => mainWindow && mainWindow.send('immersive-mode')
       },
       {
-        label: 'Back to Normal Mode',
+        label: t('menu.backToNormalMode'),
         accelerator: 'Escape',
         click: (item, mainWindow) => mainWindow && mainWindow.send('back-to-normal-mode')
       },
       {
-        label: 'Dashboard',
+        label: t('menu.dashboard'),
         accelerator: shortcuts.keyDashboard,
         click: (item, mainWindow) => mainWindow && mainWindow.send('dashboard')
       },
       {
-        label: 'About',
+        label: t('menu.about'),
         accelerator: shortcuts.keyAboutPage,
         click: (item, mainWindow) => mainWindow && mainWindow.send('about-page')
       },
       {    
-        label: 'Search',
+        label: t('menu.search'),
         accelerator: shortcuts.keyShortcutForSearch,
         click: (item, mainWindow) => mainWindow && mainWindow.send('search-gist')
       }
     ]
   }
-  let template = [...mainMenuTemplate, gistMenu]
+  let template = [...buildMainMenuTemplate(t), gistMenu]
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
 }
@@ -311,6 +313,7 @@ function setUpApplicationMenu () {
 function setUpBridgeIpcHandlers () {
   const loggerMethods = new Set(['debug', 'error', 'info', 'warn'])
   const appPathNames = new Set(['appData', 'home', 'temp', 'userData'])
+  const writableConfigKeys = new Set(['i18n:locale'])
 
   function isAllowedConfigKey (key) {
     if (typeof key !== 'string' || key.length === 0) return false
@@ -322,6 +325,27 @@ function setUpBridgeIpcHandlers () {
     return mainWindow && !mainWindow.isDestroyed() && event.sender === mainWindow.webContents
   }
 
+  function writeConfigValue (key, value) {
+    const parts = key.split(':')
+    let config = {}
+    try {
+      config = JSON.parse(fs.readFileSync(global.configFilePath))
+    } catch (error) {
+      config = {}
+    }
+
+    let cursor = config
+    parts.slice(0, -1).forEach(part => {
+      if (!cursor[part] || typeof cursor[part] !== 'object' || Array.isArray(cursor[part])) {
+        cursor[part] = {}
+      }
+      cursor = cursor[part]
+    })
+    cursor[parts[parts.length - 1]] = value
+
+    fs.writeFileSync(global.configFilePath, JSON.stringify(config, null, 2))
+  }
+
   ipcMain.on('lepton:config:get', (event, key) => {
     if (!isAllowedConfigKey(key)) {
       logger.warn(`[bridge] Rejected config read for "${key}"`)
@@ -329,6 +353,22 @@ function setUpBridgeIpcHandlers () {
       return
     }
     event.returnValue = nconf.get(key)
+  })
+
+  ipcMain.handle('lepton:config:set', (event, key, value) => {
+    if (!isMainWindowSender(event) || !writableConfigKeys.has(key)) {
+      logger.warn(`[bridge] Rejected config write for "${key}"`)
+      return undefined
+    }
+
+    const persistedValue = key === 'i18n:locale' ? configureI18n(value) : value
+    nconf.set(key, persistedValue)
+    writeConfigValue(key, persistedValue)
+    setUpApplicationMenu()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.reload()
+    }
+    return persistedValue
   })
 
   ipcMain.on('lepton:app:get-app-path', (event) => {
@@ -395,19 +435,19 @@ function setUpTouchBar() {
   const touchBar = new TouchBar({
     items: [
       new TouchBarButton({
-        label: "Immersive",
+        label: t('touchBar.immersive'),
         icon: makeIcon("immersive"),
         iconPosition: "left",
         click: () => mainWindow.send("immersive-mode")
       }),
       new TouchBarButton({
-        label: "Sync",
+        label: t('touchBar.sync'),
         icon: makeIcon("sync"),
         iconPosition: "left",
         click: () => mainWindow.send("sync-gists")
       }),
       new TouchBarButton({
-        label: "Search",
+        label: t('touchBar.search'),
         icon: makeIcon("search"),
         iconPosition: "left",
         click: () => mainWindow.send("search-gist")
@@ -416,13 +456,13 @@ function setUpTouchBar() {
         size: "flexible"
       }),
       new TouchBarButton({
-        label: "New",
+        label: t('touchBar.new'),
         icon: makeIcon("new"),
         iconPosition: "left",
         click: () => mainWindow.send("new-gist")
       }),
       new TouchBarButton({
-        label: "Edit",
+        label: t('touchBar.edit'),
         icon: makeIcon("edit"),
         iconPosition: "left",
         click: () => mainWindow.send("edit-gist")
@@ -475,13 +515,13 @@ function setTray(app, mainWindow) {
   }
   const trayMenuTemplate = [
     {
-      label: 'Open Window',
+      label: t('menu.openWindow'),
       click: () => {
         mainWindow.show()
       }
     },
     {
-      label: 'Quit',
+      label: t('menu.quit'),
       click: () => {
         operationType = 2
         if (process.platform !== 'darwin') app.quit()

--- a/preload.js
+++ b/preload.js
@@ -30,7 +30,8 @@ const leptonApi = {
     writeText: (value) => ipcRenderer.send('lepton:clipboard:write-text', value)
   },
   config: {
-    get: (key) => ipcRenderer.sendSync('lepton:config:get', key)
+    get: (key) => ipcRenderer.sendSync('lepton:config:get', key),
+    set: (key, value) => ipcRenderer.invoke('lepton:config:set', key, value)
   },
   globals: {
     getUpdateInfo: () => ipcRenderer.sendSync('lepton:update-info:get'),

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -85,6 +85,7 @@ async function getRendererState (window) {
       const appContainer = document.querySelector('.app-container')
       const loginModal = document.querySelector('.login-modal')
       const appBounds = appContainer ? appContainer.getBoundingClientRect() : null
+      const languageSelector = document.querySelector('[data-role="language-selector"]')
       return {
         bodyText: document.body ? document.body.innerText : '',
         bodyHtml: document.body ? document.body.innerHTML : '',
@@ -92,6 +93,9 @@ async function getRendererState (window) {
         readyState: document.readyState,
         hasAppContainer: Boolean(appContainer),
         hasLoginModal: Boolean(loginModal),
+        languageOptions: languageSelector
+          ? Array.from(languageSelector.options).map(option => option.value)
+          : [],
         appBounds: appBounds ? {
           width: appBounds.width,
           height: appBounds.height
@@ -118,12 +122,19 @@ function assertRendererState (state) {
     throw new Error(`Expected app container and login modal to exist: ${JSON.stringify(state)}`)
   }
 
-  if (!state.bodyText.includes('Login') || !state.bodyText.includes('GitHub Login')) {
-    throw new Error(`Expected login UI text was not visible. Body text: ${state.bodyText}`)
+  const expectedTexts = (process.env.LEPTON_SMOKE_EXPECTED_TEXT || 'Login|GitHub Login').split('|')
+  const missingText = expectedTexts.find(text => !state.bodyText.includes(text))
+  if (missingText) {
+    throw new Error(`Expected login UI text "${missingText}" was not visible. Body text: ${state.bodyText}`)
   }
 
   if (!state.appBounds || state.appBounds.width <= 0 || state.appBounds.height <= 0) {
     throw new Error(`App container did not render with visible dimensions: ${JSON.stringify(state.appBounds)}`)
+  }
+
+  const expectedLocales = ['en', 'es', 'fr', 'ja', 'ko', 'zh-Hans', 'zh-Hant']
+  if (expectedLocales.some(locale => !state.languageOptions.includes(locale))) {
+    throw new Error(`Expected language selector options were not visible: ${JSON.stringify(state.languageOptions)}`)
   }
 }
 

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -14,7 +14,7 @@ function assertBuiltBundleExists () {
   }
 }
 
-function createTempHome () {
+function createTempHome (locale = 'en') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lepton-smoke-'))
   const configHome = path.join(root, 'config')
   const userData = path.join(root, 'user-data')
@@ -22,6 +22,9 @@ function createTempHome () {
   fs.mkdirSync(userData, { recursive: true })
   fs.writeFileSync(path.join(configHome, '.leptonrc'), JSON.stringify({
     autoUpdate: false,
+    i18n: {
+      locale
+    },
     logger: {
       level: 'error'
     }
@@ -29,7 +32,7 @@ function createTempHome () {
   return { configHome, root, userData }
 }
 
-function runSmokeProcess (tempHome) {
+function runSmokeProcess (tempHome, expectedText) {
   return new Promise((resolve, reject) => {
     const electronArgs = [
       `--user-data-dir=${tempHome.userData}`,
@@ -45,6 +48,7 @@ function runSmokeProcess (tempHome) {
       env: Object.assign({}, process.env, {
         ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
         LEPTON_SMOKE_ARTIFACT_DIR: tempHome.root,
+        LEPTON_SMOKE_EXPECTED_TEXT: expectedText,
         XDG_CONFIG_HOME: tempHome.configHome
       }),
       stdio: ['ignore', 'pipe', 'pipe']
@@ -83,7 +87,8 @@ function runSmokeProcess (tempHome) {
 
 async function main () {
   assertBuiltBundleExists()
-  await runSmokeProcess(createTempHome())
+  await runSmokeProcess(createTempHome('en'), 'Login|GitHub Login')
+  await runSmokeProcess(createTempHome('ja'), 'ログイン|GitHubでログイン')
 }
 
 main().catch(err => {

--- a/tests/utilities/i18n.test.js
+++ b/tests/utilities/i18n.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it, afterEach } from 'vitest'
+
+import {
+  configureI18n,
+  getLocale,
+  getSupportedLocales,
+  t
+} from '../../app/utilities/i18n'
+import en from '../../app/utilities/i18n/locales/en'
+import es from '../../app/utilities/i18n/locales/es'
+import fr from '../../app/utilities/i18n/locales/fr'
+import ja from '../../app/utilities/i18n/locales/ja'
+import ko from '../../app/utilities/i18n/locales/ko'
+import zhHans from '../../app/utilities/i18n/locales/zh-Hans'
+import zhHant from '../../app/utilities/i18n/locales/zh-Hant'
+
+const catalogs = {
+  es,
+  fr,
+  ja,
+  ko,
+  'zh-Hans': zhHans,
+  'zh-Hant': zhHant
+}
+
+const allowedIdenticalValues = new Set([
+  'app.name',
+  'login.happyCoding',
+  'login.tokenPlaceholder',
+  'menu.gist',
+  'menu.zoom',
+  'snippet.raw'
+])
+
+function flattenCatalog (catalog, prefix = '') {
+  return Object.keys(catalog).reduce((flatCatalog, key) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    const value = catalog[key]
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(flatCatalog, flattenCatalog(value, path))
+    } else {
+      flatCatalog[path] = value
+    }
+    return flatCatalog
+  }, {})
+}
+
+describe('i18n utilities', () => {
+  afterEach(() => {
+    configureI18n('en')
+  })
+
+  it('defaults to English for unsupported locales', () => {
+    expect(configureI18n('it')).toBe('en')
+    expect(getLocale()).toBe('en')
+    expect(t('login.title')).toBe('Login')
+  })
+
+  it('uses the configured locale when it is supported', () => {
+    expect(configureI18n('ja')).toBe('ja')
+    expect(getLocale()).toBe('ja')
+    expect(t('login.title')).toBe('ログイン')
+  })
+
+  it('supports Spanish and script-based Chinese locales', () => {
+    expect(configureI18n('es')).toBe('es')
+    expect(t('login.title')).toBe('Iniciar sesion')
+
+    expect(configureI18n('zh-Hans')).toBe('zh-Hans')
+    expect(t('login.title')).toBe('登录')
+
+    expect(configureI18n('zh-Hant')).toBe('zh-Hant')
+    expect(t('login.title')).toBe('登入')
+  })
+
+  it('supports French and Korean locales', () => {
+    expect(configureI18n('fr')).toBe('fr')
+    expect(t('login.title')).toBe('Connexion')
+
+    expect(configureI18n('ko')).toBe('ko')
+    expect(t('login.title')).toBe('로그인')
+  })
+
+  it('interpolates named values', () => {
+    configureI18n('en')
+    expect(t('login.continueAs', { username: 'octocat' })).toBe('Continue as octocat')
+  })
+
+  it('falls back to English for missing keys in a supported locale', () => {
+    configureI18n('ja')
+    expect(t('app.name')).toBe('Lepton')
+  })
+
+  it('falls back to the key name when no catalog contains the key', () => {
+    configureI18n('ja')
+    expect(t('missing.translation.key')).toBe('missing.translation.key')
+  })
+
+  it('returns supported locale metadata defensively', () => {
+    const locales = getSupportedLocales()
+    expect(locales).toEqual([
+      { code: 'en', name: 'English' },
+      { code: 'es', name: 'Español' },
+      { code: 'fr', name: 'Français' },
+      { code: 'ja', name: '日本語' },
+      { code: 'ko', name: '한국어' },
+      { code: 'zh-Hans', name: '简体中文' },
+      { code: 'zh-Hant', name: '繁體中文' }
+    ])
+
+    locales[0].name = 'Mutated'
+    expect(getSupportedLocales()[0].name).toBe('English')
+  })
+
+  it('keeps every locale catalog in the same shape as English', () => {
+    const englishCatalog = flattenCatalog(en)
+    const englishKeys = Object.keys(englishCatalog).sort()
+
+    Object.keys(catalogs).forEach(locale => {
+      expect(Object.keys(flattenCatalog(catalogs[locale])).sort()).toEqual(englishKeys)
+    })
+  })
+
+  it('requires every locale catalog to translate non-brand phrases', () => {
+    const englishCatalog = flattenCatalog(en)
+
+    Object.keys(catalogs).forEach(locale => {
+      const catalog = flattenCatalog(catalogs[locale])
+      const untranslatedKeys = Object.keys(englishCatalog)
+        .filter(key => !allowedIdenticalValues.has(key))
+        .filter(key => catalog[key] === englishCatalog[key])
+
+      expect(untranslatedKeys).toEqual([])
+    })
+  })
+})

--- a/tests/utilities/menu.test.js
+++ b/tests/utilities/menu.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  default: {
+    app: {
+      getName: () => 'Lepton'
+    }
+  },
+  app: {
+    getName: () => 'Lepton'
+  }
+}))
+
+describe('main menu template', () => {
+  it('uses the provided translator for labels', async () => {
+    const { buildMainMenuTemplate } = await import('../../app/utilities/menu/mainMenu')
+    const template = buildMainMenuTemplate(key => `tx:${key}`)
+
+    expect(template.some(item => item.label === 'tx:menu.edit')).toBe(true)
+    expect(template.some(item => item.label === 'tx:menu.view')).toBe(true)
+    expect(template.some(item =>
+      item.submenu && item.submenu.some(submenuItem => submenuItem.label === 'tx:menu.learnMore')
+    )).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a config-driven i18n framework for Lepton and wires first-party UI strings through translation catalogs.

- Adds `app/utilities/i18n` with locale configuration, fallback behavior, interpolation, and supported locale metadata.
- Adds locale catalogs for `en`, `es`, `fr`, `ja`, `ko`, `zh-Hans`, and `zh-Hant`.
- Configures i18n in both the Electron main process and renderer startup.
- Localizes menus, dialogs, tray/Touch Bar/update copy, notifications, login, editor, dashboard, navigation, search, snippets, and about UI.
- Adds a minimal login-page language picker with a fade transition on language switch.
- Keeps user-generated content, storage sentinel values, parser values, filenames, custom tags, usernames, URLs, and GitHub language names untranslated.

## Notes

- Locale can be selected through `.leptonrc` via `i18n.locale`.
- The login page language selector persists the selected locale and reloads the app.
- Locale IDs use script-based Chinese tags: `zh-Hans` and `zh-Hant`.
- No in-app settings page selector is included.
- No new npm dependencies are added.

## Related Issue

- Related to #411

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`

Electron smoke launched the app with isolated config for English and Japanese login UI and verified the login modal and language selector rendered.
