### PR TITLE
[codex] Harden renderer sandbox settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,10 +76,11 @@ function createWindow (autoLogin) {
   })
 
   const webPreferences = {
-    nodeIntegration: true,
+    nodeIntegration: false,
     enableRemoteModule: false,
     preload: path.join(__dirname, 'preload.js'),
-    contextIsolation: true
+    contextIsolation: true,
+    sandbox: true
   }
 
   mainWindow = new BrowserWindow({
@@ -590,6 +591,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
       nodeIntegration: false,
       enableRemoteModule: false,
       contextIsolation: true,
+      sandbox: true,
       spellcheck: false
     }
   })

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -93,6 +93,10 @@ async function getRendererState (window) {
         readyState: document.readyState,
         hasAppContainer: Boolean(appContainer),
         hasLoginModal: Boolean(loginModal),
+        hasLeptonBridge: Boolean(window.lepton),
+        hasLeptonConfigBridge: Boolean(window.lepton && window.lepton.config && window.lepton.config.get),
+        processType: typeof process,
+        requireType: typeof require,
         languageOptions: languageSelector
           ? Array.from(languageSelector.options).map(option => option.value)
           : [],
@@ -120,6 +124,17 @@ async function captureScreenshot (window, fileName, log = console.log) {
 function assertRendererState (state) {
   if (!state.hasAppContainer || !state.hasLoginModal) {
     throw new Error(`Expected app container and login modal to exist: ${JSON.stringify(state)}`)
+  }
+
+  if (!state.hasLeptonBridge || !state.hasLeptonConfigBridge) {
+    throw new Error(`Expected preload bridge to be available: ${JSON.stringify(state)}`)
+  }
+
+  if (state.requireType !== 'undefined' || state.processType !== 'undefined') {
+    throw new Error(`Expected renderer Node globals to be unavailable: ${JSON.stringify({
+      processType: state.processType,
+      requireType: state.requireType
+    })}`)
   }
 
   const expectedTexts = (process.env.LEPTON_SMOKE_EXPECTED_TEXT || 'Login|GitHub Login').split('|')


### PR DESCRIPTION
## Summary

Stacked on #577. This covers phase 4 and phase 5 of the Electron renderer hardening stack.

- Phase 4: disables `nodeIntegration` for the main renderer window now that renderer Node access is bridged through preload/main.
- Phase 5: enables Chromium `sandbox` mode for both the main renderer window and the GitHub OAuth popup.
- Extends the Electron smoke test to verify the login UI still renders, the preload bridge remains available, and renderer-page Node globals (`require` and `process`) are not exposed.

## Stack

Base: `codex/renderer-context-isolation` (#577)
Head: `codex/renderer-sandbox-hardening`

Review and merge after #574 and #577 land.

## Validation

- `node -c main.js`
- `npm run lint`
- `npm test` - 12 files / 64 tests, plus webpack development build
- `npm run test:smoke` - Electron rendered the login UI with the new preload/Node-global assertions
- `git diff --check`

Rendering verification: the Electron smoke test launched the app with isolated config/user-data paths and saved a visible login UI screenshot at `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-adDa10/electron-render-smoke-success.png`.

## Notes

Webpack still reports the existing CodeMirror dynamic dependency warning and Dart Sass legacy JS API deprecation warnings during builds. Electron smoke still reports existing macOS CoreText font fallback notes.