### PR TITLE
[codex] Clean up Electron startup warnings

### DIFF
--- a/app/utilities/logging/mainLogger.js
+++ b/app/utilities/logging/mainLogger.js
@@ -1,0 +1,59 @@
+const winston = require('winston')
+
+const LOG_SPLAT = Symbol.for('splat')
+
+function formatLogValue (value) {
+  if (value === undefined) return 'undefined'
+  if (value === null) return 'null'
+  if (typeof value === 'string') return value
+  if (value instanceof Error) return value.stack || value.message
+
+  try {
+    const serialized = JSON.stringify(value)
+    return serialized === undefined ? String(value) : serialized
+  } catch (error) {
+    return String(value)
+  }
+}
+
+function hasPrintfToken (message) {
+  return typeof message === 'string' && /%[sdifjoO]/.test(message)
+}
+
+function createMainLogger (options = {}) {
+  const loggerTransports = Object.prototype.hasOwnProperty.call(options, 'transports')
+    ? options.transports
+    : [new winston.transports.Console()]
+
+  const captureRawMessage = winston.format(info => {
+    info.rawMessage = info.message
+    return info
+  })
+
+  const logFormat = winston.format.combine(
+    winston.format.errors({ stack: true }),
+    captureRawMessage(),
+    winston.format.splat(),
+    winston.format.timestamp(),
+    winston.format.printf(info => {
+      const splat = Array.isArray(info[LOG_SPLAT]) ? info[LOG_SPLAT] : []
+      const message = info.stack || info.message
+      const parts = hasPrintfToken(info.rawMessage)
+        ? [message]
+        : [message].concat(splat)
+      return `${info.timestamp} ${info.level}: ${parts.map(formatLogValue).join(' ')}`
+    })
+  )
+
+  return winston.createLogger({
+    level: 'info',
+    exitOnError: false,
+    format: logFormat,
+    transports: loggerTransports
+  })
+}
+
+module.exports = {
+  createMainLogger,
+  formatLogValue
+}

--- a/app/utilities/parser/index.js
+++ b/app/utilities/parser/index.js
@@ -1,4 +1,4 @@
-const twitter = require('twitter-text')
+const twitter = resolveTwitterTextApi(require('twitter-text'))
 
 /* Old(Legacy) Style:  [my_title] my_description #tags: tag1, tag2, tag3
    New(Twitter) Style: [my_title] my_description #tag1 #tag2 #tag3
@@ -76,4 +76,10 @@ function parseCustomTagsTwitter (payload) {
   const prefix = '#tags:'
   const customTags = prefix + rawCustomTags.reduce((acc, cur) => acc + ', ' + cur)
   return customTags
+}
+
+export function resolveTwitterTextApi (twitterTextModule) {
+  return twitterTextModule && twitterTextModule.default
+    ? twitterTextModule.default
+    : twitterTextModule
 }

--- a/main.js
+++ b/main.js
@@ -13,12 +13,13 @@ let willQuitApp = false
 
 // http://electron.rocks/sharing-between-main-and-renderer-process/
 // Set up the logger
-const logger = require('winston')
+const winston = require('winston')
 const path = require('path')
 const fs = require('fs')
 const isDev = require('electron-is-dev')
 const defaultConfig = require('./configs/defaultConfig')
 const appInfo = require('./package.json')
+const { createMainLogger } = require('./app/utilities/logging/mainLogger')
 const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
 const { configureI18n, t } = require('./app/utilities/i18n')
@@ -27,8 +28,8 @@ const {
   buildGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = require('./app/utilities/auth/githubOAuth')
-const { createGitHubApi } = require('./app/utilities/githubApi/core')
-const { renderNotebookContent } = require('./app/utilities/jupyterNotebook/core')
+
+const logger = createMainLogger()
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger
@@ -393,6 +394,7 @@ function setUpBridgeIpcHandlers () {
 
   function getGitHubApiBridge () {
     if (!githubApi) {
+      const { createGitHubApi } = require('./app/utilities/githubApi/core')
       githubApi = createGitHubApi({
         conf: nconf,
         logger
@@ -547,6 +549,7 @@ function setUpBridgeIpcHandlers () {
     }
 
     try {
+      const { renderNotebookContent } = require('./app/utilities/jupyterNotebook/core')
       event.returnValue = {
         status: true,
         html: renderNotebookContent(content)
@@ -792,11 +795,9 @@ function initGlobalLogger () {
   }
   const logFile = new Date().toISOString().replace(/:/g, '.') + '.log'
   const logFilePath = path.join(logFolder, logFile)
-  logger.add(logger.transports.File, {
-      json: false,
-      exitOnError: false,
-      filename: logFilePath,
-      timestamp: true })
+  logger.add(new winston.transports.File({
+    filename: logFilePath
+  }))
   global.logger = logger
   global.logFilePath = logFilePath
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "request-promise": "^4.2.2",
         "twitter-text": "^3.0.0",
         "valid-filename": "^3.1.0",
-        "winston": "^2.4.4"
+        "winston": "^3.19.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.10",
@@ -1839,6 +1839,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3192,6 +3212,16 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3377,6 +3407,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -5017,6 +5053,19 @@
       "resolved": "https://registry.npmjs.org/codemirror-one-dark-theme/-/codemirror-one-dark-theme-1.1.1.tgz",
       "integrity": "sha512-SuGz+mjIhWZcU59PQT1KQL8YDdCZOB7zWyPSKC9T8KCjiFCsNaRnaOpI9LDamHUx8X+a7tEfiogemx6L/WDZCg=="
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5033,19 +5082,53 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5248,14 +5331,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-    },
-    "node_modules/cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -6077,6 +6152,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -7118,14 +7199,6 @@
         "node >=0.6.0"
       ]
     },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
-      "engines": {
-        "node": "> 0.1.90"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7184,6 +7257,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7371,6 +7450,12 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8621,6 +8706,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -9048,6 +9145,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -9541,6 +9644,23 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -10281,6 +10401,15 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/optionator": {
@@ -11871,6 +12000,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12488,7 +12626,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -12498,7 +12635,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -13096,6 +13232,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-loader": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/text-loader/-/text-loader-0.0.1.tgz",
@@ -13252,6 +13394,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -13744,8 +13895,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/util-extend": {
       "version": "1.0.3",
@@ -14399,25 +14549,74 @@
       "dev": true
     },
     "node_modules/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
       "dependencies": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/winston/node_modules/async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha512-5mO7DX4CbJzp9zjaFXusQQ4tzKJARjNB1Ih1pVBi8wkbmXy/xzIDgEMXxWePLzt2OdFwaxfneIlT1nCiXubrPQ=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "request-promise": "^4.2.2",
     "twitter-text": "^3.0.0",
     "valid-filename": "^3.1.0",
-    "winston": "^2.4.4"
+    "winston": "^3.19.0"
   },
   "build": {
     "appId": "com.cosmox.lepton",

--- a/tests/logging/mainLogger.test.js
+++ b/tests/logging/mainLogger.test.js
@@ -1,0 +1,47 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const TransportStream = require('winston-transport')
+const {
+  createMainLogger,
+  formatLogValue
+} = require('../../app/utilities/logging/mainLogger')
+
+const LOG_MESSAGE = Symbol.for('message')
+
+class MemoryTransport extends TransportStream {
+  constructor () {
+    super()
+    this.logs = []
+  }
+
+  log (info, callback) {
+    this.logs.push(info[LOG_MESSAGE] || info.message)
+    callback()
+  }
+}
+
+describe('main logger', () => {
+  it('formats extra log arguments without duplicating printf substitutions', () => {
+    const transport = new MemoryTransport()
+    const logger = createMainLogger({
+      transports: [transport]
+    })
+
+    logger.info('plain', 'extra')
+    logger.info('hello %s', 'world')
+    logger.info('object', { a: 1 })
+
+    expect(transport.logs[0]).toMatch(/info: plain extra$/)
+    expect(transport.logs[1]).toMatch(/info: hello world$/)
+    expect(transport.logs[1]).not.toContain('hello world world')
+    expect(transport.logs[2]).toMatch(/info: object {"a":1}$/)
+  })
+
+  it('formats errors with stack context when available', () => {
+    const error = new Error('failed')
+
+    expect(formatLogValue(error)).toContain('Error: failed')
+  })
+})

--- a/tests/utilities/parser.test.js
+++ b/tests/utilities/parser.test.js
@@ -5,7 +5,8 @@ import {
   addLangPrefix,
   descriptionParser,
   parseCustomTags,
-  parseLangName
+  parseLangName,
+  resolveTwitterTextApi
 } from '../../app/utilities/parser'
 
 describe('parser utilities', () => {
@@ -51,5 +52,14 @@ describe('parser utilities', () => {
       'delta'
     ])
     expect(parseCustomTags('alpha, beta')).toEqual([])
+  })
+
+  it('resolves twitter-text default exports from bundled ESM interop', () => {
+    const twitterTextApi = {
+      extractHashtags: () => ['js']
+    }
+
+    expect(resolveTwitterTextApi(twitterTextApi)).toBe(twitterTextApi)
+    expect(resolveTwitterTextApi({ default: twitterTextApi })).toBe(twitterTextApi)
   })
 })


### PR DESCRIPTION
## Summary

Cleans up the Electron 42 startup warning surface exposed by the smoke tests and fixes the crash found during local auth/sync verification.

- Upgrades `winston` from 2.x to 3.19.0 and switches the main process to an explicit logger instance.
- Adds a small logger helper with unit coverage for Winston 3 formatting behavior, including plain extra args, printf-style substitutions, object metadata, and Error values.
- Keeps the existing logger redaction bridge intact and preserves file logging through a Winston 3 file transport.
- Lazy-loads the GitHub API and notebook rendering modules behind their IPC handlers so deprecated-heavy transitive stacks (`request-promise`, `notebookjs/jsdom/whatwg-url`) are not loaded during normal app startup.
- Fixes bundled `twitter-text` interop so hashtag parsing works when webpack resolves the package through its ESM/default export shape.

## Stack

Base PR: #582 (`codex/electron-packaging-validation`)

## Validation

- `npm run lint`
- `npm run test:unit` - 14 files / 73 tests
- `npm test` - unit tests plus webpack development build
- `node --check main.js`
- `node --check app/utilities/logging/mainLogger.js`
- `node --check app/utilities/parser/index.js`
- `NODE_OPTIONS=--trace-deprecation node tests/smoke/electron-render-smoke.js` - login UI rendered and startup emitted no `padLevels` or startup `punycode` warnings
- `npm run test:smoke` - login UI rendered, screenshot saved to `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-APCO9W/electron-render-smoke-success.png`
- `npm run test:packaged-smoke` - packaged app rendered login UI, screenshot saved to `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-packaged-smoke-3MuBRU/electron-packaged-smoke-success.png`
- Real local launch with `/Users/onyx/.leptonrc` and cached auth reached `updateUserSession ACTIVE` without the previous `twitter.extractHashtags is not a function` failure
- `git diff --check`

## Notes

This intentionally does not replace `request` / `request-promise`; it prevents that stack from loading during startup. Full HTTP client replacement remains the next modernization item.

When auth/sync loads the GitHub API stack, Electron still emits a `punycode` warning from `request-promise`; that is expected until the HTTP client replacement PR.

The packaged app still emits a separate `DEP0180 fs.Stats constructor is deprecated` warning. Packaged apps reject most `NODE_OPTIONS`, so tracing that needs a different follow-up path.
