### PR TITLE
[codex] Add render fixture smoke harness

### DIFF
--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -1,14 +1,23 @@
-*:not(.modal):not(:hover)::-webkit-scrollbar {
-  display: none;
-}
-  
 ::-webkit-scrollbar {
   width: 8px;
-  height: 5px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
   border-radius: 2px;
-  background: #f5f5f5;
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+  background: transparent;
+  -webkit-box-shadow: none;
+}
+
+*:hover::-webkit-scrollbar-thumb,
+*:focus::-webkit-scrollbar-thumb,
+*:focus-within::-webkit-scrollbar-thumb,
+.modal::-webkit-scrollbar-thumb,
+.modal *::-webkit-scrollbar-thumb {
+  background: rgba(245, 245, 245, 0.85);
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.45);
 }

--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -1,23 +1,4 @@
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 2px;
-  background: transparent;
-  -webkit-box-shadow: none;
-}
-
-*:hover::-webkit-scrollbar-thumb,
-*:focus::-webkit-scrollbar-thumb,
-*:focus-within::-webkit-scrollbar-thumb,
-.modal::-webkit-scrollbar-thumb,
-.modal *::-webkit-scrollbar-thumb {
-  background: rgba(245, 245, 245, 0.85);
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.45);
-}
+// Avoid global WebKit scrollbar customization. Setting scrollbar dimensions
+// forces classic scrollbars in Chromium and creates blank layout gutters between
+// panes. Native overlay scrollbars avoid both hover-time resize and persistent
+// gaps on macOS.

--- a/app/index.js
+++ b/app/index.js
@@ -11,6 +11,7 @@ import AppContainer from './containers/appContainer'
 import HumanReadableTime from 'human-readable-time'
 import SearchIndex from './utilities/search'
 import Store from './utilities/store'
+import { getRenderFixture } from './renderFixtures'
 import {
   addLangPrefix as Prefixed,
   parseCustomTags,
@@ -73,6 +74,11 @@ const GIST_DETAIL_SYNC_CONCURRENCY = 5
 let preSyncSnapshot = {
   activeGistTag: null,
   activeGist: null
+}
+
+function getRenderFixtureName () {
+  if (typeof window === 'undefined' || !window.location || !window.location.search) return null
+  return new URLSearchParams(window.location.search).get('renderFixture')
 }
 
 function launchAuthWindow (token) {
@@ -693,10 +699,22 @@ ipcRenderer.on('update-available', payload => {
 /** End: Response to  main process events **/
 
 // Start
-const reduxStore = createStore(
-  RootReducer,
-  applyMiddleware(thunk)
-)
+const renderFixture = getRenderFixture(getRenderFixtureName())
+if (renderFixture) {
+  logger.info(`[render-fixture] Rendering ${renderFixture.name} with mock state`)
+  SearchIndex.resetFuseIndex(renderFixture.searchIndexRecords)
+}
+
+const reduxStore = renderFixture
+  ? createStore(
+    RootReducer,
+    renderFixture.state,
+    applyMiddleware(thunk)
+  )
+  : createStore(
+    RootReducer,
+    applyMiddleware(thunk)
+  )
 
 createRoot(document.getElementById('container')).render(
   <Provider store = { reduxStore }>

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -1,0 +1,227 @@
+import { addLangPrefix as Prefixed } from './utilities/parser'
+
+const FIXTURE_USER = {
+  avatar_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+  html_url: 'https://github.com/lepton-fixture',
+  login: 'lepton-fixture'
+}
+
+const FILES = {
+  'hello.js': {
+    filename: 'hello.js',
+    language: 'JavaScript',
+    raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/hello.js',
+    content: [
+      'function hello(name) {',
+      '  return "hello " + name',
+      '}',
+      '',
+      'console.log(hello("Lepton"))'
+    ].join('\n')
+  },
+  'notes.md': {
+    filename: 'notes.md',
+    language: 'Markdown',
+    raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/notes.md',
+    content: [
+      '# Render fixture',
+      '',
+      '- exercises markdown rendering',
+      '- keeps GitHub out of smoke tests'
+    ].join('\n')
+  },
+  'styles.css': {
+    filename: 'styles.css',
+    language: 'CSS',
+    raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/styles.css',
+    content: [
+      '.fixture {',
+      '  display: grid;',
+      '  gap: 8px;',
+      '}'
+    ].join('\n')
+  }
+}
+
+function createGist (id, description, isPublic, files, updatedAt) {
+  const gist = {
+    id,
+    description,
+    public: isPublic,
+    html_url: `https://gist.github.com/lepton-fixture/${id}`,
+    updated_at: updatedAt,
+    files
+  }
+
+  return {
+    langs: new Set(Object.keys(files).map(filename => files[filename].language || 'Other')),
+    brief: gist,
+    details: gist
+  }
+}
+
+const gists = {
+  'fixture-gist-1': createGist(
+    'fixture-gist-1',
+    '[React 19 render fixture] #ui #smoke Covers editor, raw modal, tags, and dashboard rendering.',
+    false,
+    FILES,
+    '2026-06-29T16:00:00Z'
+  ),
+  'fixture-gist-2': createGist(
+    'fixture-gist-2',
+    '[Python utility] #backend Small parser helper fixture.',
+    true,
+    {
+      'parser.py': {
+        filename: 'parser.py',
+        language: 'Python',
+        raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/parser.py',
+        content: 'def parse(value):\n    return value.strip()\n'
+      }
+    },
+    '2026-06-28T14:30:00Z'
+  ),
+  'fixture-gist-3': createGist(
+    'fixture-gist-3',
+    '[Shell setup] #ops Installs local development prerequisites.',
+    true,
+    {
+      'setup.sh': {
+        filename: 'setup.sh',
+        language: 'Shell',
+        raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/setup.sh',
+        content: 'npm ci\nnpm run build\n'
+      }
+    },
+    '2026-06-27T10:15:00Z'
+  ),
+  'fixture-gist-4': createGist(
+    'fixture-gist-4',
+    '[Java sample] #backend Simple class fixture for dashboard variety.',
+    true,
+    {
+      'Example.java': {
+        filename: 'Example.java',
+        language: 'Java',
+        raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/Example.java',
+        content: 'class Example {}\n'
+      }
+    },
+    '2026-06-26T09:00:00Z'
+  )
+}
+
+const gistTags = {
+  [Prefixed('All')]: ['fixture-gist-1', 'fixture-gist-2', 'fixture-gist-3', 'fixture-gist-4'],
+  [Prefixed('JavaScript')]: ['fixture-gist-1'],
+  [Prefixed('Markdown')]: ['fixture-gist-1'],
+  [Prefixed('CSS')]: ['fixture-gist-1'],
+  [Prefixed('Python')]: ['fixture-gist-2'],
+  [Prefixed('Shell')]: ['fixture-gist-3'],
+  [Prefixed('Java')]: ['fixture-gist-4'],
+  ui: ['fixture-gist-1'],
+  smoke: ['fixture-gist-1'],
+  backend: ['fixture-gist-2', 'fixture-gist-4'],
+  ops: ['fixture-gist-3']
+}
+
+const searchIndexRecords = Object.keys(gists).map(id => {
+  const gist = gists[id].details
+  const languages = Object.keys(gist.files)
+    .map(filename => gist.files[filename].language || 'Other')
+    .join(',')
+  const filenames = Object.keys(gist.files).join(', ')
+
+  return {
+    id,
+    description: gist.description,
+    language: languages,
+    filename: filenames
+  }
+})
+
+function getBaseState () {
+  return {
+    aboutModalStatus: 'OFF',
+    accessToken: 'fixture-token',
+    activeGist: 'fixture-gist-1',
+    activeGistTag: Prefixed('All'),
+    authWindowStatus: 'OFF',
+    dashboardModalStatus: 'OFF',
+    fileExpandStatus: {},
+    gistDeleteModalStatus: 'OFF',
+    gistEditModalStatus: 'OFF',
+    gistNewModalStatus: 'OFF',
+    gistRawModal: {
+      status: 'OFF',
+      file: null,
+      content: null,
+      link: null
+    },
+    gists,
+    gistSyncStatus: 'DONE',
+    gistTags,
+    immersiveMode: 'OFF',
+    logoutModalStatus: 'OFF',
+    newVersionInfo: {
+      version: 'fixture-version',
+      url: 'https://github.com/hackjutsu/Lepton/releases'
+    },
+    pinnedTags: ['ui', Prefixed('JavaScript')],
+    pinnedTagsModalStatus: 'OFF',
+    scrollRequestStatus: 'OFF',
+    searchWindowStatus: 'OFF',
+    syncTime: '09:00 29/06/2026',
+    updateAvailableBarStatus: 'OFF',
+    userSession: {
+      activeStatus: 'ACTIVE',
+      profile: FIXTURE_USER
+    }
+  }
+}
+
+function getFixtureOverrides (name) {
+  switch (name) {
+    case 'about':
+      return { aboutModalStatus: 'ON' }
+    case 'dashboard':
+      return { dashboardModalStatus: 'ON' }
+    case 'delete':
+      return { gistDeleteModalStatus: 'ON' }
+    case 'edit':
+      return { gistEditModalStatus: 'ON' }
+    case 'immersive':
+      return { immersiveMode: 'ON' }
+    case 'new':
+      return { gistNewModalStatus: 'ON' }
+    case 'pinned-tags':
+      return { pinnedTagsModalStatus: 'ON' }
+    case 'raw':
+      return {
+        gistRawModal: {
+          status: 'ON',
+          file: FILES['hello.js'].filename,
+          content: FILES['hello.js'].content,
+          link: FILES['hello.js'].raw_url
+        }
+      }
+    case 'search':
+      return { searchWindowStatus: 'ON' }
+    case 'active':
+      return {}
+    default:
+      return null
+  }
+}
+
+export function getRenderFixture (name) {
+  const overrides = getFixtureOverrides(name)
+  if (!overrides) return null
+
+  return {
+    name,
+    searchIndexRecords,
+    state: Object.assign({}, getBaseState(), overrides)
+  }
+}

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ const winston = require('winston')
 const path = require('path')
 const fs = require('fs')
 const isDev = require('electron-is-dev')
+const { pathToFileURL } = require('url')
 const defaultConfig = require('./configs/defaultConfig')
 const appInfo = require('./package.json')
 const { createMainLogger } = require('./app/utilities/logging/mainLogger')
@@ -66,6 +67,14 @@ function getConfigPath() {
 
 function shouldCheckForUpdates () {
   return !isDev && !appInfo.version.includes('alpha') && nconf.get('autoUpdate')
+}
+
+function getRendererUrl () {
+  const rendererUrl = pathToFileURL(path.join(__dirname, 'index.html'))
+  if (process.env.LEPTON_RENDER_FIXTURE) {
+    rendererUrl.searchParams.set('renderFixture', process.env.LEPTON_RENDER_FIXTURE)
+  }
+  return rendererUrl.toString()
 }
 
 function checkForAppUpdates ({ notify = false } = {}) {
@@ -226,7 +235,7 @@ function createWindow (autoLogin) {
     prepend: (params, mainWindow) => []
   })
 
-  mainWindow.loadURL(`file://${__dirname}/index.html`)
+  mainWindow.loadURL(getRendererUrl())
   setUpApplicationMenu()
   // mainWindow.webContents.openDevTools()
 

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -87,11 +87,48 @@ async function waitForLoginUi (window) {
   }
 }
 
+async function waitForFixtureUi (window) {
+  const expectedSelector = process.env.LEPTON_SMOKE_EXPECTED_SELECTOR
+  if (!expectedSelector) {
+    throw new Error('LEPTON_SMOKE_EXPECTED_SELECTOR is required for render fixture smoke tests.')
+  }
+
+  const found = await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      const deadline = Date.now() + 30000
+      const expectedSelector = ${JSON.stringify(expectedSelector)}
+      function check() {
+        if (document.querySelector('.app-container') && document.querySelector(expectedSelector)) {
+          resolve(true)
+          return
+        }
+        if (Date.now() > deadline) {
+          resolve(false)
+          return
+        }
+        setTimeout(check, 100)
+      }
+      check()
+    })
+  `, true)
+
+  if (!found) {
+    const state = await getRendererState(window)
+    throw new Error([
+      `Timed out waiting for render fixture "${process.env.LEPTON_RENDER_FIXTURE}" to render selector "${expectedSelector}".`,
+      `Renderer state: ${JSON.stringify(state)}`,
+      `Renderer events: ${rendererEvents.join('\n') || '(none)'}`
+    ].join('\n'))
+  }
+}
+
 async function getRendererState (window) {
+  const expectedSelector = process.env.LEPTON_SMOKE_EXPECTED_SELECTOR || ''
   return window.webContents.executeJavaScript(`
     (() => {
       const appContainer = document.querySelector('.app-container')
       const loginModal = document.querySelector('.login-modal')
+      const expectedSelector = ${JSON.stringify(expectedSelector)}
       const appBounds = appContainer ? appContainer.getBoundingClientRect() : null
       const languageSelector = document.querySelector('[data-role="language-selector"]')
       return {
@@ -101,6 +138,7 @@ async function getRendererState (window) {
         readyState: document.readyState,
         hasAppContainer: Boolean(appContainer),
         hasLoginModal: Boolean(loginModal),
+        hasExpectedSelector: expectedSelector ? Boolean(document.querySelector(expectedSelector)) : true,
         hasLeptonBridge: Boolean(window.lepton),
         hasLeptonConfigBridge: Boolean(window.lepton && window.lepton.config && window.lepton.config.get),
         processType: typeof process,
@@ -135,9 +173,16 @@ async function captureScreenshot (window, fileName, log = console.log) {
   log(`Saved smoke-test screenshot to ${screenshotPath}`)
 }
 
-function assertRendererState (state) {
-  if (!state.hasAppContainer || !state.hasLoginModal) {
-    throw new Error(`Expected app container and login modal to exist: ${JSON.stringify(state)}`)
+function getBlockingRendererEvents () {
+  return rendererEvents.filter(event => {
+    if (/Download the React DevTools|Electron Security Warning/.test(event)) return false
+    return /console:(error|warning)|did-fail-load|render-process-gone|renderer crashed/.test(event)
+  })
+}
+
+function assertSharedRendererState (state) {
+  if (!state.hasAppContainer) {
+    throw new Error(`Expected app container to exist: ${JSON.stringify(state)}`)
   }
 
   if (!state.hasLeptonBridge || !state.hasLeptonConfigBridge) {
@@ -151,19 +196,49 @@ function assertRendererState (state) {
     })}`)
   }
 
+  if (!state.appBounds || state.appBounds.width <= 0 || state.appBounds.height <= 0) {
+    throw new Error(`App container did not render with visible dimensions: ${JSON.stringify(state.appBounds)}`)
+  }
+}
+
+function assertNoBlockingRendererEvents () {
+  const blockingEvents = getBlockingRendererEvents()
+  if (blockingEvents.length > 0) {
+    throw new Error(`Renderer emitted warnings/errors while rendering fixture:\n${blockingEvents.join('\n')}`)
+  }
+}
+
+function assertLoginRendererState (state) {
+  assertSharedRendererState(state)
+
+  if (!state.hasAppContainer || !state.hasLoginModal) {
+    throw new Error(`Expected app container and login modal to exist: ${JSON.stringify(state)}`)
+  }
+
   const expectedTexts = (process.env.LEPTON_SMOKE_EXPECTED_TEXT || 'Login|GitHub Login').split('|')
   const missingText = expectedTexts.find(text => !state.bodyText.includes(text))
   if (missingText) {
     throw new Error(`Expected login UI text "${missingText}" was not visible. Body text: ${state.bodyText}`)
   }
 
-  if (!state.appBounds || state.appBounds.width <= 0 || state.appBounds.height <= 0) {
-    throw new Error(`App container did not render with visible dimensions: ${JSON.stringify(state.appBounds)}`)
-  }
-
   const expectedLocales = ['en', 'es', 'fr', 'ja', 'ko', 'zh-Hans', 'zh-Hant']
   if (expectedLocales.some(locale => !state.languageOptions.includes(locale))) {
     throw new Error(`Expected language selector options were not visible: ${JSON.stringify(state.languageOptions)}`)
+  }
+}
+
+function assertFixtureRendererState (state) {
+  assertSharedRendererState(state)
+  assertNoBlockingRendererEvents()
+
+  if (!state.hasExpectedSelector) {
+    throw new Error(`Expected fixture selector was not visible: ${process.env.LEPTON_SMOKE_EXPECTED_SELECTOR}`)
+  }
+
+  const expectedTexts = (process.env.LEPTON_SMOKE_EXPECTED_TEXT || '').split('|').filter(Boolean)
+  const missingText = expectedTexts.find(text => !state.bodyText.includes(text))
+  if (missingText) {
+    throw new Error(`Expected fixture UI text "${missingText}" was not visible. Body text: ${state.bodyText}`)
   }
 }
 
@@ -174,10 +249,19 @@ async function main () {
     window = await waitForMainWindow()
     attachRendererDiagnostics(window)
     await waitForRendererLoad(window)
-    await waitForLoginUi(window)
-    assertRendererState(await getRendererState(window))
-    await captureScreenshot(window, 'electron-render-smoke-success.png')
-    console.log('electron render smoke test passed')
+
+    if (process.env.LEPTON_RENDER_FIXTURE) {
+      await waitForFixtureUi(window)
+      assertFixtureRendererState(await getRendererState(window))
+      await captureScreenshot(window, `electron-render-${process.env.LEPTON_RENDER_FIXTURE}-success.png`)
+      console.log(`electron render fixture smoke test passed: ${process.env.LEPTON_RENDER_FIXTURE}`)
+    } else {
+      await waitForLoginUi(window)
+      assertLoginRendererState(await getRendererState(window))
+      await captureScreenshot(window, 'electron-render-smoke-success.png')
+      console.log('electron render smoke test passed')
+    }
+
     app.exit(0)
   } catch (err) {
     await captureScreenshot(window, 'electron-render-smoke-failure.png', console.error)

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -32,7 +32,60 @@ function createTempHome (locale = 'en') {
   return { configHome, root, userData }
 }
 
-function runSmokeProcess (tempHome, expectedText) {
+const RENDER_FIXTURES = [
+  {
+    name: 'active',
+    selector: '.active-layout .snippet-box',
+    text: 'React 19 render fixture'
+  },
+  {
+    name: 'edit',
+    selector: '.modal .gist-editor-form .CodeMirror',
+    text: 'Edit'
+  },
+  {
+    name: 'new',
+    selector: '.modal .gist-editor-form .CodeMirror',
+    text: 'New'
+  },
+  {
+    name: 'about',
+    selector: '.about-modal .modal-title',
+    text: 'About'
+  },
+  {
+    name: 'dashboard',
+    selector: '.dashboard-modal canvas',
+    text: 'Dashboard'
+  },
+  {
+    name: 'search',
+    selector: '.search-modal .search-box',
+    text: ''
+  },
+  {
+    name: 'delete',
+    selector: '.modal-footer .btn-danger',
+    text: 'Delete the gist?'
+  },
+  {
+    name: 'raw',
+    selector: '.raw-modal .code-area-raw',
+    text: 'hello.js'
+  },
+  {
+    name: 'pinned-tags',
+    selector: '.pinned-tags-modal .pin-tag-list',
+    text: 'Shortcuts'
+  },
+  {
+    name: 'immersive',
+    selector: '.snippet-panel-immersive .snippet-box',
+    text: 'React 19 render fixture'
+  }
+]
+
+function runSmokeProcess (tempHome, options) {
   return new Promise((resolve, reject) => {
     const electronArgs = [
       `--user-data-dir=${tempHome.userData}`,
@@ -43,14 +96,21 @@ function runSmokeProcess (tempHome, expectedText) {
       electronArgs.unshift('--no-sandbox')
     }
 
+    const env = Object.assign({}, process.env, {
+      ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      LEPTON_SMOKE_ARTIFACT_DIR: tempHome.root,
+      LEPTON_SMOKE_EXPECTED_TEXT: options.expectedText,
+      XDG_CONFIG_HOME: tempHome.configHome
+    })
+
+    if (options.renderFixture) {
+      env.LEPTON_RENDER_FIXTURE = options.renderFixture
+      env.LEPTON_SMOKE_EXPECTED_SELECTOR = options.expectedSelector
+    }
+
     const child = spawn(electronPath, electronArgs, {
       cwd: repoRoot,
-      env: Object.assign({}, process.env, {
-        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
-        LEPTON_SMOKE_ARTIFACT_DIR: tempHome.root,
-        LEPTON_SMOKE_EXPECTED_TEXT: expectedText,
-        XDG_CONFIG_HOME: tempHome.configHome
-      }),
+      env,
       stdio: ['ignore', 'pipe', 'pipe']
     })
 
@@ -87,8 +147,20 @@ function runSmokeProcess (tempHome, expectedText) {
 
 async function main () {
   assertBuiltBundleExists()
-  await runSmokeProcess(createTempHome('en'), 'Login|GitHub Login')
-  await runSmokeProcess(createTempHome('ja'), 'ログイン|GitHubでログイン')
+  await runSmokeProcess(createTempHome('en'), {
+    expectedText: 'Login|GitHub Login'
+  })
+  await runSmokeProcess(createTempHome('ja'), {
+    expectedText: 'ログイン|GitHubでログイン'
+  })
+
+  for (const fixture of RENDER_FIXTURES) {
+    await runSmokeProcess(createTempHome('en'), {
+      expectedSelector: fixture.selector,
+      expectedText: fixture.text,
+      renderFixture: fixture.name
+    })
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary

Adds an opt-in renderer fixture smoke harness so React/Electron rendering can be verified without GitHub login, OS shortcut delivery, or backend calls.

This PR also removes the global WebKit scrollbar sizing override that forced classic scrollbars in Chromium and left blank gutters between panes on macOS. The app now relies on native overlay scrollbar behavior instead of app-level scrollbar dimensions.

## How the render fixtures work

- The fixture path is enabled only when `LEPTON_RENDER_FIXTURE=<name>` is present.
- `main.js` converts the renderer entry point to a file URL and appends `?renderFixture=<name>`.
- `app/index.js` reads that query param before creating the Redux store.
- `app/renderFixtures.js` returns deterministic authenticated mock state for the requested fixture: user profile, gists, files, tags, pinned tags, active gist, modal flags, sync state, and search records.
- The renderer seeds the normal Redux store and search index from that fixture state, then mounts the normal `AppContainer`.
- Normal app launches are unchanged because no fixture is loaded unless the environment variable is set.

## Covered render surfaces

`npm run test:smoke` still checks the English and Japanese login screens, then launches isolated Electron runs for these authenticated render fixtures:

- active authenticated layout
- edit gist modal
- new gist modal
- about/settings modal
- dashboard chart modal
- search overlay
- delete confirmation modal
- raw file modal
- pinned-tags modal
- immersive snippet view

Each fixture run uses isolated config and user-data directories, waits for a fixture-specific selector/text, verifies the preload bridge is available, verifies renderer Node globals are unavailable, checks visible app dimensions, captures a screenshot, and fails on renderer warnings, errors, failed loads, or renderer crashes.

## Scope and non-goals

- This validates initial rendering of important React surfaces after the major React/Electron migration.
- This does not validate GitHub OAuth, Gist CRUD, sync behavior, request signing, token handling, or real GitHub API responses.
- This does not validate OS-level keyboard shortcut delivery or full user interaction flows inside each modal.
- The mock data is intentionally deterministic and local. It is a safety net for rendering regressions, not a replacement for manual backend verification.

## Validation

- `npm run lint`
- `npm test` - 16 files / 78 tests, plus webpack development build
- `LEPTON_SMOKE_NO_SANDBOX=1 npm run test:smoke` - login smoke plus all render fixtures passed
- GitHub CI passed after rebase on `master`: `lint-test-build`, `electron-smoke`, and `packaged-smoke`
