### PR TITLE
[codex] Fix IPC listener cleanup and remove editor exit shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@
 | Edit Snippet   | `Cmd/Ctrl + E` | Edit a snippet      |
 | Delete Snippet   | `Cmd/Ctrl + Del` | Delete selected snippet      |
 | Submit         | `Cmd/Ctrl + S` | Submit the changes from the editor      |
-| Cancel         | `Cmd/Ctrl + ESC` | Exit the editor without saving   |
 | Sync           | `Cmd/Ctrl + R` | Sync with remote Gist server   |
 | Immersive Mode | `Cmd/Ctrl + I` |  Toggle the [Immersive mode](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/immersive.png)    |
 | Dashboard      | `Cmd/Ctrl + D` |  Toggle the [dashboard](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/dashboard.png)     |

--- a/app/containers/gistEditorForm/index.js
+++ b/app/containers/gistEditorForm/index.js
@@ -12,6 +12,7 @@ import {
   shouldShowError,
   touchAllFields
 } from './formState'
+import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
 import { t } from '../../utilities/i18n'
 import validFilename from 'valid-filename'
 
@@ -45,7 +46,8 @@ class GistEditorForm extends Component {
 
   componentDidMount () {
     this.isMountedFlag = true
-    ipcRenderer.on('submit-gist', () => {
+    this.ipcSubscriptions = []
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'submit-gist', () => {
       this.shortcutSubmit()
     })
   }
@@ -60,7 +62,7 @@ class GistEditorForm extends Component {
 
   componentWillUnmount () {
     this.isMountedFlag = false
-    ipcRenderer.removeAllListeners('submit-gist')
+    unsubscribeIpc(this.ipcSubscriptions)
   }
 
   shortcutSubmit () {

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -5,6 +5,7 @@ import electronBridge from '../../utilities/electronBridge'
 import LanguageSelector from '../languageSelector'
 import Modal from '../compatModal'
 import React, { Component } from 'react'
+import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
 import { t } from '../../utilities/i18n'
 
 import dojocatImage from '../../utilities/octodex/dojocat.jpg'
@@ -34,7 +35,8 @@ class LoginPage extends Component {
     logger.debug('-----> Inside LoginPage componentDidMount with loggedInUserInfo' + JSON.stringify(loggedInUserInfo))
 
     logger.debug('-----> Registering listener for auto-login signal')
-    ipcRenderer.on('auto-login', () => {
+    this.ipcSubscriptions = []
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'auto-login', () => {
       logger.debug('-----> Received "auto-login" signal with loggedInUserInfo ' + JSON.stringify(loggedInUserInfo))
       loggedInUserInfo && loggedInUserInfo.token && this.handleContinueButtonClicked(loggedInUserInfo.token)
     })
@@ -45,7 +47,7 @@ class LoginPage extends Component {
 
   componentWillUnmount () {
     logger.debug('-----> Removing listener for auto-login signal')
-    ipcRenderer.removeAllListeners('auto-login')
+    unsubscribeIpc(this.ipcSubscriptions)
     clearTimeout(this.languageChangeTimer)
   }
 

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -11,6 +11,7 @@ import Modal from '../compatModal'
 import Moment from 'moment'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
+import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
 import { t } from '../../utilities/i18n'
 import TagBadges from '../tagBadges'
 import {
@@ -56,20 +57,20 @@ const kTabLength = conf.get('editor:tabSize')
 
 class Snippet extends Component {
   componentDidMount () {
-    ipcRenderer.on('edit-gist-renderer', () => {
+    this.ipcSubscriptions = []
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'edit-gist-renderer', () => {
       this.showGistEditorModal()
     })
-    ipcRenderer.on('exit-editor', () => {
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'exit-editor', () => {
       this.closeGistEditorModal()
     })
-    ipcRenderer.on('delete-gist', () => {
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'delete-gist', () => {
       this.showDeleteModal()
     })
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeAllListeners('edit-gist-renderer')
-    ipcRenderer.removeAllListeners('exit-editor')
+    unsubscribeIpc(this.ipcSubscriptions)
   }
 
   showDeleteModal () {

--- a/app/containers/userPanel/index.js
+++ b/app/containers/userPanel/index.js
@@ -7,6 +7,7 @@ import HumanReadableTime from 'human-readable-time'
 import Modal from '../compatModal'
 import { notifySuccess, notifyFailure } from '../../utilities/notifier'
 import React, { Component } from 'react'
+import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
 import { t } from '../../utilities/i18n'
 import {
   addLangPrefix as Prefixed,
@@ -53,19 +54,20 @@ const hideProfilePhoto = conf.get('userPanel:hideProfilePhoto')
 
 class UserPanel extends Component {
   componentDidMount () {
-    ipcRenderer.on('new-gist-renderer', () => {
+    this.ipcSubscriptions = []
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'new-gist-renderer', () => {
       this.handleNewGistClicked()
     })
-    ipcRenderer.on('exit-editor', () => {
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'exit-editor', () => {
       this.closeGistEditorModal()
     })
-    ipcRenderer.on('sync-gists', () => {
+    subscribeIpc(ipcRenderer, this.ipcSubscriptions, 'sync-gists', () => {
       this.handleSyncClicked()
     })
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeAllListeners('new-gist-renderer')
+    unsubscribeIpc(this.ipcSubscriptions)
   }
 
   handleCreateSingleGist (data) {

--- a/app/index.js
+++ b/app/index.js
@@ -42,6 +42,8 @@ import {
   updateUpdateAvailableBarStatus,
   updateNewVersionInfo,
   updateImmersiveModeStatus,
+  updateGistEditModeStatus,
+  updateGistNewModeStatus,
   updateAboutModalStatus,
   updateDashboardModalStatus,
   updatePinnedTags
@@ -479,6 +481,23 @@ function allDialogsClosed (dialogsStatus) {
   return dialogsStatus.every(status => status === 'OFF')
 }
 
+function closeGistEditorIfOpen () {
+  const { gistEditModalStatus, gistNewModalStatus } = reduxStore.getState()
+  let didClose = false
+
+  if (gistEditModalStatus === 'ON') {
+    reduxStore.dispatch(updateGistEditModeStatus('OFF'))
+    didClose = true
+  }
+
+  if (gistNewModalStatus === 'ON') {
+    reduxStore.dispatch(updateGistNewModeStatus('OFF'))
+    didClose = true
+  }
+
+  return didClose
+}
+
 ipcRenderer.on('search-gist', data => {
   const state = reduxStore.getState()
   const {
@@ -687,6 +706,10 @@ ipcRenderer.on('back-to-normal-mode', data => {
     reduxStore.dispatch(updateImmersiveModeStatus('OFF'))
   }
   reduxStore.dispatch(updateAboutModalStatus('OFF'))
+})
+
+ipcRenderer.on('exit-editor', () => {
+  closeGistEditorIfOpen()
 })
 
 ipcRenderer.on('update-available', payload => {

--- a/app/utilities/ipcSubscriptions/index.js
+++ b/app/utilities/ipcSubscriptions/index.js
@@ -1,0 +1,17 @@
+export function subscribeIpc (ipcRenderer, subscriptions, channel, listener) {
+  const unsubscribe = ipcRenderer.on(channel, listener)
+  if (typeof unsubscribe === 'function') {
+    subscriptions.push(unsubscribe)
+  }
+}
+
+export function unsubscribeIpc (subscriptions) {
+  if (!subscriptions) return
+
+  subscriptions.forEach(unsubscribe => {
+    if (typeof unsubscribe === 'function') {
+      unsubscribe()
+    }
+  })
+  subscriptions.length = 0
+}

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -55,7 +55,6 @@ module.exports = {
         "keyImmersiveMode": "CommandOrControl+I",
         "keyAboutPage": "CommandOrControl+,",
         "keyDashboard": "CommandOrControl+D",
-        "keyEditorExit": "CommandOrControl+Escape",
         "keySyncGists": "CommandOrControl+R"
     }
 }

--- a/main.js
+++ b/main.js
@@ -2,7 +2,6 @@ const os = require('os')
 const electron = require('electron')
 const nconf = require('nconf')
 const windowStateKeeper = require('electron-window-state')
-const electronLocalshortcut = require('electron-localshortcut')
 const Menu = electron.Menu
 const app = electron.app
 const dialog = electron.dialog
@@ -136,11 +135,9 @@ function createWindow (autoLogin) {
 
   if (autoLogin) {
     logger.debug('-----> registering login-page-ready listener')
-    // Set up a one-time listener for 'login-page-ready'
-    ipcMain.on('login-page-ready', () => {
+    ipcMain.once('login-page-ready', () => {
       logger.info('[signal] sending auto-login signal')        
       mainWindow.webContents.send('auto-login')
-      ipcMain.removeAllListeners('login-page-ready')
     })
   }
 
@@ -272,15 +269,6 @@ app.on('window-all-closed', () => {
 app.on('before-quit', (event) => {
   if (operationType == 2) {
     willQuitApp = true
-    try {
-      // If we launch the app and close it quickly, we might run into a 
-      // situation where electronLocalshortcut is not initialized.
-      if (mainWindow && electronLocalshortcut) {
-        electronLocalshortcut.unregisterAll(mainWindow)
-      }
-    } catch (e) {
-      logger.error(e)
-    }
   }else{
     event.preventDefault()
   }
@@ -323,7 +311,6 @@ function setUpApplicationMenu () {
       },
       {
         label: t('menu.exitEditor'),
-        accelerator: shortcuts.keyEditorExit,
         click: (item, mainWindow) => mainWindow && mainWindow.send('exit-editor')
       },
       {

--- a/tests/utilities/ipcSubscriptions.test.js
+++ b/tests/utilities/ipcSubscriptions.test.js
@@ -1,0 +1,70 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  subscribeIpc,
+  unsubscribeIpc
+} from '../../app/utilities/ipcSubscriptions'
+
+function createFakeIpc () {
+  const listeners = {}
+
+  return {
+    on: vi.fn((channel, listener) => {
+      listeners[channel] = listeners[channel] || []
+      listeners[channel].push(listener)
+
+      return () => {
+        listeners[channel] = listeners[channel].filter(candidate => candidate !== listener)
+      }
+    }),
+    emit: (channel, ...args) => {
+      const channelListeners = listeners[channel] || []
+      channelListeners.forEach(listener => listener(...args))
+    },
+    listenerCount: channel => (listeners[channel] || []).length
+  }
+}
+
+function readRepoFile (path) {
+  return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8')
+}
+
+describe('IPC subscription lifecycle helpers', () => {
+  it('removes only the listeners owned by one component', () => {
+    const ipc = createFakeIpc()
+    const firstSubscriptions = []
+    const secondSubscriptions = []
+    const firstListener = vi.fn()
+    const secondListener = vi.fn()
+
+    subscribeIpc(ipc, firstSubscriptions, 'exit-editor', firstListener)
+    subscribeIpc(ipc, secondSubscriptions, 'exit-editor', secondListener)
+
+    expect(ipc.listenerCount('exit-editor')).toBe(2)
+
+    unsubscribeIpc(firstSubscriptions)
+    ipc.emit('exit-editor')
+
+    expect(ipc.listenerCount('exit-editor')).toBe(1)
+    expect(firstListener).not.toHaveBeenCalled()
+    expect(secondListener).toHaveBeenCalledTimes(1)
+    expect(firstSubscriptions).toEqual([])
+  })
+
+  it('keeps renderer components off broad listener removal', () => {
+    const rendererComponents = [
+      'app/containers/snippet/index.js',
+      'app/containers/userPanel/index.js',
+      'app/containers/gistEditorForm/index.js',
+      'app/containers/loginPage/index.js'
+    ]
+
+    rendererComponents.forEach(path => {
+      expect(readRepoFile(path)).not.toContain('removeAllListeners')
+    })
+
+    expect(readRepoFile('app/containers/snippet/index.js')).toContain("'delete-gist'")
+    expect(readRepoFile('main.js')).toContain("ipcMain.once('login-page-ready'")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a small `subscribeIpc` / `unsubscribeIpc` helper so renderer components remove only the IPC listeners they own.
- Updates `Snippet`, `UserPanel`, `GistEditorForm`, and `LoginPage` to use scoped listener cleanup, including cleanup for the previously untracked `delete-gist` listener.
- Changes the auto-login startup listener from `ipcMain.on` to `ipcMain.once` so it cannot accumulate across window lifecycles.
- Removes the default `CommandOrControl+Escape` editor-exit shortcut instead of adding workaround logic for an unreliable, low-use key chord.
- Updates the README shortcut table so it no longer documents the removed editor-exit shortcut.
- Adds focused unit coverage for the IPC subscription helper and keeps Electron smoke coverage for the renderer/editor fixtures.

## Why

Issue #465 reported memory growth while using the app. Latest `master` has changed substantially since the original report, but the same class of leak risk still existed: renderer and main-process IPC listeners could outlive their component/window lifecycle, or be cleaned up too broadly with `removeAllListeners`.

This PR makes IPC listener ownership explicit. Components retain unsubscribe callbacks for only their own listeners, then remove those callbacks on unmount. The one-shot auto-login listener now uses `ipcMain.once`.

## Shortcut Decision

`Cmd/Ctrl+Esc` was unreliable in local testing and is not central to the memory-leak fix, so this PR removes it rather than adding more shortcut-specific complexity. The Exit Editor menu item still sends the existing `exit-editor` IPC command when selected manually.

## Validation

- `npm run lint`
- `npm run test:unit`
- `npm run test:smoke`
- `git diff --check`

## Notes

`npm run test:smoke` still emits the existing Dart Sass legacy JS API deprecation warnings and the existing CodeMirror dynamic dependency warning during the webpack build.
