### PR TITLE
[codex] Fix PHP template highlighting

### DIFF
--- a/app/containers/codeArea/highlighting.js
+++ b/app/containers/codeArea/highlighting.js
@@ -1,9 +1,17 @@
 import HighlightJS from 'highlight.js'
 
+function shouldUsePhpTemplate (content, language) {
+  return typeof language === 'string' &&
+    language.toLowerCase() === 'php' &&
+    /<\?(?:php|=)?/i.test(content)
+}
+
 export function highlightContent (content, language) {
-  if (language && HighlightJS.getLanguage(language)) {
+  const highlightLanguage = shouldUsePhpTemplate(content, language) ? 'php-template' : language
+
+  if (highlightLanguage && HighlightJS.getLanguage(highlightLanguage)) {
     try {
-      return HighlightJS.highlight(content, { language, ignoreIllegals: true }).value
+      return HighlightJS.highlight(content, { language: highlightLanguage, ignoreIllegals: true }).value
     } catch (__) {}
   }
 
@@ -53,6 +61,7 @@ export function adaptedLanguage (filename, lang) {
   switch (language) {
     case 'Shell': return 'bash'
     case 'Python': return 'python'
+    case 'PHP': return 'php'
     case 'C': return 'c'
     case 'C++': return 'cpp'
     case 'C#': return 'cs'

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -43,6 +43,25 @@ const FILES = {
   }
 }
 
+const PHP_HTML_FILE = {
+  filename: 'index.php',
+  language: 'PHP',
+  raw_url: 'https://gist.githubusercontent.com/lepton-fixture/mock/raw/index.php',
+  content: [
+    '<!doctype html>',
+    '<html>',
+    '<body>',
+    '<?php if ($isVisible) { ?>',
+    '  <section class="notice">',
+    '    <h1><?= $title ?></h1>',
+    '    <p>Ready</p>',
+    '  </section>',
+    '<?php } ?>',
+    '</body>',
+    '</html>'
+  ].join('\n')
+}
+
 function createGist (id, description, isPublic, files, updatedAt) {
   const gist = {
     id,
@@ -109,20 +128,31 @@ const gists = {
       }
     },
     '2026-06-26T09:00:00Z'
+  ),
+  'fixture-gist-5': createGist(
+    'fixture-gist-5',
+    '[PHP template] #php #smoke Embedded HTML syntax fixture.',
+    true,
+    {
+      'index.php': PHP_HTML_FILE
+    },
+    '2026-06-25T11:45:00Z'
   )
 }
 
 const gistTags = {
-  [Prefixed('All')]: ['fixture-gist-1', 'fixture-gist-2', 'fixture-gist-3', 'fixture-gist-4'],
+  [Prefixed('All')]: ['fixture-gist-1', 'fixture-gist-2', 'fixture-gist-3', 'fixture-gist-4', 'fixture-gist-5'],
   [Prefixed('JavaScript')]: ['fixture-gist-1'],
   [Prefixed('Markdown')]: ['fixture-gist-1'],
   [Prefixed('CSS')]: ['fixture-gist-1'],
   [Prefixed('Python')]: ['fixture-gist-2'],
   [Prefixed('Shell')]: ['fixture-gist-3'],
   [Prefixed('Java')]: ['fixture-gist-4'],
+  [Prefixed('PHP')]: ['fixture-gist-5'],
   ui: ['fixture-gist-1'],
-  smoke: ['fixture-gist-1'],
+  smoke: ['fixture-gist-1', 'fixture-gist-5'],
   backend: ['fixture-gist-2', 'fixture-gist-4'],
+  php: ['fixture-gist-5'],
   ops: ['fixture-gist-3']
 }
 
@@ -197,6 +227,11 @@ function getFixtureOverrides (name) {
       return { gistNewModalStatus: 'ON' }
     case 'pinned-tags':
       return { pinnedTagsModalStatus: 'ON' }
+    case 'php-html':
+      return {
+        activeGist: 'fixture-gist-5',
+        activeGistTag: Prefixed('PHP')
+      }
     case 'raw':
       return {
         gistRawModal: {

--- a/tests/containers/codeArea.test.js
+++ b/tests/containers/codeArea.test.js
@@ -24,6 +24,7 @@ describe('CodeArea syntax highlighting', () => {
     expect(adaptedLanguage('shell.sh', 'Shell')).toBe('bash')
     expect(adaptedLanguage('pSolution1.py', 'Python')).toBe('python')
     expect(adaptedLanguage('form.vb', 'Visual Basic')).toBe('vbscript')
+    expect(adaptedLanguage('index.php', 'PHP')).toBe('php')
   })
 
   it('falls back to C highlighting for C source and header file extensions', () => {
@@ -62,6 +63,30 @@ describe('CodeArea syntax highlighting', () => {
     expect(html).toContain('<span class="hljs-keyword">def</span>')
     expect(html).toContain('<span class="hljs-title function_">totalFruit</span>')
     expect(html).toContain('<span class="hljs-keyword">return</span>')
+  })
+
+  it('highlights PHP snippets with embedded HTML using the mixed template grammar', () => {
+    const content = `<html>
+<body>
+<?php echo $message; if ($visible) { ?>
+<div class="notice">Ready</div>
+<?php } ?>
+</body>
+</html>`
+    const html = highlightContent(content, adaptedLanguage('index.php', 'PHP'))
+
+    expect(html).toContain('language-php')
+    expect(html).toContain('language-xml')
+    expect(html).toContain('hljs-tag')
+    expect(html).toContain('hljs-attr')
+    expect(html).toContain('hljs-keyword')
+  })
+
+  it('keeps bare PHP snippets in PHP mode when no PHP opening tag is present', () => {
+    const html = highlightContent('echo $message;', adaptedLanguage('snippet.php', 'PHP'))
+
+    expect(html).toContain('hljs-keyword')
+    expect(html).not.toContain('language-xml')
   })
 
   it('falls back to automatic highlighting for unknown language names', () => {

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -82,6 +82,11 @@ const RENDER_FIXTURES = [
     name: 'immersive',
     selector: '.snippet-panel-immersive .snippet-box',
     text: 'React 19 render fixture'
+  },
+  {
+    name: 'php-html',
+    selector: '.code-area .language-php',
+    text: 'PHP template|index.php|Ready'
   }
 ]
 


### PR DESCRIPTION
## Summary

Fixes #537 by rendering PHP snippets that include `<?php`, `<?=`, or `<?` opening tags with Highlight.js' mixed `php-template` grammar.

- Normalizes GitHub's `PHP` language name to Highlight.js' `php` identifier.
- Switches tagged PHP template content to `php-template` so embedded HTML receives proper tag and attribute highlighting.
- Keeps bare PHP snippets in normal PHP mode when there is no PHP opening tag.
- Adds a seeded `php-html` render fixture and smoke assertion for the mixed-language output.

## Root Cause

The read-only snippet renderer passed GitHub's PHP metadata straight through to Highlight.js' plain PHP grammar. That grammar highlights PHP tokens but treats surrounding HTML as PHP text, so `.php` files with HTML blocks appeared incorrectly colored.

## Validation

- `npm run lint`
- `npm run test:unit`
- `npm run test:build`
- `npm run test:smoke` - includes `electron render fixture smoke test passed: php-html`
- `git diff --check`

## Screenshot

A screenshot of the `php-html` fixture was captured locally by the smoke test at `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-9FYc3P/electron-render-php-html-success.png`. GitHub CLI/REST PR creation does not provide a supported way to upload arbitrary issue attachments from this session, so the screenshot is not embedded in this draft PR.
