### PR TITLE
[codex] Fix Python syntax highlighting

### DIFF
--- a/app/containers/codeArea/highlighting.js
+++ b/app/containers/codeArea/highlighting.js
@@ -30,6 +30,10 @@ export function adaptedLanguage (filename, lang) {
     case 'zshrc':
       language = 'bash'
       break
+    case 'py':
+    case 'pyw':
+      language = 'python'
+      break
     case 'sql':
       language = 'sql'
       break
@@ -48,6 +52,7 @@ export function adaptedLanguage (filename, lang) {
   //  expressed as 'cs' to be recognized by Highlight.js.
   switch (language) {
     case 'Shell': return 'bash'
+    case 'Python': return 'python'
     case 'C': return 'c'
     case 'C++': return 'cpp'
     case 'C#': return 'cs'

--- a/tests/containers/codeArea.test.js
+++ b/tests/containers/codeArea.test.js
@@ -6,6 +6,11 @@ import {
 } from '../../app/containers/codeArea/highlighting'
 
 const cSource = '#include<stdio.h>\n\nint main(void) {\n    printf("Hello World\\n");\n    return 0;\n}'
+const typedReturnPythonSource = [
+  'class Solution:',
+  '    def totalFruit(self, fruits: List[int]) -> int:',
+  '        return len(fruits)'
+].join('\n')
 
 describe('CodeArea syntax highlighting', () => {
   it('normalizes GitHub language names for Highlight.js', () => {
@@ -17,6 +22,7 @@ describe('CodeArea syntax highlighting', () => {
     expect(adaptedLanguage('script.bat', 'Batchfile')).toBe('dos')
     expect(adaptedLanguage('App.vue', 'Vue')).toBe('xml')
     expect(adaptedLanguage('shell.sh', 'Shell')).toBe('bash')
+    expect(adaptedLanguage('pSolution1.py', 'Python')).toBe('python')
     expect(adaptedLanguage('form.vb', 'Visual Basic')).toBe('vbscript')
   })
 
@@ -29,6 +35,8 @@ describe('CodeArea syntax highlighting', () => {
     expect(adaptedLanguage('.leptonrc')).toBe('json')
     expect(adaptedLanguage('setup.CMD')).toBe('dos')
     expect(adaptedLanguage('.zshrc')).toBe('bash')
+    expect(adaptedLanguage('pSolution1.py')).toBe('python')
+    expect(adaptedLanguage('script.PYW')).toBe('python')
     expect(adaptedLanguage('query.SQL')).toBe('sql')
     expect(adaptedLanguage('Contract.sol')).toBe('solidity')
     expect(adaptedLanguage('Contract.solidity')).toBe('solidity')
@@ -46,6 +54,14 @@ describe('CodeArea syntax highlighting', () => {
     expect(html).toContain('hljs-keyword')
     expect(html).toContain('hljs-string')
     expect(html).toContain('&lt;stdio.h&gt;')
+  })
+
+  it('renders Python functions with return annotations using Python highlighting', () => {
+    const html = highlightContent(typedReturnPythonSource, adaptedLanguage('pSolution1.py'))
+
+    expect(html).toContain('<span class="hljs-keyword">def</span>')
+    expect(html).toContain('<span class="hljs-title function_">totalFruit</span>')
+    expect(html).toContain('<span class="hljs-keyword">return</span>')
   })
 
   it('falls back to automatic highlighting for unknown language names', () => {


### PR DESCRIPTION
## Summary

Fixes Python snippet highlighting in the read-only code view for files such as `.py` / `.pyw`, including functions with return annotations.

- Maps Python file extensions to Highlight.js `python` mode when GitHub language metadata is missing.
- Normalizes GitHub's `Python` language label to Highlight.js `python`.
- Adds regression coverage for a Python function using a typed return annotation, matching the failure mode from issue #532.

## Root Cause

The editor uses CodeMirror and resolves modes from filenames, while the read-only snippet view uses Highlight.js. When the read-only highlighter falls back to auto-detection or receives unnormalized metadata, typed Python snippets can be misclassified or rendered without expected Python spans.

Fixes #532.

## Validation

- `npm run test:unit -- tests/containers/codeArea.test.js`
- `git diff --check`
- `npm run test:smoke`

## Renderer Verification

I ran the local Electron renderer smoke test with a temporary fixture for the issue sample:

```python
class Solution:
    def totalFruit(self, fruits: List[int]) -> int:
        return len(fruits)
```

The smoke test asserted the rendered DOM contained `.code-area .hljs-title.function_` and visible text `totalFruit|return len`, confirming the renderer produced Highlight.js Python markup instead of plain text. The generated screenshot showed `class`, `def`, `totalFruit`, `List`, and `return` highlighted correctly. The temporary fixture changes were removed after validation; this PR branch remains clean at the committed fix.
