### PR TITLE
[codex] Render emoji shortcodes in markdown

### DIFF
--- a/app/utilities/markdown/index.js
+++ b/app/utilities/markdown/index.js
@@ -1,5 +1,6 @@
 import HighlightJS from 'highlight.js'
 import MarkdownIt from 'markdown-it'
+import { full as MdEmoji } from 'markdown-it-emoji'
 import MdTaskList from 'markdown-it-task-lists'
 import MdKatex from 'markdown-it-katex'
 
@@ -15,6 +16,7 @@ const Md = MarkdownIt({
     return HighlightJS.highlightAuto(str).value
   }
 })
+  .use(MdEmoji)
   .use(MdTaskList)
   .use(MdKatex, { throwOnError: false, errorColor: ' #cc0000' })
 

--- a/license.json
+++ b/license.json
@@ -2182,6 +2182,12 @@
     "path": "/Users/cosmoqiu/Projects/Lepton/node_modules/markdown-it-katex",
     "licenseFile": "node_modules/markdown-it-katex/LICENSE"
   },
+  "markdown-it-emoji@3.0.0": {
+    "licenses": "MIT",
+    "repository": "https://github.com/markdown-it/markdown-it-emoji",
+    "path": "/Users/cosmoqiu/Projects/Lepton/node_modules/markdown-it-emoji",
+    "licenseFile": "node_modules/markdown-it-emoji/LICENSE"
+  },
   "markdown-it-task-lists@2.1.1": {
     "licenses": "ISC",
     "repository": "https://github.com/revin/markdown-it-task-lists",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "highlightjs-solidity": "^1.0.6",
         "human-readable-time": "^0.3.0",
         "markdown-it": "^12.0.0",
+        "markdown-it-emoji": "^3.0.0",
         "markdown-it-katex": "^2.0.3",
         "markdown-it-task-lists": "^2.1.1",
         "moment": "^2.22.2",
@@ -9744,6 +9745,12 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
+    },
+    "node_modules/markdown-it-emoji": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-3.0.0.tgz",
+      "integrity": "sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==",
+      "license": "MIT"
     },
     "node_modules/markdown-it-katex": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "highlightjs-solidity": "^1.0.6",
     "human-readable-time": "^0.3.0",
     "markdown-it": "^12.0.0",
+    "markdown-it-emoji": "^3.0.0",
     "markdown-it-katex": "^2.0.3",
     "markdown-it-task-lists": "^2.1.1",
     "moment": "^2.22.2",

--- a/tests/utilities/markdown.test.js
+++ b/tests/utilities/markdown.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import Markdown from '../../app/utilities/markdown'
+
+describe('markdown utility', () => {
+  it('renders GitHub-style emoji shortcodes as unicode emoji', () => {
+    const html = Markdown.render('Ship it :tada: :rocket:')
+
+    expect(html).toContain('\u{1F389}')
+    expect(html).toContain('\u{1F680}')
+    expect(html).not.toContain(':tada:')
+    expect(html).not.toContain(':rocket:')
+  })
+
+  it('does not replace emoji shortcodes inside inline code', () => {
+    const html = Markdown.render('Use `:tada:` in docs')
+
+    expect(html).toContain('<code>:tada:</code>')
+  })
+})


### PR DESCRIPTION
## Summary

Adds GitHub-style emoji shortcode rendering for Markdown snippets.

- Wires `markdown-it-emoji` into the shared Markdown renderer.
- Adds regression coverage for shortcode rendering and inline-code preservation.
- Updates dependency, lockfile, and license metadata for the new production dependency.

## Why

Closes #338. Markdown previews previously left emoji aliases such as `:tada:` as plain text instead of rendering them as emoji.

## Validation

Run under Node `v24.18.0` / npm `11.16.0` from `.nvmrc`:

- `npm run test:unit`
- `npm run lint`
- `npm run test:build`

`npm run test:build` still emits the existing Sass legacy JS API deprecation warnings and CodeMirror dynamic require warning, but the webpack build completes successfully.
