### PR TITLE
[codex] Render safe Markdown HTML and add anchor links

### DIFF
--- a/app/utilities/markdown/index.js
+++ b/app/utilities/markdown/index.js
@@ -4,6 +4,43 @@ import MdTaskList from 'markdown-it-task-lists'
 import MdKatex from 'markdown-it-katex'
 import sanitizeHtml, { sanitizeInlineHtml } from './sanitizeHtml'
 
+const htmlTagPattern = /<[!/a-z].*?>/ig
+const punctuationPattern = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g
+
+function getHeadingText (token) {
+  if (!token) return ''
+  if (!token.children) return token.content
+
+  return token.children.map(child => {
+    return child.type === 'html_inline'
+      ? child.content.replace(htmlTagPattern, '')
+      : child.content
+  }).join('')
+}
+
+function createHeadingId (text) {
+  const id = text
+    .trim()
+    .toLowerCase()
+    .replace(htmlTagPattern, '')
+    .replace(punctuationPattern, '')
+    .replace(/\s+/g, '-')
+
+  return id || 'heading'
+}
+
+function createUniqueHeadingId (id, env) {
+  const renderEnv = env || {}
+
+  if (!renderEnv.headingIds) {
+    renderEnv.headingIds = Object.create(null)
+  }
+
+  const count = renderEnv.headingIds[id] || 0
+  renderEnv.headingIds[id] = count + 1
+  return count === 0 ? id : `${id}-${count}`
+}
+
 // Configure markdown-it
 const Md = MarkdownIt({
   html: true,
@@ -22,5 +59,13 @@ const Md = MarkdownIt({
 
 Md.renderer.rules.html_block = (tokens, idx) => sanitizeHtml(tokens[idx].content)
 Md.renderer.rules.html_inline = (tokens, idx) => sanitizeInlineHtml(tokens[idx].content)
+
+Md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
+  const headingText = getHeadingText(tokens[idx + 1])
+  const headingId = createUniqueHeadingId(createHeadingId(headingText), env)
+
+  tokens[idx].attrSet('id', headingId)
+  return self.renderToken(tokens, idx, options)
+}
 
 export default Md

--- a/app/utilities/markdown/index.js
+++ b/app/utilities/markdown/index.js
@@ -2,9 +2,11 @@ import HighlightJS from 'highlight.js'
 import MarkdownIt from 'markdown-it'
 import MdTaskList from 'markdown-it-task-lists'
 import MdKatex from 'markdown-it-katex'
+import sanitizeHtml, { sanitizeInlineHtml } from './sanitizeHtml'
 
 // Configure markdown-it
 const Md = MarkdownIt({
+  html: true,
   linkify: true,
   highlight: (str, lang) => {
     if (lang && HighlightJS.getLanguage(lang)) {
@@ -17,5 +19,8 @@ const Md = MarkdownIt({
 })
   .use(MdTaskList)
   .use(MdKatex, { throwOnError: false, errorColor: ' #cc0000' })
+
+Md.renderer.rules.html_block = (tokens, idx) => sanitizeHtml(tokens[idx].content)
+Md.renderer.rules.html_inline = (tokens, idx) => sanitizeInlineHtml(tokens[idx].content)
 
 export default Md

--- a/app/utilities/markdown/sanitizeHtml.js
+++ b/app/utilities/markdown/sanitizeHtml.js
@@ -1,0 +1,269 @@
+const ELEMENT_NODE = 1
+const COMMENT_NODE = 8
+
+const VOID_TAGS = new Set([
+  'br',
+  'col',
+  'hr',
+  'img',
+  'input'
+])
+
+const ALLOWED_TAGS = new Set([
+  'a',
+  'abbr',
+  'b',
+  'blockquote',
+  'br',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'dd',
+  'del',
+  'details',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'li',
+  'mark',
+  'ol',
+  'p',
+  'pre',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+  'var'
+])
+
+const DROP_CONTENT_TAGS = new Set([
+  'base',
+  'button',
+  'embed',
+  'form',
+  'iframe',
+  'link',
+  'meta',
+  'object',
+  'script',
+  'select',
+  'style',
+  'textarea'
+])
+
+const GLOBAL_ATTRIBUTES = new Set([
+  'class',
+  'dir',
+  'id',
+  'lang',
+  'title'
+])
+
+const TAG_ATTRIBUTES = {
+  a: new Set(['href']),
+  blockquote: new Set(['cite']),
+  col: new Set(['span', 'width']),
+  colgroup: new Set(['span', 'width']),
+  del: new Set(['cite', 'datetime']),
+  details: new Set(['open']),
+  img: new Set(['alt', 'height', 'src', 'width']),
+  input: new Set(['checked', 'disabled', 'type']),
+  ins: new Set(['cite', 'datetime']),
+  li: new Set(['value']),
+  ol: new Set(['start', 'type']),
+  q: new Set(['cite']),
+  td: new Set(['align', 'colspan', 'rowspan']),
+  th: new Set(['align', 'colspan', 'rowspan'])
+}
+
+const URL_ATTRIBUTES = new Set([
+  'cite',
+  'href',
+  'src'
+])
+
+const SAFE_PROTOCOLS = new Set([
+  'http',
+  'https',
+  'mailto',
+  'tel'
+])
+
+function escapeHtml (html) {
+  return html
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function escapeAttribute (value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+}
+
+function removeNode (node) {
+  node.parentNode && node.parentNode.removeChild(node)
+}
+
+function unwrapNode (node) {
+  const parent = node.parentNode
+  if (!parent) return
+
+  while (node.firstChild) {
+    parent.insertBefore(node.firstChild, node)
+  }
+  parent.removeChild(node)
+}
+
+function isAllowedAttribute (tagName, attributeName) {
+  return GLOBAL_ATTRIBUTES.has(attributeName) ||
+    (TAG_ATTRIBUTES[tagName] && TAG_ATTRIBUTES[tagName].has(attributeName))
+}
+
+function removeUnsafeUrlCharacters (url) {
+  let normalized = ''
+  for (let idx = 0; idx < url.length; idx++) {
+    const char = url[idx]
+    const charCode = char.charCodeAt(0)
+    if (charCode > 31 && charCode !== 127 && char.trim() !== '') {
+      normalized += char
+    }
+  }
+  return normalized
+}
+
+function isSafeUrl (url) {
+  const normalized = removeUnsafeUrlCharacters(url.trim()).toLowerCase()
+  if (!normalized || normalized.startsWith('#')) return true
+
+  const protocolMatch = normalized.match(/^([a-z0-9.+-]+):/)
+  return !protocolMatch || SAFE_PROTOCOLS.has(protocolMatch[1])
+}
+
+function sanitizeAttributes (element, tagName) {
+  Array.from(element.attributes).forEach(attribute => {
+    const attributeName = attribute.name.toLowerCase()
+
+    if (
+      attributeName.startsWith('on') ||
+      attributeName === 'style' ||
+      attributeName === 'srcdoc' ||
+      !isAllowedAttribute(tagName, attributeName) ||
+      (URL_ATTRIBUTES.has(attributeName) && !isSafeUrl(attribute.value))
+    ) {
+      element.removeAttribute(attribute.name)
+    }
+  })
+
+  if (tagName === 'input') {
+    if (element.getAttribute('type') !== 'checkbox') {
+      element.setAttribute('type', 'checkbox')
+    }
+    element.setAttribute('disabled', '')
+  }
+}
+
+function sanitizeNode (node) {
+  Array.from(node.childNodes).forEach(child => {
+    if (child.nodeType === COMMENT_NODE) {
+      removeNode(child)
+      return
+    }
+
+    if (child.nodeType !== ELEMENT_NODE) return
+
+    const tagName = child.tagName.toLowerCase()
+    if (!ALLOWED_TAGS.has(tagName)) {
+      if (DROP_CONTENT_TAGS.has(tagName)) {
+        removeNode(child)
+      } else {
+        sanitizeNode(child)
+        unwrapNode(child)
+      }
+      return
+    }
+
+    sanitizeAttributes(child, tagName)
+    sanitizeNode(child)
+  })
+}
+
+function openingTagForElement (element, tagName) {
+  const attributes = Array.from(element.attributes)
+    .map(attribute => {
+      if (attribute.value === '') return ` ${attribute.name}`
+      return ` ${attribute.name}="${escapeAttribute(attribute.value)}"`
+    })
+    .join('')
+
+  return `<${tagName}${attributes}>`
+}
+
+export function sanitizeInlineHtml (html) {
+  const closingTag = html.match(/^<\/\s*([A-Za-z][A-Za-z0-9-]*)\s*>$/)
+  if (closingTag) {
+    const tagName = closingTag[1].toLowerCase()
+    return ALLOWED_TAGS.has(tagName) && !VOID_TAGS.has(tagName) ? `</${tagName}>` : ''
+  }
+
+  const openingTag = html.match(/^<\s*([A-Za-z][A-Za-z0-9-]*)([\s\S]*?)\/?\s*>$/)
+  if (!openingTag) return escapeHtml(html)
+
+  const tagName = openingTag[1].toLowerCase()
+  if (!ALLOWED_TAGS.has(tagName)) return ''
+
+  if (typeof document === 'undefined' || !document.createElement) {
+    return escapeHtml(html)
+  }
+
+  const template = document.createElement('template')
+  template.innerHTML = `<${tagName}${openingTag[2]}></${tagName}>`
+  sanitizeNode(template.content)
+
+  const element = template.content.firstElementChild
+  return element ? openingTagForElement(element, tagName) : ''
+}
+
+export default function sanitizeHtml (html) {
+  if (typeof document === 'undefined' || !document.createElement) {
+    return escapeHtml(html)
+  }
+
+  const template = document.createElement('template')
+  template.innerHTML = html
+  sanitizeNode(template.content)
+  return template.innerHTML
+}


### PR DESCRIPTION
## Summary

Consolidates #591 and adds markdown heading anchors so GitHub-style table-of-contents links such as `[Heading stuff](#heading-stuff)` have real in-preview targets.

- Enables safe raw HTML rendering for markdown through a small sanitizer helper.
- Adds GitHub-style heading slug generation and duplicate heading IDs.
- Keeps existing task list, KaTeX, linkify, and syntax highlighting behavior intact.

## Root Cause

Lepton rendered markdown hash links, but the markdown renderer did not assign matching `id` attributes to headings. Chromium therefore had no same-page target to scroll to when a TOC link was clicked.

Allowing markdown raw HTML also requires sanitizing rendered HTML so unsafe tags, event handlers, styles, and unsafe URL protocols are stripped before injection.

Fixes #226.
Supersedes #591.

## Validation

- `npm run lint`
- `npm test` - 17 files / 86 tests plus webpack development build
- `git diff --check`

## Notes

Webpack still emits existing Dart Sass legacy JS API deprecation warnings and the CodeMirror dynamic require warning during the development build.
