### PR TITLE
[codex] Add clickable Markdown task lists

### DIFF
--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -32,6 +32,34 @@ resolveHighlightLanguage(hljsDefineSolidity)(HighlightJS) // register solidity t
 resolveHighlightLanguage(hljsDefineGraphQL)(HighlightJS) // register graphql to hightlight.js
 
 export default class CodeArea extends Component {
+  handleMarkdownTaskListItemClicked (event) {
+    const { onMarkdownTaskListItemToggle } = this.props
+    const target = event.target
+    if (
+      !onMarkdownTaskListItemToggle ||
+      !target ||
+      !target.classList ||
+      !target.classList.contains('task-list-item-checkbox')
+    ) {
+      return
+    }
+
+    const checkboxes = Array.from(event.currentTarget.querySelectorAll('.task-list-item-checkbox'))
+    const taskIndex = checkboxes.indexOf(target)
+    if (taskIndex < 0) return
+
+    const previousChecked = !target.checked
+    target.disabled = true
+
+    Promise.resolve(onMarkdownTaskListItemToggle(taskIndex, target.checked))
+      .catch(() => {
+        target.checked = previousChecked
+      })
+      .finally(() => {
+        target.disabled = false
+      })
+  }
+
   createJupyterNotebookCodeBlock (content, language, kTabLength) {
     try {
       const result = electronBridge.notebook.render(content)
@@ -105,6 +133,7 @@ export default class CodeArea extends Component {
     }
     return (
       <div className='code-area'
+        onClick={ this.handleMarkdownTaskListItemClicked.bind(this) }
         dangerouslySetInnerHTML={ { __html: htmlContent } }/>
     )
   }

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -14,6 +14,7 @@ import React, { Component } from 'react'
 import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
 import { t } from '../../utilities/i18n'
 import TagBadges from '../tagBadges'
+import { toggleMarkdownTaskListItem } from '../../utilities/markdown/taskList'
 import {
   getRegularTagsForGist,
   shouldColorTags
@@ -169,6 +170,33 @@ class Snippet extends Component {
       .catch((err) => {
         notifyFailure(t('notification.gistUpdateFailed'))
         logger.error(JSON.stringify(err))
+      })
+      .then((response) => {
+        this.updateGistsStoreWithUpdatedGist(response)
+      })
+  }
+
+  handleMarkdownTaskListItemToggle (activeSnippet, gistFile, taskIndex, checked) {
+    const { accessToken, activeGist } = this.props
+    const updatedContent = toggleMarkdownTaskListItem(gistFile.content, taskIndex, checked)
+
+    if (updatedContent === gistFile.content) {
+      return Promise.resolve()
+    }
+
+    return getGitHubApi(EDIT_SINGLE_GIST)(
+      accessToken,
+      activeGist,
+      activeSnippet.details.description,
+      {
+        [gistFile.filename]: {
+          content: updatedContent
+        }
+      })
+      .catch((err) => {
+        notifyFailure(t('notification.gistUpdateFailed'))
+        logger.error(JSON.stringify(err))
+        throw err
       })
       .then((response) => {
         this.updateGistsStoreWithUpdatedGist(response)
@@ -565,7 +593,12 @@ class Snippet extends Component {
             </div>
             <Collapse in={ isExpanded }>
               <div className='collapsable-code-area'>
-                <CodeArea filename={gistFile.filename} content={gistFile.content} language={gistFile.language} kTabLength={kTabLength}/>
+                <CodeArea
+                  filename={gistFile.filename}
+                  content={gistFile.content}
+                  language={gistFile.language}
+                  kTabLength={kTabLength}
+                  onMarkdownTaskListItemToggle={ this.handleMarkdownTaskListItemToggle.bind(this, activeSnippet, gistFile) }/>
               </div>
             </Collapse>
           </div>

--- a/app/utilities/markdown/index.js
+++ b/app/utilities/markdown/index.js
@@ -17,7 +17,7 @@ const Md = MarkdownIt({
   }
 })
   .use(MdEmoji)
-  .use(MdTaskList)
+  .use(MdTaskList, { enabled: true })
   .use(MdKatex, { throwOnError: false, errorColor: ' #cc0000' })
 
 export default Md

--- a/app/utilities/markdown/taskList.js
+++ b/app/utilities/markdown/taskList.js
@@ -1,0 +1,21 @@
+const taskListItemPattern = /^(\s*(?:[-+*]|\d+[.)])\s+\[)([ xX])(\]\s+)/
+
+export function toggleMarkdownTaskListItem (content, taskIndex, checked) {
+  if (taskIndex < 0) return content
+
+  let currentTaskIndex = -1
+  const lineParts = content.split(/(\r\n|\n|\r)/)
+
+  for (let idx = 0; idx < lineParts.length; idx += 2) {
+    const line = lineParts[idx]
+    if (!taskListItemPattern.test(line)) continue
+
+    currentTaskIndex += 1
+    if (currentTaskIndex !== taskIndex) continue
+
+    lineParts[idx] = line.replace(taskListItemPattern, `$1${checked ? 'x' : ' '}$3`)
+    return lineParts.join('')
+  }
+
+  return content
+}

--- a/tests/utilities/markdown.test.js
+++ b/tests/utilities/markdown.test.js
@@ -17,4 +17,13 @@ describe('markdown utility', () => {
 
     expect(html).toContain('<code>:tada:</code>')
   })
+
+  it('renders task list checkboxes as clickable inputs', () => {
+    const html = Markdown.render('- [ ] open\n- [x] done')
+
+    expect(html).toContain('class="task-list-item enabled"')
+    expect(html).toContain('class="task-list-item-checkbox"type="checkbox"')
+    expect(html).toContain('class="task-list-item-checkbox" checked=""type="checkbox"')
+    expect(html).not.toContain('disabled')
+  })
 })

--- a/tests/utilities/markdownTaskList.test.js
+++ b/tests/utilities/markdownTaskList.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { toggleMarkdownTaskListItem } from '../../app/utilities/markdown/taskList'
+
+describe('Markdown task list utilities', () => {
+  it('checks and unchecks a task by rendered checkbox order', () => {
+    const source = [
+      '- [ ] first',
+      '- [x] second',
+      '  - [ ] nested'
+    ].join('\n')
+
+    expect(toggleMarkdownTaskListItem(source, 0, true)).toBe([
+      '- [x] first',
+      '- [x] second',
+      '  - [ ] nested'
+    ].join('\n'))
+
+    expect(toggleMarkdownTaskListItem(source, 1, false)).toBe([
+      '- [ ] first',
+      '- [ ] second',
+      '  - [ ] nested'
+    ].join('\n'))
+  })
+
+  it('supports ordered task list items', () => {
+    const source = [
+      '1. [ ] one',
+      '2. [X] two'
+    ].join('\n')
+
+    expect(toggleMarkdownTaskListItem(source, 1, false)).toBe([
+      '1. [ ] one',
+      '2. [ ] two'
+    ].join('\n'))
+  })
+
+  it('preserves source line endings', () => {
+    const source = '- [ ] first\r\n- [ ] second\r\n'
+
+    expect(toggleMarkdownTaskListItem(source, 1, true)).toBe('- [ ] first\r\n- [x] second\r\n')
+  })
+
+  it('leaves content unchanged when the task index is missing', () => {
+    const source = '- [ ] first'
+
+    expect(toggleMarkdownTaskListItem(source, 2, true)).toBe(source)
+    expect(toggleMarkdownTaskListItem(source, -1, true)).toBe(source)
+  })
+})


### PR DESCRIPTION
## Summary

Adds clickable Markdown task-list checkboxes in rendered snippet previews and persists each toggle back to the backing Gist file.

## Changes

- Enables `markdown-it-task-lists` checkbox inputs in preview output.
- Handles checkbox clicks from the rendered Markdown view and maps the clicked item to the matching source task marker by rendered order.
- Rewrites only the selected Markdown task marker while preserving list formatting and line endings.
- Saves the updated file through the existing single-gist update flow and refreshes the local gist store.
- Adds unit coverage for task-list marker rewriting and rendered checkbox behavior.

## Validation

- `npm run lint`
- `npm test` - 21 test files / 103 tests plus webpack development build
- `git diff --check`

Fixes #471.

## Notes

Rebased onto latest `origin/master` at `75a47d5`.

Webpack still emits existing Dart Sass legacy JS API deprecation warnings and the CodeMirror dynamic require warning during the development build.
