### PR TITLE
[codex] Add AsciiDoc rendering support

### DIFF
--- a/app/containers/codeArea/highlighting.js
+++ b/app/containers/codeArea/highlighting.js
@@ -24,6 +24,10 @@ export function adaptedLanguage (filename, lang) {
   // Adjust the language based on file extensions.
   const filenameExtension = filename && filename.split('.').pop().toLowerCase()
   switch (filenameExtension) {
+    case 'adoc':
+    case 'asciidoc':
+      language = 'AsciiDoc'
+      break
     case 'c':
     case 'h':
       if (!lang) language = 'c'

--- a/app/containers/codeArea/index.js
+++ b/app/containers/codeArea/index.js
@@ -1,6 +1,7 @@
 import HighlightJS from 'highlight.js'
 import hljsDefineSolidity from 'highlightjs-solidity'
 import hljsDefineGraphQL from 'highlightjs-graphql'
+import AsciiDoc from '../../utilities/asciidoc'
 import Markdown from '../../utilities/markdown'
 import React, { Component } from 'react'
 import electronBridge from '../../utilities/electronBridge'
@@ -48,6 +49,15 @@ export default class CodeArea extends Component {
     return `<div class='markdown-section'>${Markdown.render(content)}</div>`
   }
 
+  createAsciiDocCodeBlock (content, language, kTabLength) {
+    try {
+      return `<div class='markdown-section asciidoc-section'>${AsciiDoc.render(content)}</div>`
+    } catch (err) {
+      logger.error(`Failed to render AsciiDoc content with err ${err}`)
+      return this.createHighlightedCodeBlock(content, language, kTabLength)
+    }
+  }
+
   createHighlightedCodeBlock (content, language, kTabLength) {
     let lineNumber = 0
     const highlightedContent = highlightContent(content, language)
@@ -86,6 +96,9 @@ export default class CodeArea extends Component {
         break
       case 'Markdown':
         htmlContent = this.createMarkdownCodeBlock(content)
+        break
+      case 'AsciiDoc':
+        htmlContent = this.createAsciiDocCodeBlock(content, language, kTabLength)
         break
       default:
         htmlContent = this.createHighlightedCodeBlock(content, language, kTabLength)

--- a/app/containers/codeArea/markdown.scss
+++ b/app/containers/codeArea/markdown.scss
@@ -394,3 +394,67 @@
      margin: 0 auto;
    }
  }
+
+.markdown-section.asciidoc-section {
+  .sect1 {
+    margin: 20px 0;
+  }
+
+  .sect1 + .sect1 {
+    border-top: 1px solid var(--border-color);
+    padding-top: 15px;
+  }
+
+  .sectionbody > :last-child,
+  .paragraph > :last-child,
+  .ulist > :last-child,
+  .olist > :last-child,
+  .listingblock > :last-child,
+  .admonitionblock > :last-child {
+    margin-bottom: 0;
+  }
+
+  .listingblock {
+    margin: 15px 0;
+
+    .content {
+      margin: 0;
+    }
+
+    pre {
+      overflow: auto;
+      word-break: normal;
+    }
+
+    code {
+      display: block;
+      white-space: pre;
+    }
+  }
+
+  .admonitionblock {
+    margin: 15px 0;
+
+    table {
+      border: 0;
+      margin: 0;
+    }
+
+    td {
+      border: 0;
+      vertical-align: top;
+    }
+
+    .icon {
+      color: var(--text-secondary);
+      font-weight: bold;
+      text-transform: uppercase;
+      width: 90px;
+    }
+
+    .content {
+      border-left: 4px solid #dddddd;
+      color: #777777;
+    }
+  }
+}

--- a/app/utilities/asciidoc/index.js
+++ b/app/utilities/asciidoc/index.js
@@ -1,0 +1,91 @@
+import Asciidoctor from '@asciidoctor/core'
+
+const asciidoctor = Asciidoctor()
+const blockedTagNames = new Set([
+  'applet',
+  'base',
+  'button',
+  'embed',
+  'form',
+  'iframe',
+  'input',
+  'link',
+  'math',
+  'meta',
+  'object',
+  'option',
+  'script',
+  'select',
+  'style',
+  'svg',
+  'textarea'
+])
+const urlAttributeNames = new Set([
+  'action',
+  'formaction',
+  'href',
+  'src',
+  'xlink:href'
+])
+const safeUrlProtocols = new Set([
+  'http:',
+  'https:',
+  'mailto:'
+])
+
+function isSafeUrl (value) {
+  const trimmedValue = value.trim()
+  if (trimmedValue.startsWith('#') || !/^[a-z][a-z0-9+.-]*:/i.test(trimmedValue)) {
+    return true
+  }
+
+  try {
+    return safeUrlProtocols.has(new URL(trimmedValue).protocol)
+  } catch (err) {
+    return false
+  }
+}
+
+function sanitizeHtml (html) {
+  if (typeof document === 'undefined') return html
+
+  const template = document.createElement('template')
+  template.innerHTML = html
+
+  Array.from(template.content.querySelectorAll('*')).forEach(node => {
+    const tagName = node.tagName.toLowerCase()
+    if (blockedTagNames.has(tagName)) {
+      node.parentNode && node.parentNode.removeChild(node)
+      return
+    }
+
+    Array.from(node.attributes).forEach(attribute => {
+      const attributeName = attribute.name.toLowerCase()
+      if (
+        attributeName.startsWith('on') ||
+        attributeName === 'style' ||
+        attributeName === 'srcdoc' ||
+        (urlAttributeNames.has(attributeName) && !isSafeUrl(attribute.value))
+      ) {
+        node.removeAttribute(attribute.name)
+      }
+    })
+  })
+
+  return template.innerHTML
+}
+
+const AsciiDoc = {
+  render (content) {
+    const renderedHtml = asciidoctor.convert(content || '', {
+      safe: 'secure',
+      attributes: {
+        showtitle: true,
+        'source-highlighter': 'highlight.js'
+      }
+    })
+    return sanitizeHtml(renderedHtml)
+  }
+}
+
+export default AsciiDoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.10.1-alpha.1",
       "license": "MIT",
       "dependencies": {
+        "@asciidoctor/core": "^2.2.9",
         "autolinker": "^3.14.1",
         "bluebird": "^3.5.3",
         "boring-avatars": "^1.5.8",
@@ -96,6 +97,21 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asciidoctor/core": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.9.tgz",
+      "integrity": "sha512-tIPRHo1T2SFmAm+j77cDsj0RuaszP7xJxsaVTTAF5CwKyTbazw9TnIVlpIWM5yWfIWAWcAZy92RcnPgMJwny1w==",
+      "license": "MIT",
+      "dependencies": {
+        "asciidoctor-opal-runtime": "0.3.4",
+        "unxhr": "~1.2"
+      },
+      "engines": {
+        "node": ">=8.11",
+        "npm": ">=5.0.0",
+        "yarn": ">=1.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2520,6 +2536,41 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
@@ -4248,6 +4299,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asciidoctor-opal-runtime": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.4.tgz",
+      "integrity": "sha512-zqd6zn1LV+PZ69AP/kEbB00zuPHMIAJY3IX8+aZV+X1qOwatYvKGjsMmdMc5ApfhtkjZ4mYkqiTPJWnEnBiMJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "~3.3",
+        "unxhr": "~1.2"
+      },
+      "engines": {
+        "node": ">=8.11"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -4574,6 +4638,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -4905,8 +4981,7 @@
     "node_modules/chart.js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-1.1.1.tgz",
-      "integrity": "sha512-1lcx4nsmYk3C50xMWFucOccdU7jh+RoHP25IiPlUoE6Qf317my+Nm48JOyPFrBRscqy6O4kkxif+omPKPkqWMA==",
-      "peer": true
+      "integrity": "sha512-1lcx4nsmYk3C50xMWFucOccdU7jh+RoHP25IiPlUoE6Qf317my+Nm48JOyPFrBRscqy6O4kkxif+omPKPkqWMA=="
     },
     "node_modules/check-outdated": {
       "version": "2.11.0",
@@ -7196,6 +7271,22 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7229,6 +7320,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -7378,6 +7478,18 @@
       "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-cache-dir": {
@@ -7806,7 +7918,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8527,7 +8638,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8579,7 +8689,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -8609,6 +8718,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -9827,6 +9945,40 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -11119,6 +11271,26 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -11828,6 +12000,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -11899,6 +12081,29 @@
         "@rolldown/binding-wasm32-wasi": "1.1.3",
         "@rolldown/binding-win32-arm64-msvc": "1.1.3",
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -13330,6 +13535,18 @@
         "tmp": "^0.2.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -13692,6 +13909,15 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/unxhr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.11"
       }
     },
     "node_modules/unzipper": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
+    "@asciidoctor/core": "^2.2.9",
     "autolinker": "^3.14.1",
     "bluebird": "^3.5.3",
     "boring-avatars": "^1.5.8",


### PR DESCRIPTION
## Summary

Adds rendered preview support for AsciiDoc gist files.

- Adds `@asciidoctor/core` and a scoped AsciiDoc rendering utility.
- Renders `.adoc` and `.asciidoc` files through Asciidoctor instead of the generic highlighted-code view.
- Reuses the existing markdown preview surface with scoped styles for AsciiDoc sections, listings, admonitions, and tables.
- Sanitizes rendered AsciiDoc HTML before injecting it into the renderer.

## Issue

Closes #289

Original issue: https://github.com/hackjutsu/Lepton/issues/289

## Validation

- `npm run lint`
- `npm test`
- `git diff --check`

Note: `npm test` still emits the existing missing `configs/account` warning in this local checkout.
