### PR TITLE
[codex] Fix snippet sorting for empty values

### DIFF
--- a/app/containers/navigationPanelDetails/index.js
+++ b/app/containers/navigationPanelDetails/index.js
@@ -10,6 +10,7 @@ import {
   shouldColorTags,
   shouldShowTagsInSnippetList
 } from '../tagBadges/tags'
+import { compareGists } from './sorting'
 
 import './index.scss'
 
@@ -112,11 +113,7 @@ class NavigationPanelDetails extends Component {
 
     const sortingKey = conf.get('snippet:sorting')
     const sortingReverse = conf.get('snippet:sortingReverse')
-    if (sortingReverse) {
-      rawGists.sort((g1, g2) => g2.brief[sortingKey].localeCompare(g1.brief[sortingKey]))
-    } else {
-      rawGists.sort((g1, g2) => g1.brief[sortingKey].localeCompare(g2.brief[sortingKey]))
-    }
+    rawGists.sort(compareGists(sortingKey, sortingReverse))
 
     rawGists.forEach((gist) => {
       const firstFilename = Object.keys(gist.brief.files)[0]

--- a/app/containers/navigationPanelDetails/sorting.js
+++ b/app/containers/navigationPanelDetails/sorting.js
@@ -1,0 +1,16 @@
+export function getSortableValue (gist, sortingKey) {
+  const value = gist && gist.brief ? gist.brief[sortingKey] : ''
+  return value === null || value === undefined ? '' : String(value)
+}
+
+export function compareGists (sortingKey, sortingReverse) {
+  return (g1, g2) => {
+    const firstValue = getSortableValue(g1, sortingKey)
+    const secondValue = getSortableValue(g2, sortingKey)
+
+    if (sortingReverse) {
+      return secondValue.localeCompare(firstValue)
+    }
+    return firstValue.localeCompare(secondValue)
+  }
+}

--- a/tests/containers/navigationPanelDetails.test.js
+++ b/tests/containers/navigationPanelDetails.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compareGists,
+  getSortableValue
+} from '../../app/containers/navigationPanelDetails/sorting'
+
+function gist (id, brief) {
+  return {
+    brief: {
+      id,
+      ...brief
+    }
+  }
+}
+
+describe('navigation panel detail sorting', () => {
+  it('normalizes missing sort values before comparing', () => {
+    expect(getSortableValue(gist('missing', {}), 'description')).toBe('')
+    expect(getSortableValue(gist('null', { description: null }), 'description')).toBe('')
+    expect(getSortableValue(undefined, 'description')).toBe('')
+    expect(getSortableValue(gist('numeric', { files: 2 }), 'files')).toBe('2')
+  })
+
+  it('sorts snippets by description when some descriptions are empty', () => {
+    const sorted = [
+      gist('beta', { description: 'Beta' }),
+      gist('null', { description: null }),
+      gist('alpha', { description: 'Alpha' }),
+      gist('missing', {})
+    ].sort(compareGists('description', false))
+
+    expect(sorted.map(item => item.brief.id)).toEqual([
+      'null',
+      'missing',
+      'alpha',
+      'beta'
+    ])
+  })
+
+  it('keeps reverse snippet sorting null-safe', () => {
+    const sorted = [
+      gist('one', { description: 'One' }),
+      gist('empty', { description: null }),
+      gist('two', { description: 'Two' })
+    ].sort(compareGists('description', true))
+
+    expect(sorted.map(item => item.brief.id)).toEqual([
+      'two',
+      'one',
+      'empty'
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #482 by making snippet thumbnail sorting tolerant of empty or missing sort values.

- Moves snippet sort normalization into a focused helper module.
- Normalizes configured sort field values before calling `localeCompare`.
- Treats `null` and `undefined` as empty strings.
- Adds Vitest regression coverage for missing, null, non-string, normal, and reverse sort values.

## Root Cause

The snippet list sorter called `localeCompare` directly on `gist.brief[sortingKey]`. When `snippet.sorting` was set to `description`, gists with missing or null descriptions could throw during render, producing a blank app screen that was surfaced as a generic network failure.

## Validation

- `eslint app/containers/navigationPanelDetails/index.js app/containers/navigationPanelDetails/sorting.js`
- `npm run test:unit -- tests/containers/navigationPanelDetails.test.js`
- `npm run test:unit`
- `git diff --check`
