### PR TITLE
[codex] Fix gist file removal editor reuse

### DIFF
--- a/app/containers/gistEditorForm/formState.js
+++ b/app/containers/gistEditorForm/formState.js
@@ -1,7 +1,45 @@
+let nextGistFileEditorId = 0
+
+export function createGistFileEditorId () {
+  return `gist-file-editor-${nextGistFileEditorId++}`
+}
+
 export function normalizeGistFile (file = {}) {
   return {
     filename: file.filename || '',
+    content: file.content || '',
+    _editorId: file._editorId || createGistFileEditorId()
+  }
+}
+
+export function normalizeSubmitGistFile (file = {}) {
+  return {
+    filename: file.filename || '',
     content: file.content || ''
+  }
+}
+
+export function getGistFileEditorKey (file, fallbackKey) {
+  return file && file._editorId ? file._editorId : fallbackKey
+}
+
+export function getSubmitValues (values) {
+  return {
+    description: values.description,
+    private: values.private,
+    gistFiles: values.gistFiles.map(normalizeSubmitGistFile)
+  }
+}
+
+function getInitialSubmitValues (initialData = {}) {
+  const gistFiles = Array.isArray(initialData.gists)
+    ? initialData.gists.map(normalizeSubmitGistFile)
+    : []
+
+  return {
+    description: initialData.description || '',
+    private: Boolean(initialData.private),
+    gistFiles: gistFiles.length ? gistFiles : [normalizeSubmitGistFile()]
   }
 }
 
@@ -18,7 +56,7 @@ export function getInitialValues (initialData = {}) {
 }
 
 export function getInitialValuesKey (initialData) {
-  return JSON.stringify(getInitialValues(initialData))
+  return JSON.stringify(getInitialSubmitValues(initialData))
 }
 
 export function copyValues (values) {

--- a/app/containers/gistEditorForm/index.js
+++ b/app/containers/gistEditorForm/index.js
@@ -6,7 +6,9 @@ import React, { Component } from 'react'
 import {
   copyValues,
   createFormState,
+  getGistFileEditorKey,
   getInitialValuesKey,
+  getSubmitValues,
   hasValidationErrors,
   normalizeGistFile,
   shouldShowError,
@@ -154,7 +156,7 @@ class GistEditorForm extends Component {
       submitting: true
     })
 
-    const submittedValues = copyValues(this.state.values)
+    const submittedValues = getSubmitValues(this.state.values)
 
     return Promise.resolve()
       .then(() => this.props.onSubmit(submittedValues))
@@ -330,7 +332,7 @@ const renderGistFiles = ({
       const contentFieldName = `gistFiles.${index}.content`
 
       return (
-        <ListGroupItem className='gist-editor-gist-file' key={index}>
+        <ListGroupItem className='gist-editor-gist-file' key={ getGistFileEditorKey(file, index) }>
           <Panel>
             <Panel.Heading>{ renderGistFileHeader({
               file,

--- a/tests/containers/gistEditorFormState.test.js
+++ b/tests/containers/gistEditorFormState.test.js
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest'
 import {
   copyValues,
   createFormState,
+  getGistFileEditorKey,
   getInitialValues,
   getInitialValuesKey,
+  getSubmitValues,
   hasValidationErrors,
   shouldShowError,
   touchAllFields
@@ -16,12 +18,12 @@ describe('gist editor form state helpers', () => {
       description: '',
       private: false,
       gistFiles: [
-        { filename: '', content: '' }
+        { filename: '', content: '', _editorId: expect.any(String) }
       ]
     })
   })
 
-  it('normalizes caller initial data into the submit shape', () => {
+  it('normalizes caller initial data into editable form state', () => {
     expect(getInitialValues({
       description: 'release notes',
       private: true,
@@ -33,10 +35,25 @@ describe('gist editor form state helpers', () => {
       description: 'release notes',
       private: true,
       gistFiles: [
-        { filename: 'notes.md', content: '# Notes' },
-        { filename: 'empty.js', content: '' }
+        { filename: 'notes.md', content: '# Notes', _editorId: expect.any(String) },
+        { filename: 'empty.js', content: '', _editorId: expect.any(String) }
       ]
     })
+  })
+
+  it('keeps a surviving file editor key stable when an earlier file is removed', () => {
+    const values = getInitialValues({
+      gists: [
+        { filename: 'first.js', content: 'const first = true' },
+        { filename: 'second.js', content: 'const second = true' }
+      ]
+    })
+    const originalKeys = values.gistFiles.map((file, index) => getGistFileEditorKey(file, index))
+
+    values.gistFiles.splice(0, 1)
+
+    expect(getGistFileEditorKey(values.gistFiles[0], 0)).toBe(originalKeys[1])
+    expect(getGistFileEditorKey(values.gistFiles[0], 0)).not.toBe(originalKeys[0])
   })
 
   it('tracks the normalized initial values key inside form state', () => {
@@ -48,8 +65,10 @@ describe('gist editor form state helpers', () => {
       ]
     }
 
-    expect(createFormState(initialData)).toMatchObject({
-      values: getInitialValues(initialData),
+    const formState = createFormState(initialData)
+
+    expect(getSubmitValues(formState.values)).toEqual(getSubmitValues(getInitialValues(initialData)))
+    expect(formState).toMatchObject({
       errors: {},
       touched: {},
       submitAttempted: false,
@@ -63,7 +82,7 @@ describe('gist editor form state helpers', () => {
       description: 'snippet',
       private: false,
       gistFiles: [
-        { filename: 'app.js', content: 'console.log(1)' }
+        { filename: 'app.js', content: 'console.log(1)', _editorId: 'editor-id' }
       ]
     }
 
@@ -71,6 +90,23 @@ describe('gist editor form state helpers', () => {
     copied.gistFiles[0].content = 'changed'
 
     expect(values.gistFiles[0].content).toBe('console.log(1)')
+    expect(copied.gistFiles[0]._editorId).toBe(values.gistFiles[0]._editorId)
+  })
+
+  it('strips internal editor ids from submitted values', () => {
+    expect(getSubmitValues({
+      description: 'snippet',
+      private: false,
+      gistFiles: [
+        { filename: 'app.js', content: 'console.log(1)', _editorId: 'editor-id' }
+      ]
+    })).toEqual({
+      description: 'snippet',
+      private: false,
+      gistFiles: [
+        { filename: 'app.js', content: 'console.log(1)' }
+      ]
+    })
   })
 
   it('marks all editable fields touched after a failed submit', () => {


### PR DESCRIPTION
## Summary

Fixes #396 by preventing the gist editor from reusing the wrong CodeMirror instance after removing a file from a multi-file gist.

- Adds stable internal editor ids to gist file form state.
- Uses the stable editor id as the React key for each file editor panel instead of the array index.
- Keeps submitted gist file data clean by stripping the internal editor id before submit.
- Adds Vitest regression coverage for the remove-first-file case.

## Root Cause

The editor list keyed each file panel by array index. After removing an earlier file, React could reuse the existing editor component for the shifted file, leaving the displayed CodeMirror content stale while the filename changed.

## Validation

- `vitest run tests/containers/gistEditorFormState.test.js` against the clean worktree: 8 tests passed
- `eslint app/containers/gistEditorForm/index.js app/containers/gistEditorForm/formState.js tests/containers/gistEditorFormState.test.js`
- `git diff --check`

Note: The focused Vitest run used dependencies from the main checkout via `NODE_PATH` because the temporary clean worktree does not have its own `node_modules`; Vitest printed a config-resolution warning but exited successfully.
