### PR TITLE
[codex] Add Turkish interface locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact pat
 - Shortcuts
 - Enterprise
 - Notifications
-- Interface language (`i18n.locale`: `en`, `es`, `ja`, `zh-Hans`, or `zh-Hant`)
+- Interface language (`i18n.locale`: `en`, `es`, `fr`, `ja`, `ko`, `tr`, `zh-Hans`, or `zh-Hant`)
 
 Check out the [configuration docs](https://github.com/hackjutsu/Lepton/wiki/Configuration) to explore different customization options.
 

--- a/app/utilities/i18n/index.js
+++ b/app/utilities/i18n/index.js
@@ -3,6 +3,7 @@ const es = require('./locales/es')
 const fr = require('./locales/fr')
 const ja = require('./locales/ja')
 const ko = require('./locales/ko')
+const tr = require('./locales/tr')
 const zhHans = require('./locales/zh-Hans')
 const zhHant = require('./locales/zh-Hant')
 
@@ -13,6 +14,7 @@ const catalogs = {
   fr,
   ja,
   ko,
+  tr,
   'zh-Hans': zhHans,
   'zh-Hant': zhHant
 }
@@ -23,6 +25,7 @@ const supportedLocales = [
   { code: 'fr', name: 'Français' },
   { code: 'ja', name: '日本語' },
   { code: 'ko', name: '한국어' },
+  { code: 'tr', name: 'Türkçe' },
   { code: 'zh-Hans', name: '简体中文' },
   { code: 'zh-Hant', name: '繁體中文' }
 ]

--- a/app/utilities/i18n/locales/tr.js
+++ b/app/utilities/i18n/locales/tr.js
@@ -1,0 +1,151 @@
+module.exports = {
+  about: {
+    acknowledgement: 'Teşekkürler',
+    configurations: 'Yapılandırmalar',
+    contributors: 'Katkıda bulunanlar',
+    feedback: 'Geri bildirim',
+    license: 'Lisans',
+    licenseType: 'Lisans: {{license}}',
+    logs: 'Günlükler',
+    title: 'Hakkında'
+  },
+  app: {
+    name: 'Lepton'
+  },
+  dashboard: {
+    complimentMaster: '{{language}} ustası!',
+    complimentPrefix: 'Tebrikler! Şu yolda ilerliyorsunuz',
+    mysteriousLanguage: 'Hmm... Gizemli bir dil öğreniyor gibisiniz.',
+    notEnoughData: 'Yeterli veri yok. İkiden fazla dilde gist oluşturarak deneyin. İyi kodlamalar!',
+    statsLabel: 'Dil istatistiklerim',
+    title: 'Pano'
+  },
+  dialog: {
+    close: 'Kapat',
+    minimize: 'Küçült',
+    minimizeToTray: 'Tepsiye küçült',
+    neverMind: 'Vazgeç',
+    quit: 'Çık',
+    quitConfirm: 'Emin misiniz?',
+    quitTitle: 'Çık'
+  },
+  editor: {
+    addFile: '#dosya ekle',
+    cancel: 'İptal',
+    descriptionPlaceholder: '[başlık] açıklama #etiket1 #etiket2',
+    filenamePlaceholder: 'dosya adı... (örn. snippet.js)',
+    invalidFilename: 'geçersiz dosya adı',
+    removeFile: '#kaldır',
+    required: 'gerekli',
+    secret: 'gizli',
+    submit: 'Gönder',
+    tips: 'ipuçları'
+  },
+  login: {
+    continueAs: '{{username}} olarak devam et',
+    githubLogin: 'GitHub ile giriş',
+    happyCoding: 'İYİ KODLAMALAR',
+    switchToCredentials: 'Kimlik bilgileriyle girişe geç?',
+    switchToToken: 'Token ile girişe geç?',
+    title: 'Giriş',
+    tokenInvalid: 'Token geçersiz',
+    tokenLogin: 'Token ile giriş',
+    tokenPlaceholder: 'kapsam: gist',
+    welcome: 'Lepton ücretsizdir. GitHub\'da bizi destekleyin!'
+  },
+  i18n: {
+    language: 'Dil',
+    saveFailed: 'Dil ayarı güncellenemedi'
+  },
+  menu: {
+    about: 'Hakkında',
+    backToNormalMode: 'Normal moda dön',
+    bringAllToFront: 'Tümünü öne getir',
+    close: 'Kapat',
+    dashboard: 'Pano',
+    deleteGist: 'Gist sil',
+    edit: 'Düzenle',
+    editGist: 'Gist düzenle',
+    exitEditor: 'Düzenleyiciden çık',
+    gist: 'Gist',
+    immersiveMode: 'Odak modu',
+    learnMore: 'Daha fazla bilgi',
+    minimize: 'Küçült',
+    newGist: 'Yeni Gist',
+    openWindow: 'Pencereyi aç',
+    quit: 'Çık',
+    search: 'Ara',
+    speech: 'Konuşma',
+    submitGist: 'Gist gönder',
+    syncGist: 'Gist eşitle',
+    toggleDeveloperTools: 'Geliştirici araçlarını aç/kapat',
+    view: 'Görünüm',
+    zoom: 'Yakınlaştır'
+  },
+  navigation: {
+    cancel: 'İptal',
+    languages: 'Diller',
+    pinned: 'Sabitlenenler',
+    save: 'Kaydet',
+    shortcuts: 'Kısayollar',
+    starred: '#yıldızlı',
+    tags: 'Etiketler'
+  },
+  notification: {
+    contentCopied: 'İçerik panoya kopyalandı.',
+    copied: 'Kopyalandı',
+    deletionFailed: 'Silme başarısız',
+    gistCreated: 'Gist oluşturuldu',
+    gistCreationFailed: 'Gist oluşturulamadı',
+    gistDeleted: 'Gist silindi',
+    gistUpdateFailed: 'Gist güncellenemedi',
+    gistUpdated: 'Gist güncellendi',
+    linkCopied: 'Bağlantı panoya kopyalandı.',
+    networkFailure: 'Lütfen ağ bağlantınızı kontrol edin. {{code}}',
+    rawLinkCopied: 'Ham dosya bağlantısı panoya kopyalandı.',
+    syncFailed: 'Eşitleme başarısız',
+    syncSucceeds: 'Eşitleme tamamlandı'
+  },
+  search: {
+    noResults: 'Sonuç bulunamadı...',
+    placeholder: 'Açıklama, etiket veya dosya adı ara...'
+  },
+  snippet: {
+    copy: 'KOPYALA',
+    delete: 'Sil',
+    deleteAction: 'sil',
+    deleteConfirmTitle: 'Gist silinsin mi?',
+    edit: 'Düzenle',
+    lastActive: 'Son etkinlik {{time}}',
+    link: 'BAĞLANTI',
+    openInWeb: 'Web\'de aç',
+    publicGist: 'herkese açık gist',
+    raw: 'HAM',
+    revisions: 'Revizyonlar',
+    secretGist: 'gizli gist',
+    share: 'PAYLAŞ'
+  },
+  touchBar: {
+    edit: 'Düzenle',
+    immersive: 'Odak',
+    new: 'Yeni',
+    search: 'Ara',
+    sync: 'Eşitle'
+  },
+  update: {
+    available: 'Yeni {{version}} sürümü mevcut!',
+    download: '#indir',
+    release: '#sürüm',
+    skip: '#atla'
+  },
+  userPanel: {
+    confirmLogout: 'Çıkış onaylansın mı?',
+    logout: 'Çıkış yap',
+    logoutAction: 'çıkış yap',
+    new: 'Yeni',
+    sync: 'Eşitle'
+  },
+  welcome: {
+    emptySnippet: 'Gist oluşturmak için sol panelde #yeni\'ye tıklayın.'
+  }
+}

--- a/tests/utilities/i18n.test.js
+++ b/tests/utilities/i18n.test.js
@@ -11,6 +11,7 @@ import es from '../../app/utilities/i18n/locales/es'
 import fr from '../../app/utilities/i18n/locales/fr'
 import ja from '../../app/utilities/i18n/locales/ja'
 import ko from '../../app/utilities/i18n/locales/ko'
+import tr from '../../app/utilities/i18n/locales/tr'
 import zhHans from '../../app/utilities/i18n/locales/zh-Hans'
 import zhHant from '../../app/utilities/i18n/locales/zh-Hant'
 
@@ -19,6 +20,7 @@ const catalogs = {
   fr,
   ja,
   ko,
+  tr,
   'zh-Hans': zhHans,
   'zh-Hant': zhHant
 }
@@ -81,6 +83,12 @@ describe('i18n utilities', () => {
     expect(t('login.title')).toBe('로그인')
   })
 
+  it('supports Turkish locale', () => {
+    expect(configureI18n('tr')).toBe('tr')
+    expect(t('login.title')).toBe('Giriş')
+    expect(t('login.continueAs', { username: 'octocat' })).toBe('octocat olarak devam et')
+  })
+
   it('interpolates named values', () => {
     configureI18n('en')
     expect(t('login.continueAs', { username: 'octocat' })).toBe('Continue as octocat')
@@ -104,6 +112,7 @@ describe('i18n utilities', () => {
       { code: 'fr', name: 'Français' },
       { code: 'ja', name: '日本語' },
       { code: 'ko', name: '한국어' },
+      { code: 'tr', name: 'Türkçe' },
       { code: 'zh-Hans', name: '简体中文' },
       { code: 'zh-Hant', name: '繁體中文' }
     ])


### PR DESCRIPTION
## Summary

Adds Turkish (`tr`) support to the existing i18n system.

- Adds a Turkish locale catalog.
- Registers Turkish in supported locale metadata.
- Extends i18n unit coverage for Turkish selection and interpolation.
- Updates README locale documentation.

## Validation

- `git diff --check`
- Direct Node i18n smoke: configured `tr`, verified `login.title`, interpolation, and supported locale metadata.

## Notes

- `npm run test:unit -- tests/utilities/i18n.test.js` and `npm run lint` could not be run locally because this checkout is missing installed dev dependencies such as `vitest` and `@babel/eslint-parser`.

Fixes #411
