### PR TITLE
[codex] Show dinosaur empty gist panel

### DIFF
--- a/app/containers/snippetPanel/index.js
+++ b/app/containers/snippetPanel/index.js
@@ -2,15 +2,24 @@ import { connect } from 'react-redux'
 import { Well } from 'react-bootstrap'
 import React, { Component } from 'react'
 import Snippet from '../snippet'
-import { t } from '../../utilities/i18n'
 
 import './index.scss'
 
+const emptyStateDinosaur = [
+  '               __',
+  '              / _)',
+  '     _.----._/ /',
+  '    /         /',
+  ' __/ (  | (  |',
+  '/__.-|_|--|_|'
+].join('\n')
+
 class SnippetPanel extends Component {
   renderEmptySnippetSection () {
-    // This happens when the user has no gists
     return (
-      <Well className='welcome-section'>{ t('welcome.emptySnippet') }</Well>
+      <Well className='welcome-section'>
+        <pre className='welcome-ascii' aria-label='No gists'>{ emptyStateDinosaur }</pre>
+      </Well>
     )
   }
 

--- a/app/containers/snippetPanel/index.scss
+++ b/app/containers/snippetPanel/index.scss
@@ -39,3 +39,24 @@
     height: 100vh;
   }
 }
+
+.snippet-panel,
+.snippet-panel-immersive {
+  .welcome-section {
+    color: var(--text-primary);
+    line-height: 1.7;
+    margin-bottom: 0;
+    padding-top: 26vh;
+  }
+
+  .welcome-ascii {
+    background: transparent;
+    border: 0;
+    color: #4078C0;
+    font: inherit;
+    font-size: 14px;
+    line-height: 1.25;
+    margin: 0;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the empty gist panel message with an ASCII dinosaur empty state.
- Adds scoped styling so the dinosaur renders cleanly in regular and immersive snippet panels.

## Impact

Users with no gists now see a visual empty state instead of the prior text-only welcome message.

## Validation

- Not run; PR creation only, branch already existed remotely.