### PR TITLE
[codex] Add global content search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,9 +168,10 @@ fetches need to refresh indexed gist data. Search currently performs exact,
 case-insensitive token matching across metadata and any downloaded file content;
 do not reintroduce fuzzy matching without updating tests and UI expectations.
 
-Complete global content search depends on `gist.downloadAll` being enabled
-before sync so every gist's details and file contents are downloaded. When
-`downloadAll` is disabled, content search can only cover gists whose details
+Complete global content search depends on `snippet.downloadAll` being enabled
+before sync so every snippet's details and file contents are downloaded. The
+legacy `gist.downloadAll` key is still accepted for compatibility. When
+`downloadAll` is disabled, content search can only cover snippets whose details
 have already been loaded locally.
 
 ### GitHub OAuth Setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,8 +169,7 @@ case-insensitive token matching across metadata and any downloaded file content;
 do not reintroduce fuzzy matching without updating tests and UI expectations.
 
 Complete global content search depends on `snippet.downloadAll` being enabled
-before sync so every snippet's details and file contents are downloaded. The
-legacy `gist.downloadAll` key is still accepted for compatibility. When
+before sync so every snippet's details and file contents are downloaded. When
 `downloadAll` is disabled, content search can only cover snippets whose details
 have already been loaded locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,9 +156,22 @@ Document rendering verification in PR descriptions, including whether the app wa
 - **GitHub API Integration**: `/app/utilities/githubApi/` - handles Gist CRUD operations
 - **Theme Management**: `/app/utilities/themeManager/` - light/dark theme switching
 - **Code Rendering**: Uses CodeMirror for syntax highlighting and editing
-- **Search**: `/app/utilities/search/` - snippet search functionality
+- **Search**: `/app/utilities/search/` - snippet metadata and downloaded-content search functionality
 - **Configuration**: Uses nconf for config management, stored in `~/.leptonrc`
 - **Preload Bridge**: `/preload.js` exposes the limited renderer API as `window.lepton`
+
+### Search Development Notes
+
+Search records are built through `/app/utilities/search/records.js`. Use the
+shared builder when sync, create, edit, fixture rendering, or lazy single-gist
+fetches need to refresh indexed gist data. Search currently performs exact,
+case-insensitive token matching across metadata and any downloaded file content;
+do not reintroduce fuzzy matching without updating tests and UI expectations.
+
+Complete global content search depends on `gist.downloadAll` being enabled
+before sync so every gist's details and file contents are downloaded. When
+`downloadAll` is disabled, content search can only cover gists whose details
+have already been loaded locally.
 
 ### GitHub OAuth Setup
 The app requires GitHub OAuth credentials in `/configs/account.js`:

--- a/README.md
+++ b/README.md
@@ -53,10 +53,7 @@
 | About Page     | `Cmd/Ctrl + ,` |  Toggle the [About page](https://github.com/hackjutsu/Lepton/blob/dev/docs/img/portfolio/about.png)    |
 | Search         | `Shift + Space`|  Toggle the [search bar](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/search_bar.png)    |
 
-Search matches snippet titles, descriptions, tags, gist ids, filenames, languages,
-and downloaded file content. Complete global content search across all snippets
-requires `gist.downloadAll` to be enabled before syncing so Lepton downloads every
-gist's file content.
+See the [Search FAQ](wiki/faq.md#search) for searchable fields and content-search behavior.
 
 ## Customization
 Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact path in the About page by `Command/Ctrl + ,`. Create the file if it does not exist.
@@ -73,26 +70,6 @@ Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact pat
 - Interface language (`i18n.locale`: `en`, `es`, `fr`, `ja`, `ko`, `tr`, `zh-Hans`, or `zh-Hant`)
 
 Check out the [configuration docs](wiki/configuration.md) to explore different customization options.
-
-Example:
-
-```json
-{
-  "i18n": {
-    "locale": "ja"
-  }
-}
-```
-
-Enable complete global content search by downloading all gist details during sync:
-
-```json
-{
-  "gist": {
-    "downloadAll": true
-  }
-}
-```
 
 ## Tech Stack
 ![Based on](./docs/img/erb-logo.png)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Built-in themes
 - macOS/Win/Linux
 - Dashboard
-- [Search](wiki/faq.md#search)
+- [Search snippets and downloaded content](wiki/faq.md#search)
 - [Proxy](wiki/faq.md#proxy)
 - Free
 
@@ -35,7 +35,7 @@
 | :-------------:| :-----:| :-----: |
 | ![Screenshot](./docs/img/portfolio/stay_organized.png) | ![Screenshot](./docs/img/portfolio/markdown.png) | ![Screenshot](./docs/img/portfolio/jupyterNotebook.png) |
 
-|      Search (*⇧ + Space*)         |    Immersive Mode *(⌘/Ctrl + i)*    | Dashboard *(⌘/Ctrl + d)* |
+|      Search snippets and content (*⇧ + Space*)         |    Immersive Mode *(⌘/Ctrl + i)*    | Dashboard *(⌘/Ctrl + d)* |
 | :-------------:| :-----:| :-----: |
 | ![Screenshot](./docs/img/portfolio/search_bar.png) | ![Screenshot](./docs/img/portfolio/immersive.png) | ![Screenshot](./docs/img/portfolio/dashboard.png)
 
@@ -51,7 +51,7 @@
 | Immersive Mode | `Cmd/Ctrl + I` |  Toggle the [Immersive mode](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/immersive.png)    |
 | Dashboard      | `Cmd/Ctrl + D` |  Toggle the [dashboard](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/dashboard.png)     |
 | About Page     | `Cmd/Ctrl + ,` |  Toggle the [About page](https://github.com/hackjutsu/Lepton/blob/dev/docs/img/portfolio/about.png)    |
-| Search         | `Shift + Space`|  Toggle the [search bar](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/search_bar.png)    |
+| Search         | `Shift + Space`|  Toggle [snippet and downloaded-content search](wiki/faq.md#search)    |
 
 See the [Search FAQ](wiki/faq.md#search) for searchable fields and content-search behavior.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@
 | About Page     | `Cmd/Ctrl + ,` |  Toggle the [About page](https://github.com/hackjutsu/Lepton/blob/dev/docs/img/portfolio/about.png)    |
 | Search         | `Shift + Space`|  Toggle the [search bar](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/search_bar.png)    |
 
+Search matches snippet titles, descriptions, tags, gist ids, filenames, languages,
+and downloaded file content. Complete global content search across all snippets
+requires `gist.downloadAll` to be enabled before syncing so Lepton downloads every
+gist's file content.
+
 ## Customization
 Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact path in the About page by `Command/Ctrl + ,`. Create the file if it does not exist.
 
@@ -75,6 +80,16 @@ Example:
 {
   "i18n": {
     "locale": "ja"
+  }
+}
+```
+
+Enable complete global content search by downloading all gist details during sync:
+
+```json
+{
+  "gist": {
+    "downloadAll": true
   }
 }
 ```

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -1,6 +1,7 @@
 import { getGitHubApi, GET_SINGLE_GIST } from '../utilities/githubApi'
 import { notifyFailure } from '../utilities/notifier'
 import electronBridge from '../utilities/electronBridge'
+import SearchIndex from '../utilities/search'
 import { t } from '../utilities/i18n'
 
 const logger = electronBridge.logger
@@ -227,10 +228,11 @@ export function fetchSingleGist (oldGist, id) {
     const state = getState()
     return getGitHubApi(GET_SINGLE_GIST)(state.accessToken, id)
       .then((details) => {
-        const newGist = Object.assign(oldGist, { details: details })
+        const newGist = Object.assign({}, oldGist, { details: details })
         const newGistWithId = {}
         newGistWithId[id] = newGist
         dispatch(updateSingleGist(newGistWithId))
+        SearchIndex.updateFuseIndex(SearchIndex.buildSearchRecord(newGist))
       })
       .catch((err) => {
         logger.error('The request has failed: ' + err)

--- a/app/containers/searchPage/index.js
+++ b/app/containers/searchPage/index.js
@@ -2,6 +2,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import electronBridge from '../../utilities/electronBridge'
 import Modal from '../compatModal'
+import Moment from 'moment'
 import React, { Component } from 'react'
 import { t } from '../../utilities/i18n'
 import {
@@ -138,19 +139,167 @@ class SearchPage extends Component {
     })
   }
 
+  getSearchTokens () {
+    return this.state.inputValue.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  }
+
+  mergeHighlightRanges (ranges) {
+    const sortedRanges = ranges.slice().sort((left, right) => left[0] - right[0])
+    return sortedRanges.reduce((merged, range) => {
+      const previous = merged[merged.length - 1]
+      if (!previous || range[0] > previous[1] + 1) {
+        merged.push(range)
+        return merged
+      }
+
+      previous[1] = Math.max(previous[1], range[1])
+      return merged
+    }, [])
+  }
+
+  getHighlightSegments (text) {
+    if (!text) return []
+
+    const tokens = this.getSearchTokens()
+    const lowerText = text.toLowerCase()
+    const ranges = []
+
+    tokens.forEach(token => {
+      let searchStart = 0
+      let matchStart = lowerText.indexOf(token, searchStart)
+      while (matchStart !== -1) {
+        ranges.push([matchStart, matchStart + token.length - 1])
+        searchStart = matchStart + token.length
+        matchStart = lowerText.indexOf(token, searchStart)
+      }
+    })
+
+    if (ranges.length === 0) {
+      return [{ text: text, match: false }]
+    }
+
+    const mergedRanges = this.mergeHighlightRanges(ranges)
+    const segments = []
+    let cursor = 0
+    mergedRanges.forEach(([start, end]) => {
+      if (start > cursor) {
+        segments.push({ text: text.slice(cursor, start), match: false })
+      }
+      segments.push({ text: text.slice(start, end + 1), match: true })
+      cursor = end + 1
+    })
+    if (cursor < text.length) {
+      segments.push({ text: text.slice(cursor), match: false })
+    }
+    return segments
+  }
+
+  renderHighlightedSegments (segments) {
+    return segments.map((segment, index) => (
+      <span
+        className={ segment.match ? 'search-match-highlight' : null }
+        key={ index }>
+        { segment.text }
+      </span>
+    ))
+  }
+
+  renderHighlightedText (text) {
+    return this.renderHighlightedSegments(this.getHighlightSegments(text))
+  }
+
   renderSnippetDescription (rawDescription) {
     const { title, description } = descriptionParser(rawDescription)
 
     const htmlForDescriptionSection = []
     if (title.length > 0) {
-      htmlForDescriptionSection.push(<div className='title-section' key='title'>{ title }</div>)
+      htmlForDescriptionSection.push(
+        <div className='title-section' key='title'>{ this.renderHighlightedText(title) }</div>
+      )
     }
-    htmlForDescriptionSection.push(<div className='description-section' key='description'>{ description }</div>)
+    htmlForDescriptionSection.push(
+      <div className='description-section' key='description'>{ this.renderHighlightedText(description) }</div>
+    )
 
     return (
       <div>
         { htmlForDescriptionSection }
       </div>
+    )
+  }
+
+  getSearchMatchSource (match) {
+    const sourceByKey = {
+      id: 'id',
+      description: 'description',
+      language: 'language',
+      filename: 'filename',
+      'files.filename': 'filename',
+      'files.language': 'language',
+      'files.content': 'content'
+    }
+    return sourceByKey[match.key] || 'description'
+  }
+
+  renderSearchMatchLabel (gist) {
+    const match = gist.searchMeta && gist.searchMeta.bestMatch
+    if (!match) return null
+
+    const source = t(`search.match.${this.getSearchMatchSource(match)}`)
+    const title = match.filename
+      ? t('search.match.inFile', { source: source, filename: match.filename })
+      : source
+
+    return (
+      <div className='search-match-label' title={ title }>{ source }</div>
+    )
+  }
+
+  getSearchContentMatches (gist) {
+    const matches = gist.searchMeta && gist.searchMeta.matches
+    if (!matches) return []
+    return matches.filter(match => match.key === 'files.content' && match.excerpt && match.excerpt.segments.length > 0)
+  }
+
+  renderSearchMatchExcerpts (gist) {
+    const matches = this.getSearchContentMatches(gist)
+    if (matches.length === 0) return null
+
+    return (
+      <div>
+        { matches.map((match, index) => (
+          <div className='search-match-excerpt' key={ `${match.filename || 'content'}-${index}` }>
+            { matches.length > 1 && match.filename
+              ? <span className='search-match-excerpt-file'>{ match.filename }: </span>
+              : null }
+            { this.renderHighlightedSegments(match.excerpt.segments) }
+          </div>
+        )) }
+      </div>
+    )
+  }
+
+  renderUpdatedTime (gist) {
+    if (!gist.updated_at) return null
+
+    return (
+      <div className='search-updated-time'>
+        { t('snippet.lastActive', { time: Moment(gist.updated_at).fromNow() }) }
+      </div>
+    )
+  }
+
+  renderResultCount () {
+    const { inputValue, searchResults } = this.state
+    if (!inputValue || !searchResults) return null
+
+    const count = searchResults.length
+    const label = count === 1
+      ? t('search.resultCountOne')
+      : t('search.resultCountMany', { count: count })
+
+    return (
+      <div className='search-result-count'>{ label }</div>
     )
   }
 
@@ -180,7 +329,7 @@ class SearchPage extends Component {
       if (gist.filename) {
         filenames = gist.filename.split(',').filter(file => file.trim()).map(file => {
           return (
-            <div className='gist-tag' key={ file.trim() }>{ file }</div>
+            <div className='gist-tag' key={ file.trim() }>{ this.renderHighlightedText(file) }</div>
           )
         })
       }
@@ -192,8 +341,15 @@ class SearchPage extends Component {
           key={ gist.id }
           ref={ node => this.setResultNode(index, node) }
           onClick={ this.handleSnippetClicked.bind(this, gist.id) }>
-          <div className='snippet-description'>{ this.renderSnippetDescription(highlightedDescription) }</div>
-          <div className='gist-tag-group'>{ filenames }</div>
+          <div className='search-result-header'>
+            <div className='snippet-description'>{ this.renderSnippetDescription(highlightedDescription) }</div>
+            { this.renderSearchMatchLabel(gist) }
+          </div>
+          { this.renderSearchMatchExcerpts(gist) }
+          <div className='search-result-footer'>
+            <div className='gist-tag-group'>{ filenames }</div>
+            { this.renderUpdatedTime(gist) }
+          </div>
         </li>
       )
     })
@@ -212,6 +368,7 @@ class SearchPage extends Component {
           onChange={ this.updateInputValue.bind(this) }
           onKeyDown={ this.handleKeyDown.bind(this) }
           onKeyUp={ this.queryInputValue.bind(this) }/>
+        { this.renderResultCount() }
         <ul className='result-group'>
           { this.renderSearchResults() }
         </ul>
@@ -234,7 +391,7 @@ class SearchPage extends Component {
 
 function mapStateToProps (state) {
   return {
-    searchWindowStatus: state.authWindowStatus,
+    searchWindowStatus: state.searchWindowStatus,
     userSessionStatus: state.userSession.activeStatus,
     gists: state.gists
   }

--- a/app/containers/searchPage/index.scss
+++ b/app/containers/searchPage/index.scss
@@ -22,11 +22,19 @@
     max-height: 70vh;
     list-style-type: none;
     padding: 0px;
+    margin-top: 0;
     overflow: auto;
   }
 
+  .search-result-count {
+    @extend .font-style-base;
+    padding: 2px 14px 10px;
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
   .search-result-item {
-    padding: 10px 10px;
+    padding: 12px 14px;
     border-top: solid 1px var(--border-color);
   }
 
@@ -61,6 +69,50 @@
 
   .snippet-description {
     @extend .font-style-base;
+    min-width: 0;
+  }
+
+  .search-result-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .search-match-label {
+    @extend .font-style-base;
+    flex: 0 0 auto;
+    padding: 3px 6px;
+    border: solid 1px var(--border-color);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.3;
+    white-space: nowrap;
+  }
+
+  .search-match-excerpt {
+    margin-top: 8px;
+    padding: 6px 8px;
+    border-left: solid 2px #4078C0;
+    background: rgba(0, 0, 0, 0.04);
+    color: var(--text-secondary);
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .search-match-highlight {
+    background: rgba(255, 213, 79, 0.35);
+    color: var(--text-primary);
+  }
+
+  .search-match-excerpt-file {
+    color: var(--text-primary);
+    font-family: -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI, Ubuntu, Droid Sans, sans-serif;
+    font-weight: 600;
   }
 
   .not-found-msg {
@@ -71,7 +123,7 @@
   }
 
   .gist-tag-group {
-    margin-top: 10px;
+    min-width: 0;
   }
 
   .gist-tag {
@@ -84,6 +136,24 @@
   .gist-tag-selected {
     @extend .gist-tag;
     border:solid 2px red;
+  }
+
+  .search-result-footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 10px;
+  }
+
+  .search-updated-time {
+    @extend .font-style-base;
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.3;
+    text-align: right;
+    white-space: nowrap;
   }
 
   .modal-button-base {

--- a/app/containers/snippet/index.js
+++ b/app/containers/snippet/index.js
@@ -306,17 +306,7 @@ class Snippet extends Component {
     // this.props.selectGist(gistId)
 
     // Update the search index
-    let langSearchRecords = ''
-    newLangs.forEach(lang => {
-      langSearchRecords += ',' + lang
-    })
-
-    searchIndex.updateFuseIndex({
-      id: gistId,
-      description: gistDetails.description,
-      language: langSearchRecords,
-      filename: filenameRecords
-    })
+    searchIndex.updateFuseIndex(searchIndex.buildSearchRecord(updatedGist[gistId]))
 
     notifySuccess(t('notification.gistUpdated'), HumanReadableTime(new Date()))
   }

--- a/app/containers/userPanel/index.js
+++ b/app/containers/userPanel/index.js
@@ -109,12 +109,9 @@ class UserPanel extends Component {
 
     // update the language tags
     const langs = new Set()
-    let filenameRecords = ''
 
     gistTags[Prefixed('All')].unshift(gistId)
     Object.keys(files).forEach(filename => {
-      // leave a space in between to help tokenization
-      filenameRecords += ', ' + filename
       const language = files[filename].language || 'Other'
       langs.add(language)
       const prefixedLang = Prefixed(language)
@@ -155,18 +152,8 @@ class UserPanel extends Component {
     logger.info('[Dispatch] selectGist')
     selectGist(gistId)
 
-    let langSearchRecords = ''
-    langs.forEach(lang => {
-      langSearchRecords += ',' + lang
-    })
-
     // update the search index
-    searchIndex.addToFuseIndex({
-      id: gistId,
-      description: gistDetails.description,
-      language: langSearchRecords,
-      filename: filenameRecords
-    })
+    searchIndex.addToFuseIndex(searchIndex.buildSearchRecord(newGist[gistId]))
 
     notifySuccess(t('notification.gistCreated'), HumanReadableTime(new Date()))
   }

--- a/app/index.js
+++ b/app/index.js
@@ -289,11 +289,8 @@ function updateUserGists (userLoginId, token) {
 
       gistList.forEach((gist) => {
         const langs = new Set()
-        let filenameRecords = ''
 
         Object.keys(gist.files).forEach(filename => {
-          // leave a space in between to help tokenization
-          filenameRecords += ', ' + filename
           const file = gist.files[filename]
           const language = file.language || 'Other'
           langs.add(language)
@@ -333,18 +330,8 @@ function updateUserGists (userLoginId, token) {
           gists[gist.id] = Object.assign(gists[gist.id], { details: preGist.details })
         }
 
-        let langSearchRecords = ''
-        langs.forEach(lang => {
-          langSearchRecords += ',' + lang
-        })
-
         // Update the SearchIndex
-        fuseSearchIndex.push({
-          id: gist.id,
-          description: gist.description,
-          language: langSearchRecords,
-          filename: filenameRecords
-        })
+        fuseSearchIndex.push(SearchIndex.buildSearchRecord(gists[gist.id]))
       }) // gistList.forEach
 
       SearchIndex.resetFuseIndex(fuseSearchIndex)

--- a/app/index.js
+++ b/app/index.js
@@ -51,6 +51,7 @@ import {
 
 import { notifySuccess, notifyFailure } from './utilities/notifier'
 import { configureI18n, t } from './utilities/i18n'
+import { shouldDownloadAllSnippets } from './utilities/config'
 
 const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
@@ -243,7 +244,7 @@ function reSyncUserGists () {
 }
 
 function downloadGistDetailsAfterListSync (gistList, token) {
-  if (!conf.get('gist:downloadAll')) {
+  if (!shouldDownloadAllSnippets(conf)) {
     return Promise.resolve({})
   }
 

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -1,4 +1,5 @@
 import { addLangPrefix as Prefixed } from './utilities/parser'
+import SearchIndex from './utilities/search'
 
 const FIXTURE_USER = {
   avatar_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
@@ -156,20 +157,7 @@ const gistTags = {
   ops: ['fixture-gist-3']
 }
 
-const searchIndexRecords = Object.keys(gists).map(id => {
-  const gist = gists[id].details
-  const languages = Object.keys(gist.files)
-    .map(filename => gist.files[filename].language || 'Other')
-    .join(',')
-  const filenames = Object.keys(gist.files).join(', ')
-
-  return {
-    id,
-    description: gist.description,
-    language: languages,
-    filename: filenames
-  }
-})
+const searchIndexRecords = Object.keys(gists).map(id => SearchIndex.buildSearchRecord(gists[id]))
 
 function getBaseState () {
   return {

--- a/app/utilities/config/index.js
+++ b/app/utilities/config/index.js
@@ -3,7 +3,7 @@ function shouldDownloadAllSnippets (conf) {
     return false
   }
 
-  return Boolean(conf.get('snippet:downloadAll') || conf.get('gist:downloadAll'))
+  return Boolean(conf.get('snippet:downloadAll'))
 }
 
 module.exports = {

--- a/app/utilities/config/index.js
+++ b/app/utilities/config/index.js
@@ -1,0 +1,11 @@
+function shouldDownloadAllSnippets (conf) {
+  if (!conf || typeof conf.get !== 'function') {
+    return false
+  }
+
+  return Boolean(conf.get('snippet:downloadAll') || conf.get('gist:downloadAll'))
+}
+
+module.exports = {
+  shouldDownloadAllSnippets
+}

--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -2,6 +2,7 @@ const { Promise } = require('bluebird')
 const ProxyAgent = require('proxy-agent')
 const ReqPromise = require('request-promise')
 const Request = require('request')
+const { shouldDownloadAllSnippets } = require('../config')
 
 const TAG = '[REST] '
 const kTimeoutUnit = 10 * 1000 // ms
@@ -194,7 +195,7 @@ function createGitHubApi ({
   }
 
   function makeOptionForGetAllGists (token, userId, page) {
-    const shouldDownloadAllGists = conf && conf.get('gist:downloadAll')
+    const shouldDownloadAllGists = shouldDownloadAllSnippets(conf)
     const uri = shouldDownloadAllGists
       ? `https://${gitHubHostApi}/gists`
       : `https://${gitHubHostApi}/users/${userId}/gists`

--- a/app/utilities/i18n/locales/en.js
+++ b/app/utilities/i18n/locales/en.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: 'Sync succeeds'
   },
   search: {
+    match: {
+      content: 'Content',
+      description: 'Description',
+      filename: 'File name',
+      id: 'ID',
+      inFile: '{{source}} in {{filename}}',
+      language: 'Language'
+    },
     noResults: 'No result found...',
-    placeholder: 'Search for description, tags, file names...'
+    placeholder: 'Search descriptions, tags, file names, and content...',
+    resultCountMany: '{{count}} snippets found',
+    resultCountOne: '1 snippet found'
   },
   snippet: {
     copy: 'COPY',

--- a/app/utilities/i18n/locales/es.js
+++ b/app/utilities/i18n/locales/es.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: 'Sincronizacion completada'
   },
   search: {
+    match: {
+      content: 'Contenido',
+      description: 'Descripcion',
+      filename: 'Nombre de archivo',
+      id: 'Identificador',
+      inFile: '{{source}} en {{filename}}',
+      language: 'Idioma'
+    },
     noResults: 'No se encontraron resultados...',
-    placeholder: 'Buscar descripcion, etiquetas, nombres de archivo...'
+    placeholder: 'Buscar descripcion, etiquetas, nombres de archivo...',
+    resultCountMany: '{{count}} snippets encontrados',
+    resultCountOne: '1 snippet encontrado'
   },
   snippet: {
     copy: 'COPIAR',

--- a/app/utilities/i18n/locales/fr.js
+++ b/app/utilities/i18n/locales/fr.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: 'Synchronisation reussie'
   },
   search: {
+    match: {
+      content: 'Contenu',
+      description: 'Descriptif',
+      filename: 'Nom de fichier',
+      id: 'Identifiant',
+      inFile: '{{source}} dans {{filename}}',
+      language: 'Langage'
+    },
     noResults: 'Aucun resultat...',
-    placeholder: 'Rechercher descriptions, tags, noms de fichiers...'
+    placeholder: 'Rechercher descriptions, tags, noms de fichiers...',
+    resultCountMany: '{{count}} extraits trouves',
+    resultCountOne: '1 extrait trouve'
   },
   snippet: {
     copy: 'COPIER',

--- a/app/utilities/i18n/locales/ja.js
+++ b/app/utilities/i18n/locales/ja.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: '同期しました'
   },
   search: {
+    match: {
+      content: '内容',
+      description: '説明',
+      filename: 'ファイル名',
+      id: '識別子',
+      inFile: '{{filename}} の {{source}}',
+      language: '言語'
+    },
     noResults: '結果が見つかりません...',
-    placeholder: '説明、タグ、ファイル名を検索...'
+    placeholder: '説明、タグ、ファイル名を検索...',
+    resultCountMany: '{{count}} 件のスニペットが見つかりました',
+    resultCountOne: '1 件のスニペットが見つかりました'
   },
   snippet: {
     copy: 'コピー',

--- a/app/utilities/i18n/locales/ko.js
+++ b/app/utilities/i18n/locales/ko.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: '동기화 성공'
   },
   search: {
+    match: {
+      content: '내용',
+      description: '설명',
+      filename: '파일 이름',
+      id: '식별자',
+      inFile: '{{filename}}의 {{source}}',
+      language: '언어'
+    },
     noResults: '결과가 없습니다...',
-    placeholder: '설명, 태그, 파일 이름 검색...'
+    placeholder: '설명, 태그, 파일 이름 검색...',
+    resultCountMany: '{{count}}개 스니펫 발견',
+    resultCountOne: '1개 스니펫 발견'
   },
   snippet: {
     copy: '복사',

--- a/app/utilities/i18n/locales/tr.js
+++ b/app/utilities/i18n/locales/tr.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: 'Eşitleme tamamlandı'
   },
   search: {
+    match: {
+      content: 'İçerik',
+      description: 'Açıklama',
+      filename: 'Dosya adı',
+      id: 'Kimlik',
+      inFile: '{{filename}} içinde {{source}}',
+      language: 'Dil'
+    },
     noResults: 'Sonuç bulunamadı...',
-    placeholder: 'Açıklama, etiket veya dosya adı ara...'
+    placeholder: 'Açıklama, etiket veya dosya adı ara...',
+    resultCountMany: '{{count}} kod parcasi bulundu',
+    resultCountOne: '1 kod parcasi bulundu'
   },
   snippet: {
     copy: 'KOPYALA',

--- a/app/utilities/i18n/locales/zh-Hans.js
+++ b/app/utilities/i18n/locales/zh-Hans.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: '同步成功'
   },
   search: {
+    match: {
+      content: '内容',
+      description: '描述',
+      filename: '文件名',
+      id: '标识符',
+      inFile: '{{filename}} 中的 {{source}}',
+      language: '语言'
+    },
     noResults: '未找到结果...',
-    placeholder: '搜索描述、标签、文件名...'
+    placeholder: '搜索描述、标签、文件名...',
+    resultCountMany: '找到 {{count}} 个代码片段',
+    resultCountOne: '找到 1 个代码片段'
   },
   snippet: {
     copy: '复制',

--- a/app/utilities/i18n/locales/zh-Hant.js
+++ b/app/utilities/i18n/locales/zh-Hant.js
@@ -107,8 +107,18 @@ module.exports = {
     syncSucceeds: '同步成功'
   },
   search: {
+    match: {
+      content: '內容',
+      description: '描述',
+      filename: '檔案名稱',
+      id: '識別碼',
+      inFile: '{{filename}} 中的 {{source}}',
+      language: '語言'
+    },
     noResults: '找不到結果...',
-    placeholder: '搜尋描述、標籤、檔案名稱...'
+    placeholder: '搜尋描述、標籤、檔案名稱...',
+    resultCountMany: '找到 {{count}} 個程式碼片段',
+    resultCountOne: '找到 1 個程式碼片段'
   },
   snippet: {
     copy: '複製',

--- a/app/utilities/search/index.js
+++ b/app/utilities/search/index.js
@@ -1,24 +1,19 @@
-const Fuse = require('fuse.js')
+const {
+  buildSearchRecord,
+  createHighlightedExcerpt,
+  normalizeFuseResult
+} = require('./records')
 
-let fuse = null
 let fuseIndex = []
 
-const fuseOptions = {
-  shouldSort: true,
-  tokenize: true,
-  matchAllTokens: true,
-  findAllMatches: true,
-  threshold: 0.2,
-  location: 0,
-  distance: 100,
-  maxPatternLength: 32,
-  minMatchCharLength: 1,
-  keys: [
-    'id',
-    'description',
-    'language',
-    'filename'
-  ]
+const SEARCH_FIELD_PRIORITY = {
+  description: 1,
+  filename: 2,
+  'files.filename': 2,
+  language: 3,
+  'files.language': 3,
+  id: 4,
+  'files.content': 5
 }
 
 function resetFuseIndex (list) {
@@ -26,7 +21,8 @@ function resetFuseIndex (list) {
 }
 
 function initFuseSearch () {
-  fuse = new Fuse(fuseIndex, fuseOptions)
+  // Kept for compatibility with existing callers. The exact-match index is
+  // maintained incrementally by resetFuseIndex/addToFuseIndex/updateFuseIndex.
 }
 
 function addToFuseIndex (item) {
@@ -41,11 +37,144 @@ function updateFuseIndex (item) {
   fuseIndex = newIndex
 }
 
+function normalizeSearchValue (value) {
+  if (value === null || typeof value === 'undefined') return ''
+  return String(value)
+}
+
+function getSearchTokens (pattern) {
+  return pattern.trim().toLowerCase().split(/\s+/).filter(Boolean)
+}
+
+function getRecordSearchFields (record) {
+  const fields = [
+    { key: 'description', value: normalizeSearchValue(record.description) },
+    { key: 'filename', value: normalizeSearchValue(record.filename) },
+    { key: 'language', value: normalizeSearchValue(record.language) },
+    { key: 'id', value: normalizeSearchValue(record.id) }
+  ]
+
+  if (Array.isArray(record.files)) {
+    record.files.forEach((file, arrayIndex) => {
+      fields.push({
+        key: 'files.filename',
+        value: normalizeSearchValue(file.filename),
+        arrayIndex: arrayIndex
+      })
+      fields.push({
+        key: 'files.language',
+        value: normalizeSearchValue(file.language),
+        arrayIndex: arrayIndex
+      })
+      fields.push({
+        key: 'files.content',
+        value: normalizeSearchValue(file.content),
+        arrayIndex: arrayIndex
+      })
+    })
+  }
+
+  return fields.filter(field => field.value.length > 0)
+}
+
+function findTokenIndices (value, token) {
+  const lowerValue = value.toLowerCase()
+  const indices = []
+  let searchStart = 0
+  let matchStart = lowerValue.indexOf(token, searchStart)
+
+  while (matchStart !== -1) {
+    indices.push([matchStart, matchStart + token.length - 1])
+    searchStart = matchStart + token.length
+    matchStart = lowerValue.indexOf(token, searchStart)
+  }
+
+  return indices
+}
+
+function mergeIndices (indices) {
+  const sortedIndices = indices.slice().sort((left, right) => left[0] - right[0])
+  return sortedIndices.reduce((merged, current) => {
+    const previous = merged[merged.length - 1]
+    if (!previous || current[0] > previous[1] + 1) {
+      merged.push(current)
+      return merged
+    }
+
+    previous[1] = Math.max(previous[1], current[1])
+    return merged
+  }, [])
+}
+
+function getBestMatch (matches) {
+  return matches.slice().sort((left, right) => {
+    const leftPriority = SEARCH_FIELD_PRIORITY[left.key] || 99
+    const rightPriority = SEARCH_FIELD_PRIORITY[right.key] || 99
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority
+
+    const leftIndex = left.indices && left.indices.length ? left.indices[0][0] : Number.MAX_SAFE_INTEGER
+    const rightIndex = right.indices && right.indices.length ? right.indices[0][0] : Number.MAX_SAFE_INTEGER
+    return leftIndex - rightIndex
+  })[0]
+}
+
+function buildExactSearchResult (record, tokens, index) {
+  const matchedTokens = new Set()
+  const matches = []
+
+  getRecordSearchFields(record).forEach(field => {
+    const fieldIndices = []
+    tokens.forEach((token, tokenIndex) => {
+      const tokenIndices = findTokenIndices(field.value, token)
+      if (tokenIndices.length === 0) return
+
+      matchedTokens.add(tokenIndex)
+      fieldIndices.push(...tokenIndices)
+    })
+
+    if (fieldIndices.length > 0) {
+      matches.push({
+        key: field.key,
+        value: field.value,
+        indices: mergeIndices(fieldIndices),
+        arrayIndex: field.arrayIndex
+      })
+    }
+  })
+
+  if (matchedTokens.size !== tokens.length) return null
+
+  const bestMatch = getBestMatch(matches)
+  const priority = SEARCH_FIELD_PRIORITY[bestMatch.key] || 99
+  const matchStart = bestMatch.indices && bestMatch.indices.length ? bestMatch.indices[0][0] : 0
+
+  return {
+    result: normalizeFuseResult({
+      item: record,
+      score: priority + (matchStart / 100000),
+      matches: matches
+    }),
+    rank: [priority, matchStart, index]
+  }
+}
+
+function compareSearchResults (left, right) {
+  for (let i = 0; i < left.rank.length; i++) {
+    if (left.rank[i] !== right.rank[i]) return left.rank[i] - right.rank[i]
+  }
+  return 0
+}
+
 function fuseSearch (pattern) {
   const trimmedPattern = pattern.trim()
   if (!trimmedPattern || trimmedPattern.length <= 1) return []
 
-  return fuse.search(trimmedPattern)
+  const tokens = getSearchTokens(trimmedPattern)
+  return fuseIndex
+    .map((record, index) => buildExactSearchResult(record, tokens, index))
+    .filter(result => result !== null)
+    .sort(compareSearchResults)
+    .map(result => result.result)
 }
 
 module.exports = {
@@ -53,5 +182,7 @@ module.exports = {
   updateFuseIndex: updateFuseIndex,
   addToFuseIndex: addToFuseIndex,
   initFuseSearch: initFuseSearch,
-  fuseSearch: fuseSearch
+  fuseSearch: fuseSearch,
+  buildSearchRecord: buildSearchRecord,
+  createHighlightedExcerpt: createHighlightedExcerpt
 }

--- a/app/utilities/search/records.js
+++ b/app/utilities/search/records.js
@@ -1,0 +1,251 @@
+const DEFAULT_EXCERPT_LENGTH = 140
+const EXCERPT_CONTEXT_LENGTH = 32
+
+const MATCH_KEY_LABELS = {
+  id: 'ID',
+  description: 'Description',
+  language: 'Language',
+  filename: 'File name',
+  'files.filename': 'File name',
+  'files.language': 'Language',
+  'files.content': 'Content'
+}
+
+const MATCH_KEY_PRIORITY = {
+  description: 1,
+  filename: 2,
+  'files.filename': 2,
+  language: 3,
+  'files.language': 3,
+  id: 4,
+  'files.content': 5
+}
+
+function toGistBrief (gist) {
+  if (!gist) return {}
+  return gist.brief || gist
+}
+
+function toGistDetails (gist, detailsOverride) {
+  if (detailsOverride) return detailsOverride
+  if (!gist) return null
+  return gist.details || null
+}
+
+function normalizeFileEntries (files) {
+  if (!files) return []
+
+  return Object.keys(files).map(filename => {
+    const file = files[filename] || {}
+    return Object.assign({}, file, {
+      filename: file.filename || filename
+    })
+  })
+}
+
+function getUniqueLanguages (fileEntries) {
+  const languages = new Set()
+  fileEntries.forEach(file => {
+    languages.add(file.language || 'Other')
+  })
+  return [...languages]
+}
+
+function buildSearchRecord (gist, detailsOverride) {
+  const brief = toGistBrief(gist)
+  const details = toGistDetails(gist, detailsOverride)
+  const source = details || brief
+  const filesSource = source.files || brief.files || {}
+  const fileEntries = normalizeFileEntries(filesSource)
+  const filenames = fileEntries.map(file => file.filename).filter(Boolean)
+  const languages = getUniqueLanguages(fileEntries)
+  const searchableFiles = fileEntries
+    .filter(file => typeof file.content === 'string' && file.content.length > 0)
+    .map(file => ({
+      filename: file.filename,
+      language: file.language || 'Other',
+      content: file.content
+    }))
+
+  return {
+    id: source.id || brief.id,
+    description: source.description || brief.description || '',
+    updated_at: source.updated_at || brief.updated_at || '',
+    language: languages.join(','),
+    filename: filenames.join(', '),
+    files: searchableFiles
+  }
+}
+
+function buildExcerptBounds (value, indices, maxLength) {
+  const firstMatch = indices && indices.length > 0 ? indices[0] : [0, 0]
+  const matchStart = firstMatch[0]
+  const matchEnd = firstMatch[1]
+  const matchLength = matchEnd - matchStart + 1
+  const contextLength = Math.min(EXCERPT_CONTEXT_LENGTH, Math.floor(Math.max(0, maxLength - matchLength) / 2))
+  const start = Math.max(0, matchStart - contextLength)
+  const end = Math.min(value.length, matchEnd + 1 + contextLength)
+
+  return { start, end }
+}
+
+function normalizeExcerptText (value) {
+  return value.replace(/\s+/g, ' ')
+}
+
+function createHighlightedSegments (value, indices) {
+  if (!value) return []
+
+  const segments = []
+  let cursor = 0
+  const segmentIndices = (indices || [])
+    .slice()
+    .sort((left, right) => left[0] - right[0])
+
+  segmentIndices.forEach(([start, end]) => {
+    if (start > cursor) {
+      segments.push({
+        text: value.slice(cursor, start),
+        match: false
+      })
+    }
+    segments.push({
+      text: value.slice(start, end + 1),
+      match: true
+    })
+    cursor = end + 1
+  })
+
+  if (cursor < value.length) {
+    segments.push({
+      text: value.slice(cursor),
+      match: false
+    })
+  }
+
+  return segments.filter(segment => segment.text.length > 0)
+}
+
+function createHighlightedExcerpt (value, indices, maxLength = DEFAULT_EXCERPT_LENGTH) {
+  if (!value) {
+    return {
+      text: '',
+      segments: []
+    }
+  }
+
+  const bounds = buildExcerptBounds(value, indices || [], maxLength)
+  const excerptText = value.slice(bounds.start, bounds.end)
+  const segments = []
+
+  if (bounds.start > 0) {
+    segments.push({ text: '...', match: false })
+  }
+
+  let cursor = bounds.start
+  const excerptIndices = (indices || [])
+    .filter(([start, end]) => end >= bounds.start && start < bounds.end)
+    .map(([start, end]) => [
+      Math.max(start, bounds.start),
+      Math.min(end + 1, bounds.end)
+    ])
+    .sort((left, right) => left[0] - right[0])
+
+  excerptIndices.forEach(([start, end]) => {
+    if (start > cursor) {
+      segments.push({
+        text: normalizeExcerptText(value.slice(cursor, start)),
+        match: false
+      })
+    }
+    segments.push({
+      text: normalizeExcerptText(value.slice(start, end)),
+      match: true
+    })
+    cursor = end
+  })
+
+  if (cursor < bounds.end) {
+    segments.push({
+      text: normalizeExcerptText(value.slice(cursor, bounds.end)),
+      match: false
+    })
+  }
+
+  if (bounds.end < value.length) {
+    segments.push({ text: '...', match: false })
+  }
+
+  return {
+    text: normalizeExcerptText(excerptText),
+    segments: segments.filter(segment => segment.text.length > 0)
+  }
+}
+
+function getMatchedFile (record, match) {
+  if (!match || !match.key || !match.key.startsWith('files.')) return null
+  if (typeof match.arrayIndex !== 'number') return null
+  if (!record.files || !record.files[match.arrayIndex]) return null
+  return record.files[match.arrayIndex]
+}
+
+function buildSearchMatch (record, match) {
+  const key = match.key
+  const matchedFile = getMatchedFile(record, match)
+  const isContentMatch = key === 'files.content'
+  const baseLabel = MATCH_KEY_LABELS[key] || key
+  const fileLabel = matchedFile && matchedFile.filename
+    ? `${baseLabel} in ${matchedFile.filename}`
+    : baseLabel
+
+  return {
+    key: key,
+    label: fileLabel,
+    filename: matchedFile ? matchedFile.filename : null,
+    language: matchedFile ? matchedFile.language : null,
+    segments: createHighlightedSegments(match.value, match.indices),
+    excerpt: isContentMatch
+      ? createHighlightedExcerpt(match.value, match.indices)
+      : null
+  }
+}
+
+function compareMatches (left, right) {
+  const leftPriority = MATCH_KEY_PRIORITY[left.key] || 99
+  const rightPriority = MATCH_KEY_PRIORITY[right.key] || 99
+  if (leftPriority !== rightPriority) return leftPriority - rightPriority
+
+  const leftIndex = left.indices && left.indices.length ? left.indices[0][0] : Number.MAX_SAFE_INTEGER
+  const rightIndex = right.indices && right.indices.length ? right.indices[0][0] : Number.MAX_SAFE_INTEGER
+  return leftIndex - rightIndex
+}
+
+function buildSearchMeta (record, fuseResult) {
+  const rawMatches = fuseResult.matches || []
+  const matches = rawMatches
+    .slice()
+    .sort(compareMatches)
+    .map(match => buildSearchMatch(record, match))
+
+  return {
+    score: fuseResult.score,
+    matches: matches,
+    bestMatch: matches[0] || null
+  }
+}
+
+function normalizeFuseResult (fuseResult) {
+  if (!fuseResult || !fuseResult.item) return fuseResult
+
+  const record = fuseResult.item
+  return Object.assign({}, record, {
+    searchMeta: buildSearchMeta(record, fuseResult)
+  })
+}
+
+module.exports = {
+  buildSearchRecord: buildSearchRecord,
+  createHighlightedSegments: createHighlightedSegments,
+  createHighlightedExcerpt: createHighlightedExcerpt,
+  normalizeFuseResult: normalizeFuseResult
+}

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -23,14 +23,12 @@ module.exports = {
         "sorting": "updated_at",
         "sortingReverse": true,
         "expanded": true,
-        "newSnippetPrivate": false
+        "newSnippetPrivate": false,
+        "downloadAll": false
     },
     "tag": {
         "showInSnippetList": false,
         "colored": false
-    },
-    "gist": {
-        "downloadAll": false
     },
     "editor": {
         "tabSize": 4,

--- a/docs/index.html
+++ b/docs/index.html
@@ -178,7 +178,7 @@
                         </div>
                         <center>
                            <img src="img/portfolio/search_bar.png" class="img-responsive" alt="">
-                           <span class="feature-title">Search (⇧ + Space)</span>
+                           <span class="feature-title">Search snippets and content (⇧ + Space)</span>
                         </center>
                     </a>
                 </div>
@@ -277,6 +277,12 @@
                                     <img class="img-responsive img-centered" src="./img/formatted_description.png"/>
                                 </div>
                             <center/>
+                        </div>
+                    </li>
+                    <li class='faq-item'>
+                        <div class="faq-question">What can Search find?</div>
+                        <div class="faq-answer">
+                            Search matches snippet metadata and downloaded file content. Complete global content search requires the download-all gists option (<code>gist.downloadAll</code>) before sync. See the <a class="faq-link" href="https://github.com/hackjutsu/Lepton/blob/master/wiki/faq.md#search" target="_blank">Search FAQ</a>.
                         </div>
                     </li>
                     <li class='faq-item'>
@@ -404,11 +410,11 @@
                 <div class="row">
                     <div class="col-lg-12 col-lg-offset-0">
                         <div class="modal-body">
-                            <h2>Instant Search</h2>
+                            <h2>Search Snippets And Content</h2>
                             <hr class="star-primary">
                             <img src="img/portfolio/search_bar.png" class="img-responsive img-centered" alt="">
                             <p>
-                                Instant search for your gists!
+                                Search snippet metadata and downloaded file content. Complete global content search requires the download-all gists option (<code>gist.downloadAll</code>) before sync.
                             </p>
                             <div class="faq-note">
                                 ⇧ + Space

--- a/docs/index.html
+++ b/docs/index.html
@@ -282,7 +282,7 @@
                     <li class='faq-item'>
                         <div class="faq-question">What can Search find?</div>
                         <div class="faq-answer">
-                            Search matches snippet metadata and downloaded file content. Complete global content search requires the download-all gists option (<code>gist.downloadAll</code>) before sync. See the <a class="faq-link" href="https://github.com/hackjutsu/Lepton/blob/master/wiki/faq.md#search" target="_blank">Search FAQ</a>.
+                            Search matches snippet metadata and downloaded file content. Complete global content search requires the download-all snippets option (<code>snippet.downloadAll</code>) before sync. See the <a class="faq-link" href="https://github.com/hackjutsu/Lepton/blob/master/wiki/faq.md#search" target="_blank">Search FAQ</a>.
                         </div>
                     </li>
                     <li class='faq-item'>
@@ -414,7 +414,7 @@
                             <hr class="star-primary">
                             <img src="img/portfolio/search_bar.png" class="img-responsive img-centered" alt="">
                             <p>
-                                Search snippet metadata and downloaded file content. Complete global content search requires the download-all gists option (<code>gist.downloadAll</code>) before sync.
+                                Search snippet metadata and downloaded file content. Complete global content search requires the download-all snippets option (<code>snippet.downloadAll</code>) before sync.
                             </p>
                             <div class="faq-note">
                                 ⇧ + Space

--- a/tests/utilities/config.test.js
+++ b/tests/utilities/config.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { shouldDownloadAllSnippets } from '../../app/utilities/config'
+
+function createConf (values = {}) {
+  return {
+    get: (key) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : undefined
+  }
+}
+
+describe('configuration utilities', () => {
+  it('uses snippet.downloadAll as the canonical download-all setting', () => {
+    expect(shouldDownloadAllSnippets(createConf({
+      'snippet:downloadAll': true
+    }))).toBe(true)
+  })
+
+  it('keeps gist.downloadAll as a backward-compatible fallback', () => {
+    expect(shouldDownloadAllSnippets(createConf({
+      'gist:downloadAll': true
+    }))).toBe(true)
+  })
+
+  it('disables download-all when neither setting is enabled', () => {
+    expect(shouldDownloadAllSnippets(createConf())).toBe(false)
+  })
+})

--- a/tests/utilities/config.test.js
+++ b/tests/utilities/config.test.js
@@ -14,10 +14,10 @@ describe('configuration utilities', () => {
     }))).toBe(true)
   })
 
-  it('keeps gist.downloadAll as a backward-compatible fallback', () => {
+  it('does not enable download-all from old gist.downloadAll config', () => {
     expect(shouldDownloadAllSnippets(createConf({
       'gist:downloadAll': true
-    }))).toBe(true)
+    }))).toBe(false)
   })
 
   it('disables download-all when neither setting is enabled', () => {

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -167,10 +167,10 @@ describe('GitHub API utility', () => {
     expect(result).toEqual([{ id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }])
   })
 
-  it('uses the authenticated gists endpoint when downloadAll is enabled', async () => {
+  it('uses the authenticated gists endpoint when snippet downloadAll is enabled', async () => {
     const { api, requestPromise } = loadGitHubApi({
       confValues: {
-        'gist:downloadAll': true
+        'snippet:downloadAll': true
       },
       requestPromiseImpl: () => Promise.resolve({
         body: [],
@@ -188,6 +188,25 @@ describe('GitHub API utility', () => {
       },
       qs: { per_page: 100, page: 1 },
       resolveWithFullResponse: true
+    }))
+  })
+
+  it('keeps gist downloadAll as a legacy fallback for the authenticated gists endpoint', async () => {
+    const { api, requestPromise } = loadGitHubApi({
+      confValues: {
+        'gist:downloadAll': true
+      },
+      requestPromiseImpl: () => Promise.resolve({
+        body: [],
+        headers: {}
+      })
+    })
+
+    await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
+
+    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
+      uri: 'https://api.github.com/gists',
+      qs: { per_page: 100, page: 1 }
     }))
   })
 })

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -191,7 +191,7 @@ describe('GitHub API utility', () => {
     }))
   })
 
-  it('keeps gist downloadAll as a legacy fallback for the authenticated gists endpoint', async () => {
+  it('ignores old gist downloadAll config for the authenticated gists endpoint', async () => {
     const { api, requestPromise } = loadGitHubApi({
       confValues: {
         'gist:downloadAll': true
@@ -205,7 +205,7 @@ describe('GitHub API utility', () => {
     await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
 
     expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
-      uri: 'https://api.github.com/gists',
+      uri: 'https://api.github.com/users/octo/gists',
       qs: { per_page: 100, page: 1 }
     }))
   })

--- a/tests/utilities/search.test.js
+++ b/tests/utilities/search.test.js
@@ -35,26 +35,239 @@ describe('search utility', () => {
     expect(SearchIndex.fuseSearch('hooks')).toEqual([
       expect.objectContaining({ id: 'gist-1' })
     ])
+    expect(SearchIndex.fuseSearch('HOOKS')).toEqual([
+      expect.objectContaining({ id: 'gist-1' })
+    ])
+    expect(SearchIndex.fuseSearch('hoks')).toEqual([])
+    expect(SearchIndex.fuseSearch('react note')).toEqual([
+      expect.objectContaining({
+        id: 'gist-1',
+        searchMeta: expect.objectContaining({
+          matches: expect.arrayContaining([
+            expect.objectContaining({
+              key: 'description',
+              segments: expect.arrayContaining([
+                expect.objectContaining({ match: true, text: 'React' }),
+                expect.objectContaining({ match: true, text: 'note' })
+              ])
+            })
+          ])
+        })
+      })
+    ])
+  })
+
+  it('searches loaded gist file content', () => {
+    SearchIndex.resetFuseIndex([
+      SearchIndex.buildSearchRecord({
+        id: 'gist-1',
+        description: 'Utility helper',
+        files: {
+          'helper.js': {
+            language: 'JavaScript',
+            content: 'export const hiddenNeedle = true\n'
+          }
+        }
+      })
+    ])
+    SearchIndex.initFuseSearch()
+
+    expect(SearchIndex.fuseSearch('hiddenneedle true')).toEqual([
+      expect.objectContaining({
+        id: 'gist-1',
+        searchMeta: expect.objectContaining({
+          matches: expect.arrayContaining([
+            expect.objectContaining({
+              key: 'files.content',
+              segments: expect.arrayContaining([
+                expect.objectContaining({ match: true, text: 'hiddenNeedle' }),
+                expect.objectContaining({ match: true, text: 'true' })
+              ])
+            })
+          ]),
+          bestMatch: expect.objectContaining({
+            key: 'files.content',
+            filename: 'helper.js',
+            excerpt: expect.objectContaining({
+              segments: expect.arrayContaining([
+                expect.objectContaining({ match: true, text: 'hiddenNeedle' }),
+                expect.objectContaining({ match: true, text: 'true' })
+              ])
+            })
+          })
+        })
+      })
+    ])
   })
 
   it('adds and updates indexed items', () => {
-    SearchIndex.addToFuseIndex({
+    SearchIndex.addToFuseIndex(SearchIndex.buildSearchRecord({
       id: 'gist-1',
       description: 'old description',
-      filename: 'old.js',
-      language: 'JavaScript'
-    })
-    SearchIndex.updateFuseIndex({
+      files: {
+        'old.js': {
+          language: 'JavaScript',
+          content: 'const staleNeedle = true'
+        }
+      }
+    }))
+    SearchIndex.updateFuseIndex(SearchIndex.buildSearchRecord({
       id: 'gist-1',
       description: 'updated markdown guide',
-      filename: 'guide.md',
-      language: 'Markdown'
-    })
+      files: {
+        'guide.md': {
+          language: 'Markdown',
+          content: 'const freshNeedle = true'
+        }
+      }
+    }))
     SearchIndex.initFuseSearch()
 
     expect(SearchIndex.fuseSearch('updated')).toEqual([
       expect.objectContaining({ id: 'gist-1', filename: 'guide.md' })
     ])
     expect(SearchIndex.fuseSearch('old')).toEqual([])
+    expect(SearchIndex.fuseSearch('staleNeedle')).toEqual([])
+    expect(SearchIndex.fuseSearch('freshNeedle')).toEqual([
+      expect.objectContaining({ id: 'gist-1' })
+    ])
+  })
+
+  it('builds a brief-only search record without content files', () => {
+    expect(SearchIndex.buildSearchRecord({
+      id: 'gist-1',
+      description: 'Brief result',
+      updated_at: '2024-01-02T03:04:05Z',
+      files: {
+        'brief.js': {
+          language: 'JavaScript'
+        },
+        'notes.md': {
+          language: 'Markdown',
+          content: null
+        }
+      }
+    })).toEqual({
+      id: 'gist-1',
+      description: 'Brief result',
+      updated_at: '2024-01-02T03:04:05Z',
+      language: 'JavaScript,Markdown',
+      filename: 'brief.js, notes.md',
+      files: []
+    })
+  })
+
+  it('builds a content search record from loaded details', () => {
+    const record = SearchIndex.buildSearchRecord({
+      brief: {
+        id: 'gist-1',
+        description: 'Brief description',
+        updated_at: '2024-01-01T00:00:00Z',
+        files: {
+          'app.js': { language: 'JavaScript' }
+        }
+      },
+      details: {
+        id: 'gist-1',
+        description: 'Detailed description',
+        updated_at: '2024-02-01T00:00:00Z',
+        files: {
+          'app.js': {
+            language: 'JavaScript',
+            content: 'const loaded = true'
+          }
+        }
+      }
+    })
+
+    expect(record).toEqual({
+      id: 'gist-1',
+      description: 'Detailed description',
+      updated_at: '2024-02-01T00:00:00Z',
+      language: 'JavaScript',
+      filename: 'app.js',
+      files: [
+        {
+          filename: 'app.js',
+          language: 'JavaScript',
+          content: 'const loaded = true'
+        }
+      ]
+    })
+  })
+
+  it('builds search records from created and edited gist shapes', () => {
+    const createdDetails = {
+      id: 'gist-created',
+      description: 'Created gist',
+      files: {
+        'created.js': {
+          language: 'JavaScript',
+          content: 'const created = true'
+        }
+      }
+    }
+    const editedDetails = {
+      id: 'gist-edited',
+      description: 'Edited gist',
+      files: {
+        'edited.py': {
+          language: 'Python',
+          content: 'edited_value = True'
+        }
+      }
+    }
+
+    expect(SearchIndex.buildSearchRecord(createdDetails)).toEqual(expect.objectContaining({
+      id: 'gist-created',
+      filename: 'created.js',
+      language: 'JavaScript',
+      files: [
+        expect.objectContaining({ content: 'const created = true' })
+      ]
+    }))
+
+    expect(SearchIndex.buildSearchRecord({
+      langs: new Set(['Python']),
+      brief: editedDetails,
+      details: editedDetails,
+      filename: ', edited.py'
+    })).toEqual(expect.objectContaining({
+      id: 'gist-edited',
+      filename: 'edited.py',
+      language: 'Python',
+      files: [
+        expect.objectContaining({ content: 'edited_value = True' })
+      ]
+    }))
+  })
+
+  it('creates safe highlighted excerpt segments', () => {
+    const excerpt = SearchIndex.createHighlightedExcerpt(
+      'alpha beta gamma delta',
+      [[6, 9]],
+      20
+    )
+
+    expect(excerpt.segments).toEqual(expect.arrayContaining([
+      expect.objectContaining({ match: false, text: expect.stringContaining('alpha') }),
+      expect.objectContaining({ match: true, text: 'beta' })
+    ]))
+  })
+
+  it('keeps content excerpts focused near the matched phrase', () => {
+    const excerpt = SearchIndex.createHighlightedExcerpt(
+      `${'prefix '.repeat(40)}target ${'suffix '.repeat(40)}`,
+      [[280, 285]]
+    )
+    const matchIndex = excerpt.segments.findIndex(segment => segment.match)
+    const textBeforeMatch = excerpt.segments
+      .slice(0, matchIndex)
+      .map(segment => segment.text)
+      .join('')
+
+    expect(excerpt.segments[0]).toEqual({ text: '...', match: false })
+    expect(excerpt.segments).toContainEqual({ text: 'target', match: true })
+    expect(textBeforeMatch.length).toBeLessThanOrEqual(40)
   })
 })

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -2,5 +2,5 @@
 
 These pages are the canonical, versioned replacement for the old GitHub wiki.
 
-- [Configuration](configuration.md), including `gist.downloadAll` for complete global content search
+- [Configuration](configuration.md), including `snippet.downloadAll` for complete global content search
 - [FAQ](faq.md), including searchable fields and content-search behavior

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -2,5 +2,5 @@
 
 These pages are the canonical, versioned replacement for the old GitHub wiki.
 
-- [Configuration](configuration.md), including `snippet.downloadAll` for complete global content search
-- [FAQ](faq.md), including searchable fields and content-search behavior
+- [Configuration](configuration.md)
+- [FAQ](faq.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -2,6 +2,5 @@
 
 These pages are the canonical, versioned replacement for the old GitHub wiki.
 
-- [Configuration](configuration.md)
-- [FAQ](faq.md)
-
+- [Configuration](configuration.md), including `gist.downloadAll` for complete global content search
+- [FAQ](faq.md), including searchable fields and content-search behavior

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -89,7 +89,7 @@ The file is not generated automatically. Create it if you want to override the d
 | | `newSnippetPrivate` | `false` | Create new snippets as secret gists by default. |
 | `tag` | `showInSnippetList` | `false` | Show custom tags in snippet list rows. |
 | | `colored` | `false` | Render custom tags with stable color badges. |
-| `gist` | `downloadAll` | `false` | Load all authenticated gists from the authenticated gists endpoint instead of the user public-gists endpoint. |
+| `gist` | `downloadAll` | `false` | Load all authenticated gists and download their details during sync. Enable this for complete global content search across snippet file contents. |
 | `editor` | `tabSize` | `4` | Tab size in spaces. |
 | | `validateFilename` | `true` | Validate gist filenames before saving. |
 | `enterprise` | `enable` | `false` | Enable GitHub Enterprise mode. |

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -98,7 +98,7 @@ The file is not generated automatically. Create it if you want to override the d
 | | `avatarUrl` | `""` | Optional avatar image URL for GitHub Enterprise users. |
 | `notifications` | `success` | `true` | Show notifications for successful actions. |
 | | `failure` | `true` | Show notifications for failed actions. |
-| `shortcuts` | `keyShortcutForSearch` | `Shift+Space` | Open search. |
+| `shortcuts` | `keyShortcutForSearch` | `Shift+Space` | Open snippet metadata and downloaded-content search. |
 | | `keyNewGist` | `CommandOrControl+N` | Create a snippet. |
 | | `keyEditGist` | `CommandOrControl+E` | Edit the selected snippet. |
 | | `keyDeleteGist` | `CommandOrControl+Delete` | Delete the selected snippet. |

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -32,14 +32,12 @@ The file is not generated automatically. Create it if you want to override the d
     "sorting": "updated_at",
     "sortingReverse": true,
     "expanded": true,
-    "newSnippetPrivate": false
+    "newSnippetPrivate": false,
+    "downloadAll": false
   },
   "tag": {
     "showInSnippetList": false,
     "colored": false
-  },
-  "gist": {
-    "downloadAll": false
   },
   "editor": {
     "tabSize": 4,
@@ -87,9 +85,9 @@ The file is not generated automatically. Create it if you want to override the d
 | | `sortingReverse` | `true` | Reverse the configured snippet order. |
 | | `expanded` | `true` | Expand snippets in the detail view by default. |
 | | `newSnippetPrivate` | `false` | Create new snippets as secret gists by default. |
+| | `downloadAll` | `false` | Load all authenticated snippets and download their details during sync. Enable this for complete global content search across snippet file contents. |
 | `tag` | `showInSnippetList` | `false` | Show custom tags in snippet list rows. |
 | | `colored` | `false` | Render custom tags with stable color badges. |
-| `gist` | `downloadAll` | `false` | Load all authenticated gists and download their details during sync. Enable this for complete global content search across snippet file contents. |
 | `editor` | `tabSize` | `4` | Tab size in spaces. |
 | | `validateFilename` | `true` | Validate gist filenames before saving. |
 | `enterprise` | `enable` | `false` | Enable GitHub Enterprise mode. |

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -25,11 +25,11 @@ Lepton can search these fields:
 - downloaded snippet file content
 
 Complete global content search across every snippet requires the
-`gist.downloadAll` option to be enabled before syncing. When `downloadAll` is
-disabled, content search only covers gists whose details and file content have
+`snippet.downloadAll` option to be enabled before syncing. When `downloadAll` is
+disabled, content search only covers snippets whose details and file content have
 already been downloaded locally, such as snippets opened during the session.
 
-See [Configuration](configuration.md#options) for the `gist.downloadAll` option.
+See [Configuration](configuration.md#options) for the `snippet.downloadAll` option.
 
 ## Title And Tags
 

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -18,9 +18,16 @@ The default search shortcut is `Shift + Space`.
 Lepton can search these fields:
 
 - filename
+- language
 - description
 - tag
 - gist id
+- downloaded snippet file content
+
+Complete global content search across every snippet requires the
+`gist.downloadAll` option to be enabled before syncing. When `downloadAll` is
+disabled, content search only covers gists whose details and file content have
+already been downloaded locally, such as snippets opened during the session.
 
 ## Title And Tags
 
@@ -89,4 +96,3 @@ Lepton is a desktop GitHub Gist client and does not run its own sync service. Da
 Lepton does not accept personal donations. If you want to donate, consider donating to the [Wikimedia Foundation](https://wikimediafoundation.org/wiki/Ways_to_Give), which helps sustain free knowledge through Wikipedia and related projects.
 
 You are welcome to create an issue to share how much you contributed.
-

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -29,6 +29,8 @@ Complete global content search across every snippet requires the
 disabled, content search only covers gists whose details and file content have
 already been downloaded locally, such as snippets opened during the session.
 
+See [Configuration](configuration.md#options) for the `gist.downloadAll` option.
+
 ## Title And Tags
 
 Use this pattern in the gist description to set a title and custom tags:


### PR DESCRIPTION
## Summary

Adds exact, case-insensitive global search over loaded gist details, including snippet file content when gist details are available.

## Requirement

Complete global content search across every snippet requires `snippet.downloadAll` to be enabled before syncing. With `snippet.downloadAll: true`, sync downloads all snippet details and file content, so content search becomes complete after sync. When it is disabled, content search only covers snippets whose details/content have already been downloaded locally.

## Issues

Closes hackjutsu/Lepton#82
Closes hackjutsu/Lepton#254

## Changes

- Adds a shared search-record builder used by sync, create, edit, fixture render data, and lazy single-gist fetches.
- Extends search records with indexed files and content while preserving the existing result shape.
- Replaces fuzzy matching with deterministic, case-insensitive token matching and normalized match metadata for UI rendering.
- Updates the Shift+Space search modal with result counts, match-source labels, highlighted matched phrases, content excerpts, filename chips, and last-updated timestamps.
- Updates README, wiki, and docs-site Search/FAQ copy to describe metadata plus downloaded-content search, with the detailed `snippet.downloadAll` requirement kept in the versioned wiki docs.
- Updates `AGENTS.md` with the search-record builder and download-all guidance for future coding agents.
- Moves the download-all setting into `snippet.downloadAll`; `gist.downloadAll` is not supported because the feature has not shipped.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`

Notes: existing Dart Sass legacy JS API and CodeMirror dynamic require warnings still appear during build/smoke output; this PR does not introduce or address those warnings.
