### PR TITLE
[codex] Fix GitHub Actions Node 20 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -68,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
## Summary

Updates the GitHub Actions workflow to use Node 24-compatible action runtimes.

- Bumps `actions/checkout` from v4 to v5 in all CI jobs.
- Bumps `actions/setup-node` from v4 to v5 in all CI jobs.
- Leaves the project Node version, npm setup, caching, and job structure unchanged.

## Why

GitHub Actions is deprecating Node.js 20 for JavaScript actions. The project already targets Node 24 through `.nvmrc` and package engines, but checkout/setup-node v4 still run internally on Node 20 and trigger CI warnings.

## Validation

- `npm test` - 22 Vitest files / 107 tests passed, followed by webpack development build verification.

## Notes

Webpack still emits the existing Dart Sass legacy JS API deprecation messages and the known CodeMirror dynamic require warning during build verification. Those are unrelated to this workflow-only change.