### PR TITLE
[codex] Clean up build warnings

### DIFF
--- a/app/containers/gistEditor/index.js
+++ b/app/containers/gistEditor/index.js
@@ -133,7 +133,6 @@ import 'codemirror/mode/sass/sass'
 import 'codemirror/addon/edit/matchbrackets'
 import 'codemirror/addon/edit/matchtags'
 import 'codemirror/addon/dialog/dialog'
-import 'codemirror/addon/mode/loadmode'
 import 'codemirror/addon/search/search'
 import 'codemirror/addon/search/match-highlighter'
 import 'codemirror/addon/search/searchcursor'
@@ -234,7 +233,6 @@ class GistEditor extends Component {
     const { filename } = this.props
 
     this.CodeMirror = this.editor.getCodeMirrorInstance()
-    this.CodeMirror.modeURL = '../../../node_modules/codemirror/mode/%N/%N.js'
     this.setMode(filename)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "license-checker-evergreen": "^6.3.1",
         "raw-loader": "^4.0.0",
         "sass": "^1.69.7",
-        "sass-loader": "^8.0.0",
+        "sass-loader": "^16.0.5",
         "style-loader": "^1.2.1",
         "text-loader": "0.0.1",
         "url-loader": "^4.1.0",
@@ -9685,32 +9685,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -12236,32 +12210,30 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
+      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
+        "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 8.9.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0",
+        "@rspack/core": "0.x || 1.x",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -12269,34 +12241,13 @@
         },
         "sass": {
           "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.5",
-        "ajv": "^6.12.4",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/sass-loader/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/sass/node_modules/immutable": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "license-checker-evergreen": "^6.3.1",
     "raw-loader": "^4.0.0",
     "sass": "^1.69.7",
-    "sass-loader": "^8.0.0",
+    "sass-loader": "^16.0.5",
     "style-loader": "^1.2.1",
     "text-loader": "0.0.1",
     "url-loader": "^4.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = {
         {
           loader: 'sass-loader',
           options: {
-            implementation: require('sass')
+            implementation: require('sass'),
+            api: 'modern'
           }
         }
       ]


### PR DESCRIPTION
## Summary

Removes the build warnings called out in prior build/smoke output.

- Upgrades `sass-loader` from 8.x to 16.x and opts into Dart Sass's modern API.
- Removes CodeMirror's unused dynamic mode loader import and `modeURL` setup now that modes are statically bundled.
- Leaves generated `license.json` churn out of the diff.

## Validation

- `npm test` - 22 Vitest files, 107 tests, plus webpack development build
- `npm run build` - webpack compiled successfully without the Dart Sass legacy JS API or CodeMirror dynamic require warnings
- `LEPTON_SMOKE_NO_SANDBOX=1 npm run test:smoke`
- `git diff --check`

## Notes

`npm run build` still emits a separate existing Node `DEP0170` warning from `markdown-it-katex` license metadata during `npm run license`; this PR does not address that unrelated warning.