### PR TITLE
[codex] Replace request stack with Electron fetch

### DIFF
--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -1,7 +1,5 @@
 const { Promise } = require('bluebird')
-const ProxyAgent = require('proxy-agent')
-const ReqPromise = require('request-promise')
-const Request = require('request')
+const { createFetchRequest } = require('./fetchAdapter')
 
 const TAG = '[REST] '
 const kTimeoutUnit = 10 * 1000 // ms
@@ -21,36 +19,26 @@ const DELETE_SINGLE_GIST = 'DELETE_SINGLE_GIST'
 function createGitHubApi ({
   conf,
   logger,
-  ProxyAgentImpl = ProxyAgent,
-  requestPromiseImpl = ReqPromise,
-  requestImpl = Request
-}) {
+  fetchImpl
+} = {}) {
   const apiLogger = logger || {
     debug: () => {},
     error: () => {},
     info: () => {}
   }
+  const apiRequest = createFetchRequest(fetchImpl)
   let gitHubHostApi = 'api.github.com'
-  let proxyAgent = null
 
-  if (conf) {
-    if (conf.get('proxy:enable')) {
-      const proxyUri = conf.get('proxy:address')
-      proxyAgent = new ProxyAgentImpl(proxyUri)
-      apiLogger.info('[.leptonrc] Use proxy', proxyUri)
-    }
-    if (conf.get('enterprise:enable')) {
-      const gitHubHost = conf.get('enterprise:host')
-      gitHubHostApi = `${gitHubHost}/api/v3`
-    }
+  if (conf && conf.get('enterprise:enable')) {
+    const gitHubHost = conf.get('enterprise:host')
+    gitHubHostApi = `${gitHubHost}/api/v3`
   }
 
   function exchangeAccessToken (clientId, clientSecret, authCode) {
     apiLogger.debug(TAG + 'Exchanging authCode with access token')
-    return requestPromiseImpl({
+    return apiRequest({
       method: 'POST',
       uri: 'https://github.com/login/oauth/access_token',
-      agent: proxyAgent,
       form: {
         client_id: clientId,
         client_secret: clientSecret,
@@ -63,9 +51,8 @@ function createGitHubApi ({
 
   function getUserProfile (token) {
     apiLogger.debug(TAG + 'Getting user profile with token ' + token)
-    return requestPromiseImpl({
+    return apiRequest({
       uri: `https://${gitHubHostApi}/user`,
-      agent: proxyAgent,
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
@@ -78,9 +65,8 @@ function createGitHubApi ({
 
   function getSingleGist (token, gistId) {
     apiLogger.debug(TAG + `Getting single gist ${gistId} with token ${token}`)
-    return requestPromiseImpl({
+    return apiRequest({
       uri: `https://${gitHubHostApi}/gists/${gistId}`,
-      agent: proxyAgent,
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
@@ -104,6 +90,11 @@ function createGitHubApi ({
         }
 
         const matches = res.headers.link.match(/page=[0-9]*/g)
+        if (!matches || matches.length === 0) {
+          apiLogger.debug(TAG + '[V2] The header link property does not include page markers')
+          return sortGistsByUpdatedAt(gistList)
+        }
+
         const maxPage = matches[matches.length - 1].substring('page='.length)
         apiLogger.debug(TAG + `[V2] The max page number for gist is ${maxPage}`)
 
@@ -120,10 +111,7 @@ function createGitHubApi ({
 
   function requestGists (token, userId, page, gistList) {
     apiLogger.debug(TAG + '[V2] Requesting gists with page ' + page)
-    return requestPromiseImpl(makeOptionForGetAllGists(token, userId, page))
-      .catch(err => {
-        apiLogger.error(err)
-      })
+    return apiRequest(makeOptionForGetAllGists(token, userId, page))
       .then(res => {
         parseBody(res.body, gistList)
         return res
@@ -131,6 +119,8 @@ function createGitHubApi ({
   }
 
   function parseBody (res, gistList) {
+    if (!res) return
+
     for (const key in res) {
       if (Object.prototype.hasOwnProperty.call(res, key)) gistList.push(res[key])
     }
@@ -143,48 +133,28 @@ function createGitHubApi ({
   function getAllGistsV1 (token, userId) {
     apiLogger.debug(TAG + `[V1] Getting all gists of ${userId} with token ${token}`)
     const gistList = []
-    return new Promise(resolve => {
-      const maxPageNumber = 100
-      const funcs = Promise.resolve(
-        makeRangeArr(1, maxPageNumber).map(
-          (n) => makeRequestForGetAllGists(makeOptionForGetAllGists(token, userId, n))))
+    const maxPageNumber = 100
 
-      funcs.mapSeries(iterator)
-        .catch(err => {
-          if (err !== EMPTY_PAGE_ERROR_MESSAGE) {
-            apiLogger.error(err)
+    return Promise.mapSeries(makeRangeArr(1, maxPageNumber), page => {
+      return apiRequest(makeOptionForGetAllGists(token, userId, page))
+        .then(res => {
+          const body = Array.isArray(res.body) ? res.body : []
+          apiLogger.debug('The gist number on this page is ' + body.length)
+
+          if (body.length === 0) {
+            throw EMPTY_PAGE_ERROR_MESSAGE
           }
-        })
-        .finally(() => {
-          resolve(gistList)
+
+          parseBody(body, gistList)
+          return body
         })
     })
-
-    function iterator (f) {
-      return f()
-    }
-
-    function makeRequestForGetAllGists (option) {
-      return () => {
-        return new Promise((resolve, reject) => {
-          requestImpl(option, (error, response, body) => {
-            apiLogger.debug('The gist number on this page is ' + body.length)
-            if (error) {
-              reject(error)
-            } else if (body.length === 0) {
-              reject(EMPTY_PAGE_ERROR_MESSAGE)
-            } else {
-              for (const key in body) {
-                if (Object.prototype.hasOwnProperty.call(body, key)) {
-                  gistList.push(body[key])
-                }
-              }
-              resolve(body)
-            }
-          })
-        })
-      }
-    }
+      .catch(err => {
+        if (err !== EMPTY_PAGE_ERROR_MESSAGE) {
+          apiLogger.error(err)
+        }
+      })
+      .then(() => gistList)
   }
 
   function makeRangeArr (start, end) {
@@ -201,7 +171,6 @@ function createGitHubApi ({
 
     return {
       uri: uri,
-      agent: proxyAgent,
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
@@ -219,14 +188,13 @@ function createGitHubApi ({
 
   function createSingleGist (token, description, files, isPublic) {
     apiLogger.debug(TAG + 'Creating single gist')
-    return requestPromiseImpl({
+    return apiRequest({
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
       },
       method: 'POST',
       uri: `https://${gitHubHostApi}/gists`,
-      agent: proxyAgent,
       body: {
         description: description,
         public: isPublic,
@@ -239,14 +207,13 @@ function createGitHubApi ({
 
   function editSingleGist (token, gistId, updatedDescription, updatedFiles) {
     apiLogger.debug(TAG + 'Editing single gist ' + gistId)
-    return requestPromiseImpl({
+    return apiRequest({
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
       },
       method: 'PATCH',
       uri: `https://${gitHubHostApi}/gists/${gistId}`,
-      agent: proxyAgent,
       body: {
         description: updatedDescription,
         files: updatedFiles
@@ -258,14 +225,13 @@ function createGitHubApi ({
 
   function deleteSingleGist (token, gistId) {
     apiLogger.debug(TAG + 'Deleting single gist ' + gistId)
-    return requestPromiseImpl({
+    return apiRequest({
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
       },
       method: 'DELETE',
       uri: `https://${gitHubHostApi}/gists/${gistId}`,
-      agent: proxyAgent,
       json: true,
       timeout: 2 * kTimeoutUnit
     })

--- a/app/utilities/githubApi/fetchAdapter.js
+++ b/app/utilities/githubApi/fetchAdapter.js
@@ -1,0 +1,196 @@
+function createElectronFetchImpl () {
+  const electron = require('electron')
+  const defaultSession = electron && electron.session && electron.session.defaultSession
+
+  if (defaultSession && typeof defaultSession.fetch === 'function') {
+    return defaultSession.fetch.bind(defaultSession)
+  }
+
+  if (electron && electron.net && typeof electron.net.fetch === 'function') {
+    return electron.net.fetch.bind(electron.net)
+  }
+
+  throw new Error('Electron fetch API is unavailable')
+}
+
+function createFetchRequest (fetchImpl) {
+  const doFetch = fetchImpl || createElectronFetchImpl()
+
+  return function fetchRequest (options) {
+    const url = buildFetchUrl(options.uri, options.qs)
+    const init = buildFetchInit(options)
+    let timeoutId = null
+
+    if (options.timeout && typeof AbortController !== 'undefined') {
+      const controller = new AbortController()
+      init.signal = controller.signal
+      timeoutId = setTimeout(() => controller.abort(), options.timeout)
+    }
+
+    return Promise.resolve(doFetch(url, init))
+      .then(response => {
+        return readResponseBody(response, options.json)
+          .then(body => {
+            if (!isSuccessfulResponse(response)) {
+              throw createStatusCodeError(response, body)
+            }
+
+            if (options.resolveWithFullResponse) {
+              return {
+                body: body,
+                headers: headersToObject(response.headers),
+                statusCode: response.status,
+                statusMessage: response.statusText
+              }
+            }
+
+            return body
+          })
+      })
+      .finally(() => {
+        if (timeoutId) clearTimeout(timeoutId)
+      })
+  }
+}
+
+function buildFetchUrl (uri, query) {
+  const url = new URL(uri)
+
+  if (query) {
+    Object.keys(query).forEach(key => {
+      url.searchParams.set(key, query[key])
+    })
+  }
+
+  return url.toString()
+}
+
+function buildFetchInit (options) {
+  const headers = buildHeaders(options)
+  const body = buildBody(options, headers)
+  const init = {
+    method: options.method || 'GET',
+    headers: headers
+  }
+
+  if (body !== undefined) {
+    init.body = body
+  }
+
+  return init
+}
+
+function buildHeaders (options) {
+  const headers = Object.assign({}, options.headers)
+
+  if (options.json) {
+    setHeaderIfMissing(headers, 'Accept', 'application/json')
+  }
+
+  return headers
+}
+
+function buildBody (options, headers) {
+  if (options.form) {
+    const formBody = new URLSearchParams()
+    Object.keys(options.form).forEach(key => {
+      formBody.append(key, options.form[key])
+    })
+    setHeaderIfMissing(headers, 'Content-Type', 'application/x-www-form-urlencoded')
+    return formBody.toString()
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+    if (options.json) {
+      setHeaderIfMissing(headers, 'Content-Type', 'application/json')
+      return JSON.stringify(options.body)
+    }
+
+    return options.body
+  }
+
+  return undefined
+}
+
+function setHeaderIfMissing (headers, name, value) {
+  if (!hasHeader(headers, name)) {
+    headers[name] = value
+  }
+}
+
+function hasHeader (headers, name) {
+  const normalizedName = name.toLowerCase()
+  return Object.keys(headers).some(header => header.toLowerCase() === normalizedName)
+}
+
+function readResponseBody (response, shouldParseJson) {
+  return response.text()
+    .then(text => {
+      if (!shouldParseJson) return text
+      if (!text) return null
+      return JSON.parse(text)
+    })
+}
+
+function isSuccessfulResponse (response) {
+  if (typeof response.ok === 'boolean') return response.ok
+  return response.status >= 200 && response.status < 300
+}
+
+function createStatusCodeError (response, body) {
+  const statusCode = response.status || 0
+  const statusMessage = response.statusText || ''
+  const message = `GitHub API request failed with status ${statusCode}${statusMessage ? ' ' + statusMessage : ''}`
+  const error = new Error(message)
+
+  error.name = 'StatusCodeError'
+  error.status = statusCode
+  error.statusCode = statusCode
+  error.error = body
+  error.response = {
+    body: body,
+    headers: headersToObject(response.headers),
+    statusCode: statusCode,
+    statusMessage: statusMessage
+  }
+
+  return error
+}
+
+function headersToObject (headers) {
+  const result = {}
+
+  if (!headers) return result
+
+  if (typeof headers.forEach === 'function') {
+    headers.forEach((value, key) => {
+      result[key.toLowerCase()] = value
+    })
+  } else {
+    Object.keys(headers).forEach(key => {
+      result[key.toLowerCase()] = headers[key]
+    })
+  }
+
+  const linkHeader = getHeaderValue(headers, 'link')
+  if (linkHeader && !result.link) {
+    result.link = linkHeader
+  }
+
+  return result
+}
+
+function getHeaderValue (headers, name) {
+  if (!headers) return undefined
+
+  if (typeof headers.get === 'function') {
+    return headers.get(name)
+  }
+
+  return headers[name] || headers[name.toLowerCase()]
+}
+
+module.exports = {
+  createElectronFetchImpl,
+  createFetchRequest
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "nconf": "^0.11.4",
         "notebookjs": "^0.6.0",
         "prismjs": "^1.30.0",
-        "proxy-agent": "^4.0.0",
         "react": "^19.2.7",
         "react-bootstrap": "^0.32.4",
         "react-dom": "^19.2.7",
@@ -44,8 +43,6 @@
         "react-split-pane": "^3.2.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "request": "^2.88.0",
-        "request-promise": "^4.2.2",
         "twitter-text": "^3.0.0",
         "valid-filename": "^3.1.0",
         "winston": "^3.19.0"
@@ -3892,6 +3889,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4370,14 +4368,6 @@
         "node": ">=8.11"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/asn1js": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
@@ -4400,14 +4390,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4417,22 +4399,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ast-types/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -4503,18 +4469,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/aws4": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true
     },
     "node_modules/babel-loader": {
       "version": "8.4.1",
@@ -4651,14 +4610,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/big.js": {
@@ -4862,14 +4813,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
@@ -4999,11 +4942,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -5327,7 +5265,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -5425,25 +5364,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/data-urls": {
       "version": "2.0.0",
@@ -5573,7 +5493,8 @@
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw=="
+      "integrity": "sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==",
+      "dev": true
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -5619,54 +5540,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/degenerator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
-      "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/degenerator/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -5833,15 +5712,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ejs": {
@@ -7191,6 +7061,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -7262,23 +7133,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7300,12 +7159,14 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -7427,14 +7288,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-      "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/filelist": {
@@ -7573,14 +7426,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
@@ -7636,47 +7481,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/ftp": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-      "integrity": "sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ftp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/ftp/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/ftp/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-    },
-    "node_modules/ftp/node_modules/xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/function-bind": {
@@ -7827,51 +7631,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-      "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/get-uri/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/get-uri/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -7980,27 +7739,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has": {
       "version": "1.0.4",
@@ -8223,25 +7961,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -8253,20 +7972,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/http2-wrapper": {
@@ -8420,19 +8125,6 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8817,11 +8509,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -8900,11 +8587,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
     "node_modules/jake": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
@@ -8981,11 +8663,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "node_modules/jsdom": {
       "version": "16.7.0",
@@ -9074,15 +8751,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9093,7 +8766,9 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -9124,20 +8799,6 @@
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -9753,6 +9414,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -10275,14 +9937,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -10505,14 +10159,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A=="
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -10659,34 +10305,6 @@
         "fn.name": "1.x.x"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/optionator/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -10728,38 +10346,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-      "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^4.1.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
-      "dependencies": {
-        "degenerator": "^2.2.0",
-        "ip": "^1.1.5",
-        "netmask": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/param-case": {
@@ -10855,11 +10441,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11159,14 +10740,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -11258,29 +10831,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "node_modules/proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
-      "dependencies": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^4.1.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -11366,14 +10916,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -11410,20 +10952,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/raw-loader": {
@@ -11884,108 +11412,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12228,25 +11654,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -12509,11 +11916,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -12655,41 +12057,6 @@
         "node": "*"
       }
     },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/socks/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -12795,30 +12162,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -12844,28 +12187,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -13431,14 +12758,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -13531,22 +12850,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    },
     "node_modules/twemoji-parser": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-11.0.2.tgz",
@@ -13567,17 +12870,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
-    },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -13764,16 +13056,9 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/unused-filename": {
@@ -13887,6 +13172,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -13986,15 +13272,6 @@
       "integrity": "sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
@@ -14020,19 +13297,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vitest": {
@@ -14151,28 +13415,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vitest/node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vitest/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/vitest/node_modules/vite": {
       "version": "8.1.0",
@@ -14780,6 +14022,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14866,7 +14109,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "nconf": "^0.11.4",
     "notebookjs": "^0.6.0",
     "prismjs": "^1.30.0",
-    "proxy-agent": "^4.0.0",
     "react": "^19.2.7",
     "react-bootstrap": "^0.32.4",
     "react-dom": "^19.2.7",
@@ -110,8 +109,6 @@
     "react-split-pane": "^3.2.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
-    "request": "^2.88.0",
-    "request-promise": "^4.2.2",
     "twitter-text": "^3.0.0",
     "valid-filename": "^3.1.0",
     "winston": "^3.19.0"

--- a/tests/utilities/electronProxy.test.js
+++ b/tests/utilities/electronProxy.test.js
@@ -50,7 +50,7 @@ describe('Electron proxy utility', () => {
       .toBe('http=proxy1:80;socks=socks-proxy:1080')
   })
 
-  it('maps proxy-agent PAC addresses to Electron PAC script mode', () => {
+  it('maps PAC addresses to Electron PAC script mode', () => {
     expect(createElectronProxyConfig(createConf({
       'proxy:enable': true,
       'proxy:address': 'pac+https://proxy.example.test/proxy.pac'

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import githubApiCore from '../../app/utilities/githubApi/core'
 
 const {
+  CREATE_SINGLE_GIST,
+  DELETE_SINGLE_GIST,
   EXCHANGE_ACCESS_TOKEN,
   GET_ALL_GISTS,
   GET_SINGLE_GIST,
@@ -21,80 +23,101 @@ function createConf (values = {}) {
   }
 }
 
+function createHeaders (values = {}) {
+  const normalizedValues = {}
+  Object.keys(values).forEach(key => {
+    normalizedValues[key.toLowerCase()] = values[key]
+  })
+
+  return {
+    forEach: (callback) => {
+      Object.keys(normalizedValues).forEach(key => callback(normalizedValues[key], key))
+    },
+    get: (key) => normalizedValues[key.toLowerCase()] || null
+  }
+}
+
+function createJsonResponse (body, {
+  status = 200,
+  statusText = 'OK',
+  headers = {}
+} = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: createHeaders(headers),
+    text: () => Promise.resolve(body === null || body === undefined ? '' : JSON.stringify(body))
+  }
+}
+
 function loadGitHubApi ({
   confValues = {},
-  requestImpl,
-  requestPromiseImpl
+  fetchImpl
 } = {}) {
-  const requestPromise = vi.fn(requestPromiseImpl || (() => Promise.resolve({})))
-  const request = vi.fn(requestImpl || (() => {}))
-  const proxyAgentInstances = []
-  const ProxyAgent = vi.fn(function ProxyAgent (uri) {
-    this.uri = uri
-    proxyAgentInstances.push(this)
-  })
+  const fetch = vi.fn(fetchImpl || (() => Promise.resolve(createJsonResponse({}))))
 
   const api = createGitHubApi({
     conf: createConf(confValues),
     logger,
-    ProxyAgentImpl: ProxyAgent,
-    requestImpl: request,
-    requestPromiseImpl: requestPromise
+    fetchImpl: fetch
   })
 
   return {
     api,
-    ProxyAgent,
-    proxyAgentInstances,
-    request,
-    requestPromise
+    fetch
   }
 }
 
 describe('GitHub API utility', () => {
   it('builds the OAuth access-token exchange request', async () => {
-    const { api, requestPromise } = loadGitHubApi()
+    const { api, fetch } = loadGitHubApi()
 
     await api.getGitHubApi(EXCHANGE_ACCESS_TOKEN)('client-id', 'client-secret', 'auth-code')
 
-    expect(requestPromise).toHaveBeenCalledWith({
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://github.com/login/oauth/access_token')
+    expect(init).toEqual(expect.objectContaining({
       method: 'POST',
-      uri: 'https://github.com/login/oauth/access_token',
-      agent: null,
-      form: {
-        client_id: 'client-id',
-        client_secret: 'client-secret',
-        code: 'auth-code'
-      },
-      json: true,
-      timeout: 20000
-    })
+      body: 'client_id=client-id&client_secret=client-secret&code=auth-code'
+    }))
+    expect(init.headers).toEqual(expect.objectContaining({
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }))
+    expect(init).not.toHaveProperty('agent')
   })
 
   it('uses GitHub Enterprise API host when configured', async () => {
-    const { api, requestPromise } = loadGitHubApi({
+    const { api, fetch } = loadGitHubApi({
       confValues: {
         'enterprise:enable': true,
         'enterprise:host': 'ghe.example.test'
-      }
+      },
+      fetchImpl: () => Promise.resolve(createJsonResponse({ login: 'octo' }))
     })
 
-    await api.getGitHubApi(GET_USER_PROFILE)('token-1')
+    const result = await api.getGitHubApi(GET_USER_PROFILE)('token-1')
 
-    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
-      uri: 'https://ghe.example.test/api/v3/user',
-      headers: {
-        'User-Agent': 'hackjutsu-lepton-app',
-        Authorization: 'token token-1'
-      },
-      method: 'GET',
-      json: true,
-      timeout: 20000
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://ghe.example.test/api/v3/user')
+    expect(init).toEqual(expect.objectContaining({
+      method: 'GET'
     }))
+    expect(init.headers).toEqual(expect.objectContaining({
+      Accept: 'application/json',
+      'User-Agent': 'hackjutsu-lepton-app',
+      Authorization: 'token token-1'
+    }))
+    expect(result).toEqual({ login: 'octo' })
   })
 
-  it('wires proxy configuration into requests', async () => {
-    const { api, ProxyAgent, proxyAgentInstances, requestPromise } = loadGitHubApi({
+  it('relies on Electron session fetch when proxy configuration is enabled', async () => {
+    const { api, fetch } = loadGitHubApi({
       confValues: {
         'proxy:enable': true,
         'proxy:address': 'socks://localhost:1080'
@@ -103,11 +126,61 @@ describe('GitHub API utility', () => {
 
     await api.getGitHubApi(GET_SINGLE_GIST)('token-1', 'gist-1')
 
-    expect(ProxyAgent).toHaveBeenCalledWith('socks://localhost:1080')
-    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
-      uri: 'https://api.github.com/gists/gist-1',
-      agent: proxyAgentInstances[0]
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.github.com/gists/gist-1')
+    expect(init).not.toHaveProperty('agent')
+  })
+
+  it('serializes JSON request bodies for gist creation', async () => {
+    const files = {
+      'hello.js': {
+        content: 'console.log("hello")'
+      }
+    }
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse({ id: 'gist-1' }))
+    })
+
+    const result = await api.getGitHubApi(CREATE_SINGLE_GIST)('token-1', 'description', files, false)
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.github.com/gists')
+    expect(init).toEqual(expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        description: 'description',
+        public: false,
+        files: files
+      })
     }))
+    expect(init.headers).toEqual(expect.objectContaining({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'hackjutsu-lepton-app',
+      Authorization: 'token token-1'
+    }))
+    expect(result).toEqual({ id: 'gist-1' })
+  })
+
+  it('handles empty delete responses', async () => {
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse(null, {
+        status: 204,
+        statusText: 'No Content'
+      }))
+    })
+
+    const result = await api.getGitHubApi(DELETE_SINGLE_GIST)('token-1', 'gist-1')
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.github.com/gists/gist-1')
+    expect(init).toEqual(expect.objectContaining({
+      method: 'DELETE'
+    }))
+    expect(init).not.toHaveProperty('body')
+    expect(result).toBeNull()
   })
 
   it('requests all paginated gists and sorts newest first', async () => {
@@ -125,69 +198,110 @@ describe('GitHub API utility', () => {
         }
       }
     }
-    const { api, requestPromise } = loadGitHubApi({
-      requestPromiseImpl: (options) => Promise.resolve(pages[options.qs.page])
-    })
-
-    const result = await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
-
-    expect(requestPromise).toHaveBeenCalledTimes(2)
-    expect(requestPromise).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      uri: 'https://api.github.com/users/octo/gists',
-      qs: { per_page: 100, page: 1 },
-      resolveWithFullResponse: true
-    }))
-    expect(requestPromise).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      qs: { per_page: 100, page: 2 }
-    }))
-    expect(result.map(gist => gist.id)).toEqual(['new', 'old'])
-  })
-
-  it('treats a missing pagination header as a complete single-page gist response', async () => {
-    const { api, request, requestPromise } = loadGitHubApi({
-      requestPromiseImpl: () => Promise.resolve({
-        body: [{ id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }],
-        headers: {}
-      }),
-      requestImpl: (options, callback) => {
-        const body = options.qs.page === 1
-          ? [{ id: 'fallback', updated_at: '2022-01-01T00:00:00Z' }]
-          : []
-        callback(null, {}, body)
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: (url) => {
+        const page = new URL(url).searchParams.get('page')
+        return Promise.resolve(createJsonResponse(pages[page].body, {
+          headers: pages[page].headers
+        }))
       }
     })
 
     const result = await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
 
-    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
-      uri: 'https://api.github.com/users/octo/gists',
-      qs: { per_page: 100, page: 1 }
-    }))
-    expect(request).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch.mock.calls[0][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=1')
+    expect(fetch.mock.calls[1][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=2')
+    expect(result.map(gist => gist.id)).toEqual(['new', 'old'])
+  })
+
+  it('treats a missing pagination header as a complete single-page gist response', async () => {
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse([
+        { id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }
+      ]))
+    })
+
+    const result = await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch.mock.calls[0][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=1')
     expect(result).toEqual([{ id: 'single-page', updated_at: '2022-01-01T00:00:00Z' }])
   })
 
   it('uses the authenticated gists endpoint when downloadAll is enabled', async () => {
-    const { api, requestPromise } = loadGitHubApi({
+    const { api, fetch } = loadGitHubApi({
       confValues: {
         'gist:downloadAll': true
       },
-      requestPromiseImpl: () => Promise.resolve({
-        body: [],
-        headers: {}
-      })
+      fetchImpl: () => Promise.resolve(createJsonResponse([]))
     })
 
     await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
 
-    expect(requestPromise).toHaveBeenCalledWith(expect.objectContaining({
-      uri: 'https://api.github.com/gists',
-      headers: {
-        'User-Agent': 'hackjutsu-lepton-app',
-        Authorization: 'token token-1'
-      },
-      qs: { per_page: 100, page: 1 },
-      resolveWithFullResponse: true
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.github.com/gists?per_page=100&page=1')
+    expect(init.headers).toEqual(expect.objectContaining({
+      'User-Agent': 'hackjutsu-lepton-app',
+      Authorization: 'token token-1'
     }))
+  })
+
+  it('falls back to sequential V1 gist requests when V2 fetching fails', async () => {
+    let shouldFailV2 = true
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: (url) => {
+        if (shouldFailV2) {
+          shouldFailV2 = false
+          return Promise.reject(new Error('network unavailable'))
+        }
+
+        const page = new URL(url).searchParams.get('page')
+        const body = page === '1'
+          ? [{ id: 'fallback', updated_at: '2023-01-01T00:00:00Z' }]
+          : []
+        return Promise.resolve(createJsonResponse(body))
+      }
+    })
+
+    const result = await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
+
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(fetch.mock.calls[0][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=1')
+    expect(fetch.mock.calls[1][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=1')
+    expect(fetch.mock.calls[2][0]).toBe('https://api.github.com/users/octo/gists?per_page=100&page=2')
+    expect(result).toEqual([{ id: 'fallback', updated_at: '2023-01-01T00:00:00Z' }])
+  })
+
+  it('rejects non-successful responses with request-compatible status fields', async () => {
+    const { api } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse({
+        message: 'Bad credentials'
+      }, {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {
+          'x-github-request-id': 'request-1'
+        }
+      }))
+    })
+
+    await expect(api.getGitHubApi(GET_USER_PROFILE)('token-1')).rejects.toMatchObject({
+      name: 'StatusCodeError',
+      status: 401,
+      statusCode: 401,
+      error: {
+        message: 'Bad credentials'
+      },
+      response: {
+        statusCode: 401,
+        statusMessage: 'Unauthorized',
+        headers: {
+          'x-github-request-id': 'request-1'
+        }
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

Replaces the deprecated GitHub API request stack with an Electron-session fetch adapter.

- Adds a small fetch adapter that preserves the old request-promise call-site contract: JSON parsing, form bodies, query strings, full-response headers, timeout aborts, and request-style HTTP status errors.
- Routes OAuth, user profile, gist fetch/list/create/edit/delete, and the V1 pagination fallback through Electron `session.defaultSession.fetch`.
- Removes direct `request`, `request-promise`, and `proxy-agent` dependencies, relying on the existing Electron session proxy setup instead of per-request Node proxy agents.
- Updates GitHub API tests around fetch calls, pagination headers, V1 fallback behavior, JSON bodies, 204 deletes, and status rejection.

## Why

The direct `request`/`request-promise`/`proxy-agent` stack is deprecated and was responsible for a large cluster of audit findings. Electron already owns proxy configuration at the session level, so using the session fetch API keeps network behavior aligned with Chromium/Electron and removes the vulnerable Node request chain.

## Validation

- `npm run test:unit -- tests/utilities/githubApi.test.js tests/utilities/electronProxy.test.js`
- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`
- `npm audit --json` now reports 6 remaining vulnerabilities: 3 low, 2 moderate, 1 high, 0 critical
- `npm ls request request-promise proxy-agent --depth=0` reports `(empty)`

## Notes

Remaining audit items are now concentrated around `chart.js` and `notebookjs`/`dompurify`; those should be handled in separate passes because they imply larger rendering-library compatibility work.
