### PR TITLE
[codex] Add CODEOWNERS for repository automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Protect repository automation, review policy, and CODEOWNERS itself.
+/.github/ @hackjutsu
+
+# Protect future AI review helper scripts if they are added outside .github.
+/scripts/ai-review/ @hackjutsu


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file that makes `@hackjutsu` the owner for repository automation and review-policy paths.

- Protects `.github/`, including workflows and CODEOWNERS itself.
- Reserves `/scripts/ai-review/` for the future custom AI-review helper implementation.

## Why

This is the first small step toward making the AI review flow modifiable only by `@hackjutsu`. After this merges, GitHub branch rules should require code-owner review for protected branches.

## Validation

- `git diff --check`

## Follow-up

Enable a branch ruleset on `master` that requires pull requests and code-owner review, with `@hackjutsu` as the only bypass actor.