### PR TITLE
[codex] Upgrade Chart.js dashboard chart

### DIFF
--- a/app/containers/dashboard/chartConfig.js
+++ b/app/containers/dashboard/chartConfig.js
@@ -1,0 +1,42 @@
+const GREY = '#C2C4D1'
+const ACCENT = 'rgba(81,192,191,1)'
+const ACCENT_FILL = 'rgba(81,192,191,0.2)'
+
+export function buildRadarChartConfig (data, labels, datasetLabel) {
+  return {
+    type: 'radar',
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: datasetLabel,
+          backgroundColor: ACCENT_FILL,
+          borderColor: ACCENT,
+          pointBackgroundColor: ACCENT,
+          pointBorderColor: GREY,
+          pointHoverBackgroundColor: GREY,
+          pointHoverBorderColor: ACCENT,
+          data: data
+        }
+      ]
+    },
+    options: {
+      responsive: false,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false
+        }
+      },
+      scales: {
+        r: {
+          pointLabels: {
+            font: {
+              size: 12
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/containers/dashboard/chartConfig.js
+++ b/app/containers/dashboard/chartConfig.js
@@ -30,6 +30,9 @@ export function buildRadarChartConfig (data, labels, datasetLabel) {
       },
       scales: {
         r: {
+          ticks: {
+            display: false
+          },
           pointLabels: {
             font: {
               size: 12

--- a/app/containers/dashboard/index.js
+++ b/app/containers/dashboard/index.js
@@ -1,11 +1,12 @@
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import Chart from 'chart.js'
+import Chart from 'chart.js/auto'
 import { Image } from 'react-bootstrap'
 import Modal from '../compatModal'
 import { updateDashboardModalStatus } from '../../actions'
 import React, { Component } from 'react'
 import { t } from '../../utilities/i18n'
+import { buildRadarChartConfig } from './chartConfig'
 
 import robotocatImage from '../../utilities/octodex/robotocat.png'
 
@@ -40,7 +41,7 @@ class RadarChart extends Component {
     if (!this.canvasNode) return
 
     const context = this.canvasNode.getContext('2d')
-    this.chart = new Chart(context).Radar(this.props.data, this.props.options || {})
+    this.chart = new Chart(context, this.props.config)
   }
 
   render () {
@@ -79,31 +80,12 @@ class Dashboard extends Component {
     )
   }
 
-  // https://github.com/chartjs/Chart.js/blob/v1.1.1/docs/03-Radar-Chart.md
   buildRadarChart (data, labels) {
-    const GREY = '#C2C4D1'
-    const chartData = {
-      labels: labels,
-      datasets: [
-        {
-          label: t('dashboard.statsLabel'),
-          fillColor: 'rgba(81,192,191,0.2)',
-          strokeColor: 'rgba(81,192,191,1)',
-          pointColor: 'rgba(81,192,191,1)',
-          pointStrokeColor: GREY,
-          pointHighlightFill: GREY,
-          pointHighlightStroke: 'rgba(81,192,191,1)',
-          data: data
-        }
-      ]
-    }
-    const chartOptions = {
-      pointLabelFontSize: 12,
-    }
+    const chartConfig = buildRadarChartConfig(data, labels, t('dashboard.statsLabel'))
 
     return (
       <div className='dashboard-section'>
-        <RadarChart data={ chartData } options={ chartOptions } width="350" height="300"/>
+        <RadarChart config={ chartConfig } width="350" height="300"/>
         <div className='compliment'>
           { this.renderCompliments(labels[0]) }
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "autolinker": "^3.14.1",
         "bluebird": "^3.5.3",
         "boring-avatars": "^1.5.8",
-        "chart.js": "^1.1.1",
+        "chart.js": "^4.5.1",
         "codemirror": "^5.65.21",
         "codemirror-one-dark-theme": "^1.1.1",
         "electron-context-menu": "^3.0.0",
@@ -2557,6 +2557,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -5051,9 +5057,16 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-1.1.1.tgz",
-      "integrity": "sha512-1lcx4nsmYk3C50xMWFucOccdU7jh+RoHP25IiPlUoE6Qf317my+Nm48JOyPFrBRscqy6O4kkxif+omPKPkqWMA=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/check-outdated": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "autolinker": "^3.14.1",
     "bluebird": "^3.5.3",
     "boring-avatars": "^1.5.8",
-    "chart.js": "^1.1.1",
+    "chart.js": "^4.5.1",
     "codemirror": "^5.65.21",
     "codemirror-one-dark-theme": "^1.1.1",
     "electron-context-menu": "^3.0.0",

--- a/tests/containers/dashboardChart.test.js
+++ b/tests/containers/dashboardChart.test.js
@@ -39,6 +39,9 @@ describe('dashboard radar chart config', () => {
         },
         scales: {
           r: {
+            ticks: {
+              display: false
+            },
             pointLabels: {
               font: {
                 size: 12

--- a/tests/containers/dashboardChart.test.js
+++ b/tests/containers/dashboardChart.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import Chart from 'chart.js/auto'
+import { buildRadarChartConfig } from '../../app/containers/dashboard/chartConfig'
+
+describe('dashboard radar chart config', () => {
+  it('uses Chart.js 4 and builds a radar chart config', () => {
+    const config = buildRadarChartConfig(
+      [8, 5, 3],
+      ['JavaScript', 'Markdown', 'Python'],
+      'Snippets'
+    )
+
+    expect(Chart.version).toMatch(/^4\./)
+    expect(config).toMatchObject({
+      type: 'radar',
+      data: {
+        labels: ['JavaScript', 'Markdown', 'Python'],
+        datasets: [
+          {
+            label: 'Snippets',
+            backgroundColor: 'rgba(81,192,191,0.2)',
+            borderColor: 'rgba(81,192,191,1)',
+            pointBackgroundColor: 'rgba(81,192,191,1)',
+            pointBorderColor: '#C2C4D1',
+            pointHoverBackgroundColor: '#C2C4D1',
+            pointHoverBorderColor: 'rgba(81,192,191,1)',
+            data: [8, 5, 3]
+          }
+        ]
+      },
+      options: {
+        responsive: false,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false
+          }
+        },
+        scales: {
+          r: {
+            pointLabels: {
+              font: {
+                size: 12
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('does not use legacy Chart.js 1 radar option names', () => {
+    const config = buildRadarChartConfig([1, 2, 3], ['A', 'B', 'C'], 'Snippets')
+    const dataset = config.data.datasets[0]
+
+    expect(dataset).not.toHaveProperty('fillColor')
+    expect(dataset).not.toHaveProperty('strokeColor')
+    expect(dataset).not.toHaveProperty('pointColor')
+    expect(dataset).not.toHaveProperty('pointStrokeColor')
+    expect(dataset).not.toHaveProperty('pointHighlightFill')
+    expect(dataset).not.toHaveProperty('pointHighlightStroke')
+    expect(config.options).not.toHaveProperty('pointLabelFontSize')
+  })
+})


### PR DESCRIPTION
## Summary

Upgrades the retained Chart.js dependency and adapts the dashboard radar chart to the current Chart.js API.

- Upgrades `chart.js` from `^1.1.1` to `^4.5.1`.
- Switches the dashboard chart construction to `chart.js/auto` and the Chart.js 4 config object shape.
- Adds a pure dashboard chart config helper with unit coverage for the Chart.js 4 radar config and a guard against legacy v1-only option names.

## Why

The previous direct `chart.js@1.1.1` dependency was the remaining local npm audit issue. Keeping Chart.js is fine, but the v1 radar API is no longer compatible with supported Chart.js versions, so the dashboard canvas needed a small adapter update.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke` - Electron fixture smoke passed, including the dashboard modal with the rendered radar chart canvas
- `npm audit --json` - 0 vulnerabilities
- `git diff --check`

## Notes

Local dashboard fixture screenshot was captured at `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-LlnLkQ/electron-render-dashboard-success.png` and showed the chart rendered in the dashboard modal.
