### PR TITLE
[codex] Remove unused Standard ESLint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
       }
     },
     "plugins": [
-        "standard",
         "react"
     ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-promise": "^5.0.0",
         "eslint-plugin-react": "^7.11.1",
-        "eslint-plugin-standard": "^5.0.0",
         "file-loader": "^6.0.0",
         "html-loader": "^2.0.0",
         "json-loader": "^0.5.7",
@@ -6807,30 +6806,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^5.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "eslint-plugin-standard": "^5.0.0",
     "file-loader": "^6.0.0",
     "html-loader": "^2.0.0",
     "json-loader": "^0.5.7",


### PR DESCRIPTION
## Summary

Removes the deprecated `eslint-plugin-standard` package from the lint toolchain.

- Removes `eslint-plugin-standard` from `devDependencies` and `package-lock.json`.
- Removes the unused `standard` plugin registration from `.eslintrc.js`.
- Keeps `extends: "standard"`, which is provided by `eslint-config-standard` and no longer requires this plugin in v16.

## Why

`npm ci` reported a deprecation warning for `eslint-plugin-standard@5.0.0`. `eslint-config-standard@16` no longer uses or requires this plugin, and this repo does not reference any `standard/*` rules directly.

## Validation

- `npm ci` - completed successfully, 0 vulnerabilities, and the `eslint-plugin-standard` deprecation warning is gone
- `npm run lint`
- `npm test`
- `git diff --check`

## Notes

This was done in a separate temporary worktree from `origin/master` so unrelated local edits in the main checkout were left untouched.
