### PR TITLE
[codex] Replace Electron JSON storage dependency

### DIFF
--- a/app/utilities/electronLocalStorage.js
+++ b/app/utilities/electronLocalStorage.js
@@ -1,0 +1,83 @@
+const fs = require('fs')
+const path = require('path')
+
+function createErrorObject (error) {
+  return {
+    status: false,
+    error
+  }
+}
+
+function createSuccessObject (data) {
+  return {
+    status: true,
+    data
+  }
+}
+
+function validateStorageKey (key) {
+  if (typeof key !== 'string' || !key.trim()) {
+    throw new Error('Invalid Key')
+  }
+}
+
+function getStorageDir (userDataPath) {
+  return path.join(userDataPath, 'storage')
+}
+
+function getStorageFilePath (userDataPath, key) {
+  validateStorageKey(key)
+
+  const fileName = path.basename(key, '.json') + '.json'
+  return path.join(getStorageDir(userDataPath), encodeURIComponent(fileName))
+}
+
+function createElectronLocalStorage ({ getUserDataPath }) {
+  function resolveFilePath (key) {
+    return getStorageFilePath(getUserDataPath(), key)
+  }
+
+  return {
+    get (key) {
+      try {
+        return createSuccessObject(JSON.parse(fs.readFileSync(resolveFilePath(key), 'utf8')))
+      } catch (error) {
+        return createErrorObject(error)
+      }
+    },
+
+    set (key, data) {
+      let filePath
+      try {
+        filePath = resolveFilePath(key)
+      } catch (error) {
+        return createErrorObject(error)
+      }
+
+      let stringifiedJson
+      try {
+        stringifiedJson = JSON.stringify(data)
+      } catch (error) {
+        return createErrorObject(error)
+      }
+
+      if (!stringifiedJson) {
+        return createErrorObject(new Error('Invalid JSON object'))
+      }
+
+      try {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true })
+        fs.writeFileSync(filePath, stringifiedJson, 'utf8')
+        return createSuccessObject(data)
+      } catch (error) {
+        return createErrorObject(error)
+      }
+    }
+  }
+}
+
+module.exports = {
+  createElectronLocalStorage,
+  getStorageDir,
+  getStorageFilePath
+}

--- a/main.js
+++ b/main.js
@@ -24,13 +24,16 @@ const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
 const { applyElectronProxy } = require('./app/utilities/electronProxy')
 const { configureI18n, t } = require('./app/utilities/i18n')
-const electronLocalStorage = require('electron-json-storage-sync')
+const { createElectronLocalStorage } = require('./app/utilities/electronLocalStorage')
 const {
   buildGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = require('./app/utilities/auth/githubOAuth')
 
 const logger = createMainLogger()
+const electronLocalStorage = createElectronLocalStorage({
+  getUserDataPath: () => app.getPath('userData')
+})
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "codemirror-one-dark-theme": "^1.1.1",
         "electron-context-menu": "^3.0.0",
         "electron-is-dev": "^2.0.0",
-        "electron-json-storage-sync": "^1.1.1",
         "electron-localshortcut": "^3.1.0",
         "electron-updater": "^6.8.9",
         "electron-window-state": "^5.0.0",
@@ -5977,16 +5976,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/electron-json-storage-sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/electron-json-storage-sync/-/electron-json-storage-sync-1.1.1.tgz",
-      "integrity": "sha512-av6detBZCCrhTyMKNPEsibblMfGvyK68wNy1dtKwK5hBIALZ8C3O38KNDw2eHLDA+YpHEaYvbGjEJJ+ZhHKJXw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1"
-      }
-    },
     "node_modules/electron-localshortcut": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz",
@@ -11563,18 +11552,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/roarr": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "codemirror-one-dark-theme": "^1.1.1",
     "electron-context-menu": "^3.0.0",
     "electron-is-dev": "^2.0.0",
-    "electron-json-storage-sync": "^1.1.1",
     "electron-localshortcut": "^3.1.0",
     "electron-updater": "^6.8.9",
     "electron-window-state": "^5.0.0",

--- a/tests/utilities/electronLocalStorage.test.js
+++ b/tests/utilities/electronLocalStorage.test.js
@@ -1,0 +1,78 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  createElectronLocalStorage,
+  getStorageFilePath
+} = require('../../app/utilities/electronLocalStorage')
+
+let tempRoot
+
+function createStorage () {
+  tempRoot = mkdtempSync(join(tmpdir(), 'lepton-local-storage-'))
+  return createElectronLocalStorage({
+    getUserDataPath: () => tempRoot
+  })
+}
+
+afterEach(() => {
+  if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+  tempRoot = null
+})
+
+describe('Electron local storage utility', () => {
+  it('stores and reads JSON values using the previous storage path layout', () => {
+    const storage = createStorage()
+    const profile = { login: 'octocat', avatar_url: 'https://example.test/avatar.png' }
+
+    expect(storage.set('profile', profile)).toEqual({
+      status: true,
+      data: profile
+    })
+    expect(storage.get('profile')).toEqual({
+      status: true,
+      data: profile
+    })
+    expect(readFileSync(join(tempRoot, 'storage', 'profile.json'), 'utf8')).toBe(JSON.stringify(profile))
+  })
+
+  it('keeps key normalization compatible with electron-json-storage-sync', () => {
+    const userDataPath = '/tmp/lepton-user-data'
+
+    expect(getStorageFilePath(userDataPath, 'token')).toBe(join(userDataPath, 'storage', 'token.json'))
+    expect(getStorageFilePath(userDataPath, 'token.json')).toBe(join(userDataPath, 'storage', 'token.json'))
+    expect(getStorageFilePath(userDataPath, 'nested/token')).toBe(join(userDataPath, 'storage', 'token.json'))
+    expect(getStorageFilePath(userDataPath, 'token value')).toBe(join(userDataPath, 'storage', 'token%20value.json'))
+  })
+
+  it('returns status false for missing or invalid keys', () => {
+    const storage = createStorage()
+
+    expect(storage.get('missing').status).toBe(false)
+    expect(storage.get('').status).toBe(false)
+    expect(storage.get('  ').status).toBe(false)
+    expect(storage.set('', 'token').status).toBe(false)
+    expect(storage.set('  ', 'token').status).toBe(false)
+  })
+
+  it('returns status false for invalid JSON values', () => {
+    const storage = createStorage()
+    const circular = {}
+    circular.self = circular
+
+    expect(storage.set('token', undefined).status).toBe(false)
+    expect(storage.set('token', circular).status).toBe(false)
+  })
+
+  it('returns status false when a stored JSON file cannot be parsed', () => {
+    const storage = createStorage()
+    storage.set('token', 'abc123')
+    writeFileSync(join(tempRoot, 'storage', 'token.json'), '{', 'utf8')
+
+    expect(storage.get('token').status).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the unsupported `electron-json-storage-sync` runtime dependency with a small in-repo main-process storage utility.

- Adds `app/utilities/electronLocalStorage.js` for synchronous JSON key/value storage.
- Wires the existing `lepton:local-storage:get` and `lepton:local-storage:set` IPC handlers to the in-repo implementation.
- Removes `electron-json-storage-sync` and its no-longer-referenced top-level `rimraf@2.7.1` lockfile entry.
- Adds unit coverage for old-compatible file paths, result shapes, missing keys, invalid keys, invalid JSON values, and parse failures.

## Expected behavior

Before this change, token/profile/update-skip data was stored by `electron-json-storage-sync` as one JSON file per key under `app.getPath('userData')/storage`.

After this change, Lepton stores the same keys in the same directory with the same filename normalization and the same `{ status, data }` / `{ status, error }` return shape. Existing cached `token`, `profile`, and `skipped-version` files should continue to work. No user-visible functionality change is expected.

## Validation

- `npm ci` - completed successfully with 0 vulnerabilities; the `electron-json-storage-sync` warning and the extra top-level `rimraf@2.7.1` warning are gone
- `npm run test:unit -- tests/utilities/electronLocalStorage.test.js`
- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `npm run test:packaged-smoke`
- `git diff --check`

## Notes

`npm run test:packaged-smoke` regenerated `license.json` during packaging; that generated file was restored and is intentionally not part of this PR.
