### PR TITLE
Silence packaged smoke warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     publicPath: '/bundle/',
     filename: 'app.bundle.js'
   },
+  performance: {
+    hints: false
+  },
   resolve: {
     alias: {
       'punycode$': require.resolve('punycode/'),


### PR DESCRIPTION
## Summary

Disables Webpack’s default web performance hints for the Electron renderer bundle.

## Why

The bundle-size warnings are browser-oriented Webpack budget hints. Lepton ships this renderer inside an Electron desktop app, so these warnings add noise to packaged smoke output without indicating a packaged-app failure.

The Electron `DEP0180 fs.Stats` warning is left unchanged.

## Validation

- `npm run webpack-prod`

## Notes

The production build compiles successfully without Webpack performance warnings.