### PR TITLE
[codex] Remove twitter-text dependency

### DIFF
--- a/app/utilities/parser/index.js
+++ b/app/utilities/parser/index.js
@@ -1,4 +1,4 @@
-const twitter = resolveTwitterTextApi(require('twitter-text'))
+const HASHTAG_REGEX = /(^|[^\p{L}\p{M}\p{N}_])#([\p{L}\p{M}\p{N}_]+)/gu
 
 /* Old(Legacy) Style:  [my_title] my_description #tags: tag1, tag2, tag3
    New(Twitter) Style: [my_title] my_description #tag1 #tag2 #tag3
@@ -68,18 +68,28 @@ function parseCustomTagsLegacy (payload) {
 }
 
 function parseCustomTagsTwitter (payload) {
-  const rawCustomTags = twitter.extractHashtags(payload)
+  const rawCustomTags = extractHashtags(payload)
   if (rawCustomTags.length === 0) {
     return ''
   }
 
   const prefix = '#tags:'
-  const customTags = prefix + rawCustomTags.reduce((acc, cur) => acc + ', ' + cur)
+  const customTags = prefix + rawCustomTags.join(', ')
   return customTags
 }
 
-export function resolveTwitterTextApi (twitterTextModule) {
-  return twitterTextModule && twitterTextModule.default
-    ? twitterTextModule.default
-    : twitterTextModule
+export function extractHashtags (payload) {
+  const tags = []
+  const text = payload || ''
+  let match
+
+  HASHTAG_REGEX.lastIndex = 0
+  while ((match = HASHTAG_REGEX.exec(text)) !== null) {
+    const tag = match[2]
+    if (!/^\d+$/.test(tag)) {
+      tags.push(tag)
+    }
+  }
+
+  return tags
 }

--- a/app/utilities/parser/index.js
+++ b/app/utilities/parser/index.js
@@ -1,4 +1,4 @@
-// Extract standalone Lepton custom-tag hashtags without pulling in twitter-text.
+// Match standalone hashtag tokens for custom-tag parsing; embedded hashes stay in plain text.
 const HASHTAG_REGEX = /(^|[^\p{L}\p{M}\p{N}_])#([\p{L}\p{M}\p{N}_]+)/gu
 
 /* Old(Legacy) Style:  [my_title] my_description #tags: tag1, tag2, tag3

--- a/app/utilities/parser/index.js
+++ b/app/utilities/parser/index.js
@@ -1,3 +1,4 @@
+// Extract standalone Lepton custom-tag hashtags without pulling in twitter-text.
 const HASHTAG_REGEX = /(^|[^\p{L}\p{M}\p{N}_])#([\p{L}\p{M}\p{N}_]+)/gu
 
 /* Old(Legacy) Style:  [my_title] my_description #tags: tag1, tag2, tag3

--- a/license.json
+++ b/license.json
@@ -272,7 +272,7 @@
     "color-name@2.1.0": {
         "licenses": "MIT",
         "repository": "https://github.com/colorjs/color-name",
-        "licenseFile": "node_modules/color-string/node_modules/color-name/LICENSE"
+        "licenseFile": "node_modules/color/node_modules/color-name/LICENSE"
     },
     "color-string@2.1.4": {
         "licenses": "MIT",
@@ -293,11 +293,6 @@
         "licenses": "MIT",
         "repository": "https://github.com/tj/commander.js",
         "licenseFile": "node_modules/katex/node_modules/commander/LICENSE"
-    },
-    "core-js@2.6.11": {
-        "licenses": "MIT",
-        "repository": "https://github.com/zloirock/core-js",
-        "licenseFile": "node_modules/core-js/LICENSE"
     },
     "core-js@2.6.12": {
         "licenses": "MIT",
@@ -854,11 +849,6 @@
         "repository": "https://github.com/mathiasbynens/punycode.js",
         "licenseFile": "node_modules/punycode.js/LICENSE-MIT.txt"
     },
-    "punycode@1.4.1": {
-        "licenses": "MIT",
-        "repository": "https://github.com/bestiejs/punycode.js",
-        "licenseFile": "node_modules/twitter-text/node_modules/punycode/LICENSE-MIT.txt"
-    },
     "punycode@2.3.1": {
         "licenses": "MIT",
         "repository": "https://github.com/mathiasbynens/punycode.js",
@@ -1097,15 +1087,6 @@
         "licenses": "0BSD",
         "repository": "https://github.com/Microsoft/tslib",
         "licenseFile": "node_modules/tslib/LICENSE.txt"
-    },
-    "twemoji-parser@11.0.2": {
-        "licenses": "MIT",
-        "licenseFile": "node_modules/twemoji-parser/LICENSE.md"
-    },
-    "twitter-text@3.1.0": {
-        "licenses": "Apache*",
-        "repository": "https://github.com/twitter/twitter-text",
-        "licenseFile": "node_modules/twitter-text/LICENSE"
     },
     "uc.micro@2.1.0": {
         "licenses": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-split-pane": "^3.2.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "twitter-text": "^3.0.0",
         "valid-filename": "^3.1.0",
         "winston": "^3.19.0"
       },
@@ -6155,13 +6154,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -14243,27 +14235,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/twemoji-parser": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-11.0.2.tgz",
-      "integrity": "sha512-5kO2XCcpAql6zjdLwRwJjYvAZyDy3+Uj7v1ipBzLthQmDL7Ce19bEqHr3ImSNeoSW2OA8u02XmARbXHaNO8GhA=="
-    },
-    "node_modules/twitter-text": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/twitter-text/-/twitter-text-3.1.0.tgz",
-      "integrity": "sha512-nulfUi3FN6z0LUjYipJid+eiwXvOLb8Ass7Jy/6zsXmZK3URte043m8fL3FyDzrK+WLpyqhHuR/TcARTN/iuGQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "core-js": "^2.5.0",
-        "punycode": "1.4.1",
-        "twemoji-parser": "^11.0.2"
-      }
-    },
-    "node_modules/twitter-text/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/type-fest": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "react-split-pane": "^3.2.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
-    "twitter-text": "^3.0.0",
     "valid-filename": "^3.1.0",
     "winston": "^3.19.0"
   },

--- a/tests/utilities/parser.test.js
+++ b/tests/utilities/parser.test.js
@@ -4,9 +4,9 @@ import {
   addCustomTagsPrefix,
   addLangPrefix,
   descriptionParser,
+  extractHashtags,
   parseCustomTags,
-  parseLangName,
-  resolveTwitterTextApi
+  parseLangName
 } from '../../app/utilities/parser'
 
 describe('parser utilities', () => {
@@ -54,12 +54,23 @@ describe('parser utilities', () => {
     expect(parseCustomTags('alpha, beta')).toEqual([])
   })
 
-  it('resolves twitter-text default exports from bundled ESM interop', () => {
-    const twitterTextApi = {
-      extractHashtags: () => ['js']
-    }
+  it('extracts hashtag tags without matching embedded hashes or numeric-only tags', () => {
+    expect(extractHashtags('Use #js #react_native. Not issue#123, #123, or C#')).toEqual([
+      'js',
+      'react_native'
+    ])
+    expect(extractHashtags('#abc123 #_x #a-b')).toEqual([
+      'abc123',
+      '_x',
+      'a'
+    ])
+  })
 
-    expect(resolveTwitterTextApi(twitterTextApi)).toBe(twitterTextApi)
-    expect(resolveTwitterTextApi({ default: twitterTextApi })).toBe(twitterTextApi)
+  it('extracts unicode hashtag tags', () => {
+    expect(descriptionParser('[Title] body text #标签1 #テスト')).toEqual({
+      title: 'Title',
+      description: ' body text #标签1 #テスト',
+      customTags: '#tags:标签1, テスト'
+    })
   })
 })


### PR DESCRIPTION
## Summary

Removes the `twitter-text` runtime dependency and replaces its single use with a small local hashtag extractor for snippet custom-tag parsing.

- Keeps the existing description parser behavior for `#tag` style custom tags.
- Preserves Unicode hashtag support and keeps embedded hashes such as `issue#123` in plain text.
- Regenerates package metadata and license output against the current license-checker setup.

## Expected behavior

No user-facing behavior change is expected. Snippet descriptions should still preserve hashtag text in the visible description while exposing parsed custom tags.

## Warning impact

This removes the direct `twitter-text` dependency path that pulled in `core-js@2.6.11`, so `npm ci` no longer reports the `core-js@2.6.11` deprecation or its allow-scripts entry.

## Validation

- `npm ci`
- `npm run lint`
- `npm run test:unit -- tests/utilities/parser.test.js`
- `npm test`
- `npm run test:smoke`
- `git diff --check`