### PR TITLE
[codex] Reduce packaged app size

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,20 @@
     "winston": "^3.19.0"
   },
   "build": {
+    "files": [
+      "app/**",
+      "bundle/**",
+      "configs/**",
+      "build/icon/icon.png",
+      "build/touchbar/**",
+      "index.html",
+      "main.js",
+      "preload.js",
+      "package.json",
+      "license.json",
+      ".all-contributorsrc",
+      "!**/*.map"
+    ],
     "appId": "com.cosmox.lepton",
     "mac": {
       "category": "public.app-category.productivity",


### PR DESCRIPTION
## Summary

Adds an explicit electron-builder files allowlist for runtime application files and excludes generated/source map files from packaged artifacts.

- Keeps the runtime app source, renderer bundle, configs, preload/main entrypoints, license metadata, contributors metadata, and small runtime icon/Touch Bar assets.
- Stops packaging broad non-runtime project files such as docs/tests/root tooling by default.
- Excludes *.map files from the packaged app archive.

## Impact

Estimated package-size reduction from local packaged-smoke output:

- app.asar: 90,697,126 bytes -> 71,215,410 bytes
- Estimated savings: 19,481,716 bytes, about 18.6 MiB
- Relative reduction for app.asar: about 21%
- Unpacked local macOS app: about 361M -> 343M

These numbers are local macOS arm64 package measurements and should be treated as a reference estimate; release artifacts may vary slightly by platform and compression target.

## Validation

- npm run test:packaged-smoke passed and rendered the login UI.
- git diff --check HEAD

Notes: the first sandboxed packaged-smoke attempt failed because electron-builder could not resolve github.com; rerunning with network access passed. The local packaged smoke emitted the expected unsigned macOS codesign warning. It also emitted a Chart.js webpack warning because the working node_modules was still from the existing chart-upgrade branch while this focused branch is based on master; this package-size PR does not modify Chart.js code or dependencies.