### PR TITLE
[codex] Round modal corners

### DIFF
--- a/app/containers/appContainer/index.scss
+++ b/app/containers/appContainer/index.scss
@@ -63,6 +63,11 @@ div > div.modal-header > button {
 }
 /**/
 
+.modal .modal-content {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
 /*For the resizer handle*/
 .split-pane-divider {
   background: #000;


### PR DESCRIPTION
## Summary

Adds a shared modal content style so Lepton dialogs render with macOS-style rounded corners, including the login modal.

## Impact

- Applies a 12px border radius to Bootstrap-style modal content.
- Clips modal content to the rounded frame so headers and scrollable modal bodies do not square off the corners.
- Keeps the change CSS-only and does not alter modal behavior.

## Validation

- npm run test:build
- npm run test:smoke
- Verified smoke screenshots for both the login modal and an authenticated About modal fixture.