### PR TITLE
[codex] Prune packaged renderer dependencies

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -1,6 +1,9 @@
 const { getSupportedLocales } = require('./app/utilities/i18n')
 const { getElectronLanguages } = require('./configs/electronLanguages')
 
+// Keep only app source that the Electron main process reads at runtime.
+// Renderer source is compiled into bundle/app.bundle.js and does not need to
+// ship separately inside app.asar.
 const mainRuntimeAppFiles = [
   'app/utilities/auth/**',
   'app/utilities/electronLocalStorage.js',
@@ -14,6 +17,9 @@ const mainRuntimeAppFiles = [
   'app/utilities/startAtLogin/**'
 ]
 
+// Packages in this list are renderer-only dependencies that webpack already
+// folds into bundle/app.bundle.js. Excluding their node_modules copies trims the
+// packaged archive without changing runtime module resolution.
 const rendererOnlyNodeModules = [
   '@asciidoctor/core',
   '@babel/runtime',
@@ -71,10 +77,15 @@ const rendererOnlyNodeModules = [
   'warning'
 ]
 
+// Some packages are renderer-only at the root, but package-manager hoisting can
+// also place versions of the same package under runtime dependencies. Exclude
+// only the root copy when nested copies may still be needed by main-process IPC.
 const topLevelRendererOnlyNodeModules = [
   'entities'
 ]
 
+// Apply package exclusions to both direct dependencies and nested copies so
+// transitive renderer-only packages do not remain in the final archive.
 function excludeNodeModule (packageName) {
   return [
     `!node_modules/${packageName}/**`,
@@ -83,6 +94,9 @@ function excludeNodeModule (packageName) {
 }
 
 module.exports = {
+  // electron-builder processes this list in order. The allowlist keeps the app
+  // payload intentionally small, and later negated patterns remove build-only
+  // or renderer-only artifacts that can otherwise be pulled in through deps.
   files: [
     ...mainRuntimeAppFiles,
     'bundle/**',
@@ -102,7 +116,12 @@ module.exports = {
     ...topLevelRendererOnlyNodeModules.map(packageName => `!node_modules/${packageName}/**`)
   ],
   appId: 'com.cosmox.lepton',
+  // Keep Electron's own locale files aligned with the locales Lepton exposes in
+  // the renderer. Add new locales in the shared i18n config first, then let this
+  // derived list control the packaged Electron resources.
   electronLanguages: getElectronLanguages(getSupportedLocales()),
+  // macOS builds publish both installer and archive artifacts for Intel and
+  // Apple Silicon users.
   mac: {
     category: 'public.app-category.productivity',
     target: [
@@ -126,6 +145,8 @@ module.exports = {
     ],
     darkModeSupport: true
   },
+  // Windows builds keep the configurable installer and an archive artifact for
+  // the supported desktop architectures.
   win: {
     target: [
       {
@@ -147,10 +168,14 @@ module.exports = {
       'github'
     ]
   },
+  // NSIS settings preserve the current installer UX: guided install flow with a
+  // selectable installation directory.
   nsis: {
     oneClick: false,
     allowToChangeInstallationDirectory: true
   },
+  // Linux builds produce the existing portable and store-friendly package
+  // formats, both published through the GitHub release flow.
   linux: {
     category: 'Development',
     target: [

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -1,9 +1,90 @@
 const { getSupportedLocales } = require('./app/utilities/i18n')
 const { getElectronLanguages } = require('./configs/electronLanguages')
 
+const mainRuntimeAppFiles = [
+  'app/utilities/auth/**',
+  'app/utilities/electronLocalStorage.js',
+  'app/utilities/electronProxy/**',
+  'app/utilities/githubApi/core.js',
+  'app/utilities/githubApi/fetchAdapter.js',
+  'app/utilities/i18n/**',
+  'app/utilities/jupyterNotebook/core.js',
+  'app/utilities/logging/**',
+  'app/utilities/menu/**',
+  'app/utilities/startAtLogin/**'
+]
+
+const rendererOnlyNodeModules = [
+  '@asciidoctor/core',
+  '@babel/runtime',
+  '@babel/runtime-corejs2',
+  '@kurkle/color',
+  '@mdit/helper',
+  '@mdit/plugin-katex',
+  '@mdit/plugin-tex',
+  'asciidoctor-opal-runtime',
+  'autolinker',
+  'boring-avatars',
+  'chart.js',
+  'classnames',
+  'codemirror',
+  'codemirror-one-dark-theme',
+  'core-js',
+  'dom-helpers',
+  'highlight.js',
+  'highlightjs-graphql',
+  'highlightjs-solidity',
+  'human-readable-time',
+  'katex',
+  'keycode',
+  'linkify-it',
+  'loose-envify',
+  'markdown-it',
+  'markdown-it-emoji',
+  'markdown-it-task-lists',
+  'mdurl',
+  'moment',
+  'object-assign',
+  'invariant',
+  'js-tokens',
+  'punycode.js',
+  'prop-types',
+  'prop-types-extra',
+  'react',
+  'react-bootstrap',
+  'react-dom',
+  'react-is',
+  'react-lifecycles-compat',
+  'react-overlays',
+  'react-prop-types',
+  'react-redux',
+  'react-split-pane',
+  'react-transition-group',
+  'redux',
+  'redux-thunk',
+  'scheduler',
+  'tslib',
+  'uc.micro',
+  'uncontrollable',
+  'use-sync-external-store',
+  'valid-filename',
+  'warning'
+]
+
+const topLevelRendererOnlyNodeModules = [
+  'entities'
+]
+
+function excludeNodeModule (packageName) {
+  return [
+    `!node_modules/${packageName}/**`,
+    `!node_modules/**/node_modules/${packageName}/**`
+  ]
+}
+
 module.exports = {
   files: [
-    'app/**',
+    ...mainRuntimeAppFiles,
     'bundle/**',
     'configs/**',
     'build/icon/icon.png',
@@ -14,7 +95,11 @@ module.exports = {
     'package.json',
     'license.json',
     '.all-contributorsrc',
-    '!**/*.map'
+    '!**/*.map',
+    '!node_modules/@types/**',
+    '!node_modules/**/node_modules/@types/**',
+    ...rendererOnlyNodeModules.flatMap(excludeNodeModule),
+    ...topLevelRendererOnlyNodeModules.map(packageName => `!node_modules/${packageName}/**`)
   ],
   appId: 'com.cosmox.lepton',
   electronLanguages: getElectronLanguages(getSupportedLocales()),

--- a/tests/smoke/electron-packaged-smoke.js
+++ b/tests/smoke/electron-packaged-smoke.js
@@ -40,6 +40,19 @@ function createTempHome (locale = 'en') {
   return { configHome, root, userData }
 }
 
+const PACKAGED_RENDER_FIXTURES = [
+  {
+    name: 'dashboard',
+    selector: '.dashboard-modal canvas',
+    text: 'Dashboard'
+  },
+  {
+    name: 'jupyter-notebook',
+    selector: '.jupyterNotebook-section .nb-notebook',
+    text: 'Notebook Fixture|hello from notebook|42'
+  }
+]
+
 function waitForProcessExit (child, timeout = 5000) {
   return new Promise((resolve, reject) => {
     if (child.exitCode !== null || child.signalCode !== null) {
@@ -240,6 +253,57 @@ async function waitForLoginUi (cdp, expectedText) {
   throw new Error('Timed out waiting for the packaged login UI to render.')
 }
 
+async function waitForFixtureUi (cdp, expectedSelector, expectedText) {
+  const deadline = Date.now() + 30000
+
+  while (Date.now() < deadline) {
+    const result = await cdp.call('Runtime.evaluate', {
+      expression: `
+        (() => {
+          const expectedNode = document.querySelector(${JSON.stringify(expectedSelector)})
+          const bounds = expectedNode ? expectedNode.getBoundingClientRect() : null
+          const appContainer = document.querySelector('.app-container')
+          return {
+            bodyText: document.body ? document.body.innerText : '',
+            hasAppContainer: Boolean(appContainer),
+            hasExpectedNode: Boolean(expectedNode),
+            hasLeptonBridge: Boolean(window.lepton),
+            hasLeptonConfigBridge: Boolean(window.lepton && window.lepton.config && window.lepton.config.get),
+            processType: typeof process,
+            requireType: typeof require,
+            expectedBounds: bounds ? {
+              width: bounds.width,
+              height: bounds.height
+            } : null
+          }
+        })()
+      `,
+      returnByValue: true
+    })
+    const state = result.result.value
+    const expectedTexts = expectedText.split('|').filter(Boolean)
+
+    if (
+      state.hasAppContainer &&
+      state.hasExpectedNode &&
+      state.hasLeptonBridge &&
+      state.hasLeptonConfigBridge &&
+      state.requireType === 'undefined' &&
+      state.processType === 'undefined' &&
+      state.expectedBounds &&
+      state.expectedBounds.width > 0 &&
+      state.expectedBounds.height > 0 &&
+      expectedTexts.every(text => state.bodyText.includes(text))
+    ) {
+      return state
+    }
+
+    await wait(100)
+  }
+
+  throw new Error(`Timed out waiting for packaged fixture selector "${expectedSelector}" to render.`)
+}
+
 async function captureScreenshot (cdp, artifactDir, fileName) {
   await cdp.call('Runtime.evaluate', {
     expression: 'new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))',
@@ -252,20 +316,19 @@ async function captureScreenshot (cdp, artifactDir, fileName) {
   console.log(`Saved packaged smoke-test screenshot to ${screenshotPath}`)
 }
 
-async function runPackagedSmoke () {
-  const appPath = findPackagedApp()
+async function runPackagedScenario (appPath, options) {
   const executablePath = getExecutablePath(appPath)
   const tempHome = createTempHome('en')
   const port = await getFreePort()
-
-  runCodesignDiagnostics(appPath)
 
   const child = spawn(executablePath, [
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${tempHome.userData}`
   ], {
     cwd: repoRoot,
-    env: Object.assign({}, process.env, {
+    env: Object.assign({}, process.env, options.renderFixture ? {
+      LEPTON_RENDER_FIXTURE: options.renderFixture
+    } : {}, {
       ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
       XDG_CONFIG_HOME: tempHome.configHome
     }),
@@ -290,10 +353,13 @@ async function runPackagedSmoke () {
     cdp = await connectCdp(target.webSocketDebuggerUrl)
     await cdp.call('Page.enable')
     await cdp.call('Runtime.enable')
-    await waitForLoginUi(cdp, 'Login|GitHub Login')
-    await captureScreenshot(cdp, tempHome.root, 'electron-packaged-smoke-success.png')
+    if (options.renderFixture) {
+      await waitForFixtureUi(cdp, options.expectedSelector, options.expectedText)
+    } else {
+      await waitForLoginUi(cdp, options.expectedText)
+    }
+    await captureScreenshot(cdp, tempHome.root, options.screenshotName)
     cdp.call('Browser.close').catch(() => {})
-    console.log('electron packaged smoke test passed')
   } catch (err) {
     if (cdp) cdp.close()
     child.kill('SIGKILL')
@@ -305,6 +371,27 @@ async function runPackagedSmoke () {
       await waitForProcessExit(child).catch(() => {})
     }
   }
+}
+
+async function runPackagedSmoke () {
+  const appPath = findPackagedApp()
+  runCodesignDiagnostics(appPath)
+
+  await runPackagedScenario(appPath, {
+    expectedText: 'Login|GitHub Login',
+    screenshotName: 'electron-packaged-smoke-success.png'
+  })
+
+  for (const fixture of PACKAGED_RENDER_FIXTURES) {
+    await runPackagedScenario(appPath, {
+      expectedSelector: fixture.selector,
+      expectedText: fixture.text,
+      renderFixture: fixture.name,
+      screenshotName: `electron-packaged-${fixture.name}-success.png`
+    })
+  }
+
+  console.log('electron packaged smoke test passed')
 }
 
 runPackagedSmoke().catch(err => {


### PR DESCRIPTION
## Summary

Prunes renderer-only source and dependency files from packaged apps while keeping the production renderer bundle and main-process runtime files intact.

- Replaces broad `app/**` packaging with a focused main-process runtime allowlist.
- Excludes renderer-only `node_modules` packages already bundled into `bundle/app.bundle.js`.
- Keeps notebook-rendering dependencies packaged because the main process still renders notebooks through IPC.
- Extends packaged smoke coverage to launch packaged dashboard and notebook fixtures, not just the login UI.

## Estimated Size Reduction

Local macOS arm64 unpacked app build, compared against the current merged package-size and locale-pruning baseline:

- App bundle: 305,012 KiB -> 264,220 KiB
- `app.asar`: 67,148 KiB -> 26,356 KiB
- Estimated reduction: 40,792 KiB, about 39.8 MiB or 13.4% of the local unpacked app

The `app.asar` payload now reports 25,536 KiB across 3,203 files, down from the prior measured 64,943 KiB across 8,667 files. This is a local unpacked macOS estimate; compressed installer sizes may vary by platform.

## Validation

- `npm run lint`
- `npm test`
- `node --check tests/smoke/electron-packaged-smoke.js`
- `npm run test:packaged-smoke`
- `git diff --check`
- Direct `app.asar` content check verified required main-process runtime files remain and selected renderer-only packages are absent.

Packaged smoke now verifies the packaged login UI, dashboard fixture, and notebook fixture.
