### PR TITLE
[codex] Add automated distribution release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,317 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish artifacts instead of only building them.
+        required: true
+        default: never
+        type: choice
+        options:
+          - never
+          - always
+      release_type:
+        description: GitHub release type for manual publishing.
+        required: true
+        default: draft
+        type: choice
+        options:
+          - draft
+          - prerelease
+          - release
+      snap_channels:
+        description: Comma-separated Snap Store channels for manual publishing.
+        required: true
+        default: edge
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-context:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.context.outputs.environment }}
+      github_release_type: ${{ steps.context.outputs.github_release_type }}
+      publish_policy: ${{ steps.context.outputs.publish_policy }}
+      snap_channels: ${{ steps.context.outputs.snap_channels }}
+    steps:
+      - name: Resolve release mode
+        id: context
+        env:
+          MANUAL_PUBLISH_POLICY: ${{ inputs.publish || 'never' }}
+          MANUAL_RELEASE_TYPE: ${{ inputs.release_type || 'draft' }}
+          MANUAL_SNAP_CHANNELS: ${{ inputs.snap_channels || 'edge' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Release tags must look like v1.2.3 or v1.2.3-beta.1." >&2
+              exit 1
+            fi
+
+            publish_policy="always"
+            if [[ "${tag}" == *-* ]]; then
+              github_release_type="prerelease"
+              environment="prerelease"
+              snap_channels="edge"
+            else
+              github_release_type="release"
+              environment="production"
+              snap_channels="stable"
+            fi
+          else
+            publish_policy="${MANUAL_PUBLISH_POLICY}"
+            github_release_type="${MANUAL_RELEASE_TYPE}"
+            snap_channels="${MANUAL_SNAP_CHANNELS}"
+            if [[ "${github_release_type}" == "release" ]]; then
+              environment="production"
+            else
+              environment="prerelease"
+            fi
+          fi
+
+          {
+            echo "environment=${environment}"
+            echo "github_release_type=${github_release_type}"
+            echo "publish_policy=${publish_policy}"
+            echo "snap_channels=${snap_channels}"
+          } >> "${GITHUB_OUTPUT}"
+
+  validate:
+    name: Validate release inputs
+    runs-on: ubuntu-latest
+    needs: release-context
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm 11
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Build verification
+        run: npm run test:build
+
+  build-macos:
+    name: Build macOS
+    # Build both macOS architectures together so electron-builder writes one
+    # coherent latest-mac.yml for updater clients.
+    runs-on: macos-15-intel
+    needs:
+      - release-context
+      - validate
+    environment: ${{ needs.release-context.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm 11
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create OAuth account config
+        env:
+          LEPTON_GITHUB_CLIENT_ID: ${{ secrets.LEPTON_GITHUB_CLIENT_ID }}
+          LEPTON_GITHUB_CLIENT_SECRET: ${{ secrets.LEPTON_GITHUB_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${LEPTON_GITHUB_CLIENT_ID:-}" || -z "${LEPTON_GITHUB_CLIENT_SECRET:-}" ]]; then
+            echo "Missing LEPTON_GITHUB_CLIENT_ID or LEPTON_GITHUB_CLIENT_SECRET." >&2
+            exit 1
+          fi
+
+          node -e "const fs = require('fs'); const config = { client_id: process.env.LEPTON_GITHUB_CLIENT_ID, client_secret: process.env.LEPTON_GITHUB_CLIENT_SECRET }; fs.writeFileSync('configs/account.js', 'module.exports = ' + JSON.stringify(config, null, 2) + '\n')"
+
+      - name: Require production signing secrets
+        if: needs.release-context.outputs.publish_policy == 'always' && needs.release-context.outputs.github_release_type == 'release'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for name in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID CSC_LINK CSC_KEY_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required macOS production signing secret: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Prepare package assets
+        run: npm run package:prepare
+
+      - name: Build and publish macOS artifacts
+        env:
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
+        run: npx electron-builder --mac --x64 --arm64 --publish ${{ needs.release-context.outputs.publish_policy }}
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lepton-macos
+          path: |
+            dist/*.dmg
+            dist/*.zip
+            dist/*.yml
+          if-no-files-found: error
+
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    needs:
+      - release-context
+      - validate
+    environment: ${{ needs.release-context.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm 11
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create OAuth account config
+        shell: bash
+        env:
+          LEPTON_GITHUB_CLIENT_ID: ${{ secrets.LEPTON_GITHUB_CLIENT_ID }}
+          LEPTON_GITHUB_CLIENT_SECRET: ${{ secrets.LEPTON_GITHUB_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${LEPTON_GITHUB_CLIENT_ID:-}" || -z "${LEPTON_GITHUB_CLIENT_SECRET:-}" ]]; then
+            echo "Missing LEPTON_GITHUB_CLIENT_ID or LEPTON_GITHUB_CLIENT_SECRET." >&2
+            exit 1
+          fi
+
+          node -e "const fs = require('fs'); const config = { client_id: process.env.LEPTON_GITHUB_CLIENT_ID, client_secret: process.env.LEPTON_GITHUB_CLIENT_SECRET }; fs.writeFileSync('configs/account.js', 'module.exports = ' + JSON.stringify(config, null, 2) + '\n')"
+
+      - name: Prepare package assets
+        run: npm run package:prepare
+
+      - name: Build and publish Windows artifacts
+        env:
+          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
+        run: npx electron-builder --win --x64 --ia32 --publish ${{ needs.release-context.outputs.publish_policy }}
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lepton-windows
+          path: |
+            dist/*.exe
+            dist/*.7z
+            dist/*.yml
+          if-no-files-found: error
+
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    needs:
+      - release-context
+      - validate
+    environment: ${{ needs.release-context.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm 11
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create OAuth account config
+        env:
+          LEPTON_GITHUB_CLIENT_ID: ${{ secrets.LEPTON_GITHUB_CLIENT_ID }}
+          LEPTON_GITHUB_CLIENT_SECRET: ${{ secrets.LEPTON_GITHUB_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${LEPTON_GITHUB_CLIENT_ID:-}" || -z "${LEPTON_GITHUB_CLIENT_SECRET:-}" ]]; then
+            echo "Missing LEPTON_GITHUB_CLIENT_ID or LEPTON_GITHUB_CLIENT_SECRET." >&2
+            exit 1
+          fi
+
+          node -e "const fs = require('fs'); const config = { client_id: process.env.LEPTON_GITHUB_CLIENT_ID, client_secret: process.env.LEPTON_GITHUB_CLIENT_SECRET }; fs.writeFileSync('configs/account.js', 'module.exports = ' + JSON.stringify(config, null, 2) + '\n')"
+
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
+
+      - name: Prepare package assets
+        run: npm run package:prepare
+
+      - name: Build and publish Linux artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
+          LEPTON_SNAP_CHANNELS: ${{ needs.release-context.outputs.snap_channels }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: npx electron-builder --linux --x64 --publish ${{ needs.release-context.outputs.publish_policy }}
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lepton-linux
+          path: |
+            dist/*.AppImage
+            dist/*.snap
+            dist/*.yml
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,33 +157,12 @@ jobs:
 
           node -e "const fs = require('fs'); const config = { client_id: process.env.LEPTON_GITHUB_CLIENT_ID, client_secret: process.env.LEPTON_GITHUB_CLIENT_SECRET }; fs.writeFileSync('configs/account.js', 'module.exports = ' + JSON.stringify(config, null, 2) + '\n')"
 
-      - name: Require production signing secrets
-        if: needs.release-context.outputs.publish_policy == 'always' && needs.release-context.outputs.github_release_type == 'release'
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          for name in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID CSC_LINK CSC_KEY_PASSWORD; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "Missing required macOS production signing secret: ${name}" >&2
-              exit 1
-            fi
-          done
-
       - name: Prepare package assets
         run: npm run package:prepare
 
       - name: Build and publish macOS artifacts
         env:
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
         run: npx electron-builder --mac --x64 --arm64 --publish ${{ needs.release-context.outputs.publish_policy }}
@@ -240,8 +219,7 @@ jobs:
 
       - name: Build and publish Windows artifacts
         env:
-          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
         run: npx electron-builder --win --x64 --ia32 --publish ${{ needs.release-context.outputs.publish_policy }}

--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ module.exports = {
 }
 ```
 
+`configs/account.js` is intentionally ignored by Git. If it is missing, the app
+falls back to `configs/accountDummy.js`, which is useful for rendering tests but
+will not support real GitHub login. Release builds create `configs/account.js`
+from GitHub Actions secrets before packaging.
+
 ### Run
 ```bash
 $ npm run build && npm start
@@ -224,6 +229,7 @@ GitHub Actions currently runs:
 - `lint-test-build`: lint, unit tests, and webpack build verification
 - `electron-smoke`: Electron renderer smoke test
 - `packaged-smoke`: packaged app smoke test
+- `release`: tag-driven cross-platform packaging and publishing
 
 The smoke jobs are currently configured as non-blocking CI checks while the
 cross-platform Electron validation continues to mature.
@@ -242,8 +248,102 @@ settings/about, dashboard, search, sync, and GitHub/Gist backend interactions.
 Manual verification is still required for visual quality and real GitHub
 behavior; automated smoke checks do not replace backend workflow testing.
 
-## Build Installer App
+## Distribution and Release
+
 >Read [electron-builder docs](https://github.com/electron-userland/electron-builder#readme) and check out the [code signing wiki](https://github.com/electron-userland/electron-builder#code-signing) before building the installer app.
+
+Lepton uses `electron-builder.js` for packaging and GitHub Actions for
+cross-platform release automation. GitHub Releases are the primary download
+channel. Linux users can also install the Snap Store build.
+
+Stable releases use plain semver tags and are eligible for the in-app update
+banner:
+
+```bash
+$ git tag v1.10.2
+$ git push origin v1.10.2
+```
+
+Testing releases use semver prerelease tags and are published as GitHub
+prereleases. They must not notify stable users:
+
+```bash
+$ git tag v1.11.0-alpha.1
+$ git push origin v1.11.0-alpha.1
+
+$ git tag v1.11.0-beta.1
+$ git push origin v1.11.0-beta.1
+
+$ git tag v1.11.0-rc.1
+$ git push origin v1.11.0-rc.1
+```
+
+The automated flow is:
+
+```text
+version tag
+    |
+    v
+release workflow
+    |
+    +--> validate: lint, unit tests, webpack build
+    |
+    +--> macOS Intel: signed/notarized dmg + zip
+    +--> macOS Apple Silicon: signed/notarized dmg + zip
+    +--> Windows: NSIS installer + archive
+    +--> Linux: AppImage + snap
+    |
+    v
+GitHub Release
+    |
+    +--> stable tag: published release + stable update metadata
+    +--> prerelease tag: GitHub prerelease, no stable-user notification
+    |
+    v
+Snap Store
+    |
+    +--> stable tag: stable channel
+    +--> prerelease tag: edge channel
+```
+
+The macOS release job builds Intel and Apple Silicon artifacts in the same
+`electron-builder` invocation so `latest-mac.yml` is generated once with a
+coherent set of updater files.
+
+Expected artifact names include the version, operating system, and architecture,
+for example:
+
+- `Lepton-1.10.2-mac-x64.dmg`
+- `Lepton-1.10.2-mac-arm64.zip`
+- `Lepton-1.10.2-win-x64.exe`
+- `Lepton-1.10.2-linux-x64.AppImage`
+
+Release publishing requires repository secrets:
+
+- `LEPTON_GITHUB_CLIENT_ID`
+- `LEPTON_GITHUB_CLIENT_SECRET`
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `APPLE_TEAM_ID`
+- `CSC_LINK`
+- `CSC_KEY_PASSWORD`
+- `WINDOWS_CSC_LINK`
+- `WINDOWS_CSC_KEY_PASSWORD`
+- `SNAPCRAFT_STORE_CREDENTIALS`
+
+The workflow uses the built-in `GITHUB_TOKEN` for GitHub Release uploads.
+Production macOS publishing fails early if Apple signing and notarization secrets
+are missing. Windows signing is enabled when the Windows certificate secrets are
+present.
+
+Use environment-scoped secrets if prerelease and production should use different
+GitHub OAuth applications.
+
+The release workflow can also be started manually from GitHub Actions. Manual
+runs default to `--publish never`, which is intended for packaging dry runs
+without creating a public release.
+
+### Local Packaging
 
 Build an unpacked app for the current platform.
 ```bash

--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ release workflow
     |
     +--> validate: lint, unit tests, webpack build
     |
-    +--> macOS Intel: signed/notarized dmg + zip
-    +--> macOS Apple Silicon: signed/notarized dmg + zip
-    +--> Windows: NSIS installer + archive
+    +--> macOS Intel: unsigned dmg + zip
+    +--> macOS Apple Silicon: unsigned dmg + zip
+    +--> Windows: unsigned NSIS installer + archive
     +--> Linux: AppImage + snap
     |
     v
@@ -322,19 +322,14 @@ Release publishing requires repository secrets:
 
 - `LEPTON_GITHUB_CLIENT_ID`
 - `LEPTON_GITHUB_CLIENT_SECRET`
-- `APPLE_ID`
-- `APPLE_APP_SPECIFIC_PASSWORD`
-- `APPLE_TEAM_ID`
-- `CSC_LINK`
-- `CSC_KEY_PASSWORD`
-- `WINDOWS_CSC_LINK`
-- `WINDOWS_CSC_KEY_PASSWORD`
 - `SNAPCRAFT_STORE_CREDENTIALS`
 
 The workflow uses the built-in `GITHUB_TOKEN` for GitHub Release uploads.
-Production macOS publishing fails early if Apple signing and notarization secrets
-are missing. Windows signing is enabled when the Windows certificate secrets are
-present.
+macOS and Windows artifacts are intentionally unsigned. macOS users should
+expect Gatekeeper warnings and may need to open the app from Finder's context
+menu or adjust Privacy & Security settings. Windows users should expect
+Microsoft Defender SmartScreen warnings. If signing is added later, update the
+workflow, `electron-builder.js`, and this documentation together.
 
 Use environment-scoped secrets if prerelease and production should use different
 GitHub OAuth applications.

--- a/app/utilities/updatePolicy.js
+++ b/app/utilities/updatePolicy.js
@@ -1,0 +1,78 @@
+const semverPattern = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+function parseVersion (version) {
+  if (typeof version !== 'string') return null
+
+  const match = semverPattern.exec(version.trim())
+  if (!match) return null
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] || ''
+  }
+}
+
+function isStableVersion (version) {
+  const parsed = parseVersion(version)
+  return Boolean(parsed && !parsed.prerelease)
+}
+
+function compareVersions (left, right) {
+  const parsedLeft = parseVersion(left)
+  const parsedRight = parseVersion(right)
+  if (!parsedLeft || !parsedRight) return null
+
+  for (const field of ['major', 'minor', 'patch']) {
+    if (parsedLeft[field] > parsedRight[field]) return 1
+    if (parsedLeft[field] < parsedRight[field]) return -1
+  }
+  return 0
+}
+
+function getUpdateCheckDecision ({ autoUpdate, currentVersion, isDev }) {
+  if (isDev) {
+    return { reason: 'development build', shouldCheck: false }
+  }
+
+  if (autoUpdate !== true) {
+    return { reason: 'autoUpdate disabled', shouldCheck: false }
+  }
+
+  if (!isStableVersion(currentVersion)) {
+    return { reason: 'current version is not a stable release', shouldCheck: false }
+  }
+
+  return { reason: 'stable release with autoUpdate enabled', shouldCheck: true }
+}
+
+function getUpdateNotificationDecision ({ currentVersion, updateInfo }) {
+  if (!isStableVersion(currentVersion)) {
+    return { reason: 'current version is not a stable release', shouldNotify: false }
+  }
+
+  const nextVersion = updateInfo && updateInfo.version
+  if (!isStableVersion(nextVersion)) {
+    return { reason: 'candidate version is not a stable release', shouldNotify: false }
+  }
+
+  const comparison = compareVersions(nextVersion, currentVersion)
+  if (comparison === null) {
+    return { reason: 'candidate version could not be compared', shouldNotify: false }
+  }
+
+  if (comparison <= 0) {
+    return { reason: 'candidate version is not newer', shouldNotify: false }
+  }
+
+  return { reason: 'candidate version is a newer stable release', shouldNotify: true }
+}
+
+module.exports = {
+  compareVersions,
+  getUpdateCheckDecision,
+  getUpdateNotificationDecision,
+  isStableVersion,
+  parseVersion
+}

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -200,30 +200,22 @@ module.exports = {
     oneClick: false,
     allowToChangeInstallationDirectory: true
   },
-  // Linux builds produce the existing portable and store-friendly package
-  // formats, both published through the GitHub release flow.
+  // Linux targets stay as strings because this electron-builder version validates
+  // Linux target entries as scalar target names. Snap Store publishing belongs in
+  // the dedicated snap config below.
   linux: {
     category: 'Development',
     target: [
-      {
-        target: 'AppImage',
-        arch: [
-          'x64'
-        ],
-        publish: [
-          githubPublishConfig
-        ]
-      },
-      {
-        target: 'snap',
-        arch: [
-          'x64'
-        ],
-        publish: [
-          githubPublishConfig,
-          snapStorePublishConfig
-        ]
-      }
+      'AppImage',
+      'snap'
+    ],
+    publish: [
+      githubPublishConfig
+    ]
+  },
+  snap: {
+    publish: [
+      snapStorePublishConfig
     ]
   }
 }

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -1,6 +1,29 @@
 const { getSupportedLocales } = require('./app/utilities/i18n')
 const { getElectronLanguages } = require('./configs/electronLanguages')
 
+function buildGithubPublishConfig () {
+  const releaseType = process.env.LEPTON_GITHUB_RELEASE_TYPE
+  return {
+    provider: 'github',
+    ...(releaseType ? { releaseType } : {})
+  }
+}
+
+function buildSnapStorePublishConfig () {
+  const channels = process.env.LEPTON_SNAP_CHANNELS
+    ? process.env.LEPTON_SNAP_CHANNELS.split(',').map(channel => channel.trim()).filter(Boolean)
+    : undefined
+
+  return {
+    provider: 'snapStore',
+    publishAutoUpdate: false,
+    ...(channels && channels.length > 0 ? { channels } : {})
+  }
+}
+
+const githubPublishConfig = buildGithubPublishConfig()
+const snapStorePublishConfig = buildSnapStorePublishConfig()
+
 // Keep only app source that the Electron main process reads at runtime.
 // Renderer source is compiled into bundle/app.bundle.js and does not need to
 // ship separately inside app.asar.
@@ -116,6 +139,9 @@ module.exports = {
     ...topLevelRendererOnlyNodeModules.map(packageName => `!node_modules/${packageName}/**`)
   ],
   appId: 'com.cosmox.lepton',
+  // electron-builder expands these macros at packaging time.
+  // eslint-disable-next-line no-template-curly-in-string
+  artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
   // Keep Electron's own locale files aligned with the locales Lepton exposes in
   // the renderer. Add new locales in the shared i18n config first, then let this
   // derived list control the packaged Electron resources.
@@ -133,7 +159,7 @@ module.exports = {
         ]
       },
       {
-        target: '7z',
+        target: 'zip',
         arch: [
           'x64',
           'arm64'
@@ -141,7 +167,7 @@ module.exports = {
       }
     ],
     publish: [
-      'github'
+      githubPublishConfig
     ],
     darkModeSupport: true
   },
@@ -165,7 +191,7 @@ module.exports = {
       }
     ],
     publish: [
-      'github'
+      githubPublishConfig
     ]
   },
   // NSIS settings preserve the current installer UX: guided install flow with a
@@ -179,11 +205,25 @@ module.exports = {
   linux: {
     category: 'Development',
     target: [
-      'AppImage',
-      'snap'
-    ],
-    publish: [
-      'github'
+      {
+        target: 'AppImage',
+        arch: [
+          'x64'
+        ],
+        publish: [
+          githubPublishConfig
+        ]
+      },
+      {
+        target: 'snap',
+        arch: [
+          'x64'
+        ],
+        publish: [
+          githubPublishConfig,
+          snapStorePublishConfig
+        ]
+      }
     ]
   }
 }

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -147,10 +147,12 @@ module.exports = {
   // the renderer. Add new locales in the shared i18n config first, then let this
   // derived list control the packaged Electron resources.
   electronLanguages: getElectronLanguages(getSupportedLocales()),
-  // macOS builds publish both installer and archive artifacts for Intel and
-  // Apple Silicon users.
+  // macOS builds publish unsigned installer and archive artifacts for Intel and
+  // Apple Silicon users. A paid Apple Developer account is intentionally not
+  // required for the release flow.
   mac: {
     category: 'public.app-category.productivity',
+    identity: null,
     target: [
       {
         target: 'dmg',

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -37,7 +37,8 @@ const mainRuntimeAppFiles = [
   'app/utilities/jupyterNotebook/core.js',
   'app/utilities/logging/**',
   'app/utilities/menu/**',
-  'app/utilities/startAtLogin/**'
+  'app/utilities/startAtLogin/**',
+  'app/utilities/updatePolicy.js'
 ]
 
 // Packages in this list are renderer-only dependencies that webpack already

--- a/main.js
+++ b/main.js
@@ -26,6 +26,10 @@ const { applyElectronProxy } = require('./app/utilities/electronProxy')
 const { configureI18n, t } = require('./app/utilities/i18n')
 const { createElectronLocalStorage } = require('./app/utilities/electronLocalStorage')
 const {
+  getUpdateCheckDecision,
+  getUpdateNotificationDecision
+} = require('./app/utilities/updatePolicy')
+const {
   buildGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = require('./app/utilities/auth/githubOAuth')
@@ -37,6 +41,8 @@ const electronLocalStorage = createElectronLocalStorage({
 
 const { autoUpdater } = require("electron-updater")
 autoUpdater.logger = logger
+autoUpdater.allowPrerelease = false
+autoUpdater.allowDowngrade = false
 
 initGlobalConfigs()
 configureI18n(nconf.get('i18n:locale'))
@@ -69,7 +75,17 @@ function getConfigPath() {
 }
 
 function shouldCheckForUpdates () {
-  return !isDev && !appInfo.version.includes('alpha') && nconf.get('autoUpdate')
+  const decision = getUpdateCheckDecision({
+    autoUpdate: nconf.get('autoUpdate'),
+    currentVersion: appInfo.version,
+    isDev
+  })
+
+  if (!decision.shouldCheck) {
+    logger.debug('[autoUpdater] update check skipped: ' + decision.reason)
+  }
+
+  return decision.shouldCheck
 }
 
 function getRendererUrl () {
@@ -82,7 +98,6 @@ function getRendererUrl () {
 
 function checkForAppUpdates ({ notify = false } = {}) {
   if (!shouldCheckForUpdates()) {
-    logger.debug('[autoUpdater] update check skipped')
     return
   }
 
@@ -172,6 +187,16 @@ function createWindow (autoLogin) {
       logger.debug('[autoUpdater] update-not-available')
     })
     autoUpdater.on('update-available', (info) => {
+      const decision = getUpdateNotificationDecision({
+        currentVersion: appInfo.version,
+        updateInfo: info
+      })
+
+      if (!decision.shouldNotify) {
+        logger.debug('[autoUpdater] update notification skipped: ' + decision.reason)
+        return
+      }
+
       logger.debug('[autoUpdater] update-available. ' + mainWindow)
       global.newVersionInfo = info
       mainWindow && mainWindow.webContents.send('update-available')

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -9,6 +9,10 @@ describe('electron-builder distribution config', () => {
     expect(builderConfig.artifactName).toBe('${productName}-${version}-${os}-${arch}.${ext}')
   })
 
+  it('packages main-process runtime files used at startup', () => {
+    expect(builderConfig.files).toContain('app/utilities/updatePolicy.js')
+  })
+
   it('builds macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
     expect(builderConfig.mac.target).toEqual([
       {

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -14,6 +14,7 @@ describe('electron-builder distribution config', () => {
   })
 
   it('builds macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
+    expect(builderConfig.mac.identity).toBeNull()
     expect(builderConfig.mac.target).toEqual([
       {
         target: 'dmg',

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -28,20 +28,19 @@ describe('electron-builder distribution config', () => {
     ])
   })
 
-  it('publishes AppImage only to GitHub and snap to GitHub plus Snap Store', () => {
-    const appImageTarget = builderConfig.linux.target.find(target => target.target === 'AppImage')
-    const snapTarget = builderConfig.linux.target.find(target => target.target === 'snap')
+  it('keeps Linux targets schema-compatible and publishes snap to Snap Store', () => {
+    expect(builderConfig.linux.target).toEqual([
+      'AppImage',
+      'snap'
+    ])
 
-    expect(appImageTarget.publish).toHaveLength(1)
-    expect(appImageTarget.publish[0]).toMatchObject({
+    expect(builderConfig.linux.publish).toHaveLength(1)
+    expect(builderConfig.linux.publish[0]).toMatchObject({
       provider: 'github'
     })
 
-    expect(snapTarget.publish).toHaveLength(2)
-    expect(snapTarget.publish[0]).toMatchObject({
-      provider: 'github'
-    })
-    expect(snapTarget.publish[1]).toMatchObject({
+    expect(builderConfig.snap.publish).toHaveLength(1)
+    expect(builderConfig.snap.publish[0]).toMatchObject({
       provider: 'snapStore',
       publishAutoUpdate: false
     })

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -1,0 +1,49 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const builderConfig = require('../../electron-builder')
+
+describe('electron-builder distribution config', () => {
+  it('names release artifacts with platform and architecture', () => {
+    expect(builderConfig.artifactName).toBe('${productName}-${version}-${os}-${arch}.${ext}')
+  })
+
+  it('builds macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
+    expect(builderConfig.mac.target).toEqual([
+      {
+        target: 'dmg',
+        arch: [
+          'x64',
+          'arm64'
+        ]
+      },
+      {
+        target: 'zip',
+        arch: [
+          'x64',
+          'arm64'
+        ]
+      }
+    ])
+  })
+
+  it('publishes AppImage only to GitHub and snap to GitHub plus Snap Store', () => {
+    const appImageTarget = builderConfig.linux.target.find(target => target.target === 'AppImage')
+    const snapTarget = builderConfig.linux.target.find(target => target.target === 'snap')
+
+    expect(appImageTarget.publish).toHaveLength(1)
+    expect(appImageTarget.publish[0]).toMatchObject({
+      provider: 'github'
+    })
+
+    expect(snapTarget.publish).toHaveLength(2)
+    expect(snapTarget.publish[0]).toMatchObject({
+      provider: 'github'
+    })
+    expect(snapTarget.publish[1]).toMatchObject({
+      provider: 'snapStore',
+      publishAutoUpdate: false
+    })
+  })
+})

--- a/tests/utilities/updatePolicy.test.js
+++ b/tests/utilities/updatePolicy.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compareVersions,
+  getUpdateCheckDecision,
+  getUpdateNotificationDecision,
+  isStableVersion,
+  parseVersion
+} from '../../app/utilities/updatePolicy'
+
+describe('update policy', () => {
+  it('parses stable and prerelease semver strings', () => {
+    expect(parseVersion('v1.2.3')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: ''
+    })
+    expect(parseVersion('1.2.3-beta.1')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: 'beta.1'
+    })
+    expect(parseVersion('latest')).toBeNull()
+  })
+
+  it('identifies only non-prerelease versions as stable', () => {
+    expect(isStableVersion('1.2.3')).toBe(true)
+    expect(isStableVersion('1.2.3+build.4')).toBe(true)
+    expect(isStableVersion('1.2.3-alpha.1')).toBe(false)
+    expect(isStableVersion(undefined)).toBe(false)
+  })
+
+  it('compares version precedence by major, minor, and patch', () => {
+    expect(compareVersions('1.3.0', '1.2.9')).toBe(1)
+    expect(compareVersions('2.0.0', '2.0.0')).toBe(0)
+    expect(compareVersions('2.0.0', '2.0.1')).toBe(-1)
+    expect(compareVersions('not-a-version', '2.0.1')).toBeNull()
+  })
+
+  it('only checks for updates from stable production builds with autoUpdate enabled', () => {
+    expect(getUpdateCheckDecision({
+      autoUpdate: true,
+      currentVersion: '1.2.3',
+      isDev: false
+    }).shouldCheck).toBe(true)
+
+    expect(getUpdateCheckDecision({
+      autoUpdate: true,
+      currentVersion: '1.2.3-beta.1',
+      isDev: false
+    })).toEqual({
+      reason: 'current version is not a stable release',
+      shouldCheck: false
+    })
+
+    expect(getUpdateCheckDecision({
+      autoUpdate: false,
+      currentVersion: '1.2.3',
+      isDev: false
+    }).shouldCheck).toBe(false)
+
+    expect(getUpdateCheckDecision({
+      autoUpdate: true,
+      currentVersion: '1.2.3',
+      isDev: true
+    }).shouldCheck).toBe(false)
+  })
+
+  it('notifies only for newer stable update candidates', () => {
+    expect(getUpdateNotificationDecision({
+      currentVersion: '1.2.3',
+      updateInfo: { version: '1.2.4' }
+    }).shouldNotify).toBe(true)
+
+    expect(getUpdateNotificationDecision({
+      currentVersion: '1.2.3',
+      updateInfo: { version: '1.2.4-rc.1' }
+    })).toEqual({
+      reason: 'candidate version is not a stable release',
+      shouldNotify: false
+    })
+
+    expect(getUpdateNotificationDecision({
+      currentVersion: '1.2.3-beta.1',
+      updateInfo: { version: '1.2.4' }
+    }).shouldNotify).toBe(false)
+
+    expect(getUpdateNotificationDecision({
+      currentVersion: '1.2.3',
+      updateInfo: { version: '1.2.3' }
+    })).toEqual({
+      reason: 'candidate version is not newer',
+      shouldNotify: false
+    })
+
+    expect(getUpdateNotificationDecision({
+      currentVersion: '1.2.3',
+      updateInfo: { version: 'invalid' }
+    }).shouldNotify).toBe(false)
+  })
+})

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,4 +4,4 @@ These pages are the canonical, versioned replacement for the old GitHub wiki.
 
 - [Configuration](configuration.md)
 - [FAQ](faq.md)
-
+- [Publish Flow](publish-flow.md)

--- a/wiki/publish-flow.md
+++ b/wiki/publish-flow.md
@@ -1,0 +1,236 @@
+# Publish Flow
+
+Lepton publishes desktop builds through the `Release` GitHub Actions workflow.
+Merging release-flow changes does not publish anything by itself. Publishing
+starts only when a version tag is pushed or when the workflow is run manually.
+
+## Release Types
+
+| Flow | Tag example | GitHub release | Snap channel | Stable users notified |
+| :--- | :--- | :--- | :--- | :--- |
+| Stable release | `v1.10.2` | Published release | `stable` | Yes, when `autoUpdate` is enabled |
+| Prerelease | `v1.11.0-beta.1` | Prerelease | `edge` | No |
+| Manual dry run | No tag | No release by default | No store publish by default | No |
+
+Stable tags must be plain semver tags:
+
+```bash
+git tag v1.10.2
+git push origin v1.10.2
+```
+
+Prerelease tags must include a semver prerelease suffix:
+
+```bash
+git tag v1.11.0-alpha.1
+git push origin v1.11.0-alpha.1
+
+git tag v1.11.0-beta.1
+git push origin v1.11.0-beta.1
+
+git tag v1.11.0-rc.1
+git push origin v1.11.0-rc.1
+```
+
+The workflow rejects tags that do not look like `v1.2.3` or
+`v1.2.3-beta.1`.
+
+## Required Secrets
+
+Configure these in GitHub Actions secrets before publishing:
+
+| Secret | Used by | Required for |
+| :--- | :--- | :--- |
+| `LEPTON_GITHUB_CLIENT_ID` | All packaging jobs | All release builds |
+| `LEPTON_GITHUB_CLIENT_SECRET` | All packaging jobs | All release builds |
+| `APPLE_ID` | macOS | Stable signed/notarized macOS release |
+| `APPLE_APP_SPECIFIC_PASSWORD` | macOS | Stable signed/notarized macOS release |
+| `APPLE_TEAM_ID` | macOS | Stable signed/notarized macOS release |
+| `CSC_LINK` | macOS | Stable signed/notarized macOS release |
+| `CSC_KEY_PASSWORD` | macOS | Stable signed/notarized macOS release |
+| `WINDOWS_CSC_LINK` | Windows | Signed Windows release |
+| `WINDOWS_CSC_KEY_PASSWORD` | Windows | Signed Windows release |
+| `SNAPCRAFT_STORE_CREDENTIALS` | Linux | Snap Store publish |
+
+The workflow uses GitHub's built-in `GITHUB_TOKEN` for GitHub Release uploads.
+
+`configs/account.js` is not committed. Each release job generates it from
+`LEPTON_GITHUB_CLIENT_ID` and `LEPTON_GITHUB_CLIENT_SECRET` before packaging so
+release artifacts use the configured GitHub OAuth app.
+
+Use GitHub Environments if prerelease and production should have different
+secret values or approval rules.
+
+## Stable Release Flow
+
+Use this flow for versions intended for all users.
+
+```text
+merge release-ready code to master
+    |
+    v
+create plain semver tag, for example v1.10.2
+    |
+    v
+push tag to origin
+    |
+    v
+Release workflow
+    |
+    +--> resolve context:
+    |       publish_policy=always
+    |       github_release_type=release
+    |       environment=production
+    |       snap_channels=stable
+    |
+    +--> validate:
+    |       npm run lint
+    |       npm run test:unit
+    |       npm run test:build
+    |
+    +--> build macOS:
+    |       dmg + zip for x64
+    |       dmg + zip for arm64
+    |       signed and notarized when Apple secrets are present
+    |
+    +--> build Windows:
+    |       NSIS installer for x64 and ia32
+    |       7z archive for x64 and ia32
+    |       signed when Windows certificate secrets are present
+    |
+    +--> build Linux:
+    |       AppImage for x64
+    |       snap for x64
+    |
+    v
+publish GitHub Release and release assets
+    |
+    v
+publish Snap to stable channel
+    |
+    v
+stable auto-update metadata is available
+```
+
+The macOS job builds Intel and Apple Silicon artifacts in one electron-builder
+run so `latest-mac.yml` is generated once for the full macOS artifact set.
+
+Stable app builds are eligible to check for updates when the user's
+`.leptonrc` has:
+
+```json
+{
+  "autoUpdate": true
+}
+```
+
+Only newer stable versions should notify users. Prerelease candidates are
+ignored by the updater policy.
+
+## Prerelease Flow
+
+Use this flow for testing builds that should be public but should not notify
+stable users.
+
+```text
+merge prerelease-ready code to master
+    |
+    v
+create semver prerelease tag, for example v1.11.0-beta.1
+    |
+    v
+push tag to origin
+    |
+    v
+Release workflow
+    |
+    +--> resolve context:
+    |       publish_policy=always
+    |       github_release_type=prerelease
+    |       environment=prerelease
+    |       snap_channels=edge
+    |
+    +--> validate:
+    |       npm run lint
+    |       npm run test:unit
+    |       npm run test:build
+    |
+    +--> build macOS, Windows, and Linux artifacts
+    |
+    v
+publish GitHub prerelease and prerelease assets
+    |
+    v
+publish Snap to edge channel
+    |
+    v
+no stable-user auto-update notification
+```
+
+Prerelease app versions do not check for updates. Stable app versions also do
+not notify for prerelease update candidates.
+
+## Manual Release Workflow Runs
+
+The workflow can be started manually from the GitHub Actions UI.
+
+Manual inputs:
+
+| Input | Default | Purpose |
+| :--- | :--- | :--- |
+| `publish` | `never` | Use `never` for a packaging dry run. Use `always` to publish. |
+| `release_type` | `draft` | GitHub release type for manual publishing: `draft`, `prerelease`, or `release`. |
+| `snap_channels` | `edge` | Comma-separated Snap channels for manual publishing. |
+
+Manual runs default to `publish=never`, so they build artifacts and upload
+workflow artifacts without creating a GitHub Release or publishing to the Snap
+Store.
+
+## Expected Artifacts
+
+Artifact names include product name, version, operating system, architecture,
+and extension:
+
+```text
+Lepton-1.10.2-mac-x64.dmg
+Lepton-1.10.2-mac-arm64.zip
+Lepton-1.10.2-win-x64.exe
+Lepton-1.10.2-win-ia32.7z
+Lepton-1.10.2-linux-x64.AppImage
+Lepton-1.10.2-linux-x64.snap
+```
+
+Updater metadata files such as `latest.yml` and `latest-mac.yml` are also
+generated and published with GitHub release assets.
+
+## Failure Handling
+
+If validation fails, fix the branch and create a new tag after the fix is
+merged. Do not reuse a published version tag unless the failed workflow did not
+publish any artifacts.
+
+If publishing partially succeeds:
+
+1. Remove or repair the incomplete GitHub Release assets.
+2. Remove incorrect Snap channel revisions or close the affected channel in the
+   Snap Store.
+3. Create a new patch or prerelease tag.
+4. Run the release flow again from the new tag.
+
+Avoid force-moving public release tags after users may have downloaded assets.
+
+## Local Packaging Fallback
+
+Local packaging is still available for diagnosing build issues:
+
+```bash
+npm ci
+npm run dist -- -m
+npm run dist -- -w
+npm run dist -- -l
+```
+
+Local release-like packaging still needs `configs/account.js` to exist. The
+GitHub Actions workflow generates this file from secrets; local builds must
+create it manually.
+

--- a/wiki/publish-flow.md
+++ b/wiki/publish-flow.md
@@ -43,13 +43,6 @@ Configure these in GitHub Actions secrets before publishing:
 | :--- | :--- | :--- |
 | `LEPTON_GITHUB_CLIENT_ID` | All packaging jobs | All release builds |
 | `LEPTON_GITHUB_CLIENT_SECRET` | All packaging jobs | All release builds |
-| `APPLE_ID` | macOS | Stable signed/notarized macOS release |
-| `APPLE_APP_SPECIFIC_PASSWORD` | macOS | Stable signed/notarized macOS release |
-| `APPLE_TEAM_ID` | macOS | Stable signed/notarized macOS release |
-| `CSC_LINK` | macOS | Stable signed/notarized macOS release |
-| `CSC_KEY_PASSWORD` | macOS | Stable signed/notarized macOS release |
-| `WINDOWS_CSC_LINK` | Windows | Signed Windows release |
-| `WINDOWS_CSC_KEY_PASSWORD` | Windows | Signed Windows release |
 | `SNAPCRAFT_STORE_CREDENTIALS` | Linux | Snap Store publish |
 
 The workflow uses GitHub's built-in `GITHUB_TOKEN` for GitHub Release uploads.
@@ -91,12 +84,12 @@ Release workflow
     +--> build macOS:
     |       dmg + zip for x64
     |       dmg + zip for arm64
-    |       signed and notarized when Apple secrets are present
+    |       unsigned by policy
     |
     +--> build Windows:
     |       NSIS installer for x64 and ia32
     |       7z archive for x64 and ia32
-    |       signed when Windows certificate secrets are present
+    |       unsigned by policy
     |
     +--> build Linux:
     |       AppImage for x64
@@ -114,6 +107,25 @@ stable auto-update metadata is available
 
 The macOS job builds Intel and Apple Silicon artifacts in one electron-builder
 run so `latest-mac.yml` is generated once for the full macOS artifact set.
+
+## Unsigned macOS And Windows Builds
+
+Lepton does not require paid Apple Developer Program or Windows code-signing
+certificates for publishing. The release workflow intentionally disables
+macOS/Windows signing and does not read Apple or Windows certificate secrets.
+
+Expected user-facing behavior:
+
+- macOS users should expect Gatekeeper warnings. They may need to open Lepton
+  from Finder's context menu or approve it in Privacy & Security settings.
+- Windows users should expect Microsoft Defender SmartScreen warnings until the
+  unsigned app has enough reputation.
+- macOS and Windows auto-update metadata is still published for stable tags,
+  but unsigned update installation should be manually verified before it is
+  advertised as a fully supported update path.
+
+If signing is added later, update `.github/workflows/release.yml`,
+`electron-builder.js`, this wiki page, and the README together.
 
 Stable app builds are eligible to check for updates when the user's
 `.leptonrc` has:
@@ -233,4 +245,3 @@ npm run dist -- -l
 Local release-like packaging still needs `configs/account.js` to exist. The
 GitHub Actions workflow generates this file from secrets; local builds must
 create it manually.
-


### PR DESCRIPTION
## Summary

Adds an automated cross-platform release flow for Lepton distribution.

- Adds a tag/manual GitHub Actions release workflow for stable and prerelease builds.
- Updates electron-builder distribution config for explicit OS/arch artifact names, unsigned macOS dmg+zip artifacts, unsigned Windows NSIS/7z artifacts, GitHub release type control, and Snap Store publishing for snap artifacts.
- Adds stable-only updater policy so prerelease/current builds and prerelease update candidates do not notify stable users.
- Documents the release process, required secrets, account.js handling, artifact naming, Snap channels, local packaging fallback, unsigned macOS/Windows behavior, and the full wiki publish flow.

## Release Behavior

- Stable tags like `v1.10.2` publish stable GitHub Releases, stable Snap channel artifacts, and stable updater metadata.
- Prerelease tags like `v1.10.2-beta.1` publish GitHub prereleases and Snap edge artifacts.
- macOS and Windows artifacts are intentionally unsigned; Apple Developer Program and Windows code-signing certificates are not required.
- The release workflow generates `configs/account.js` from `LEPTON_GITHUB_CLIENT_ID` and `LEPTON_GITHUB_CLIENT_SECRET` before packaging so release builds do not fall back to `accountDummy.js`.

## Validation

- `npm run lint`
- `npm test` - 142 Vitest tests plus webpack development build
- `npm run test:packaged-smoke` - unsigned packaged login and fixture surfaces rendered
- `npm run test:unit -- tests/configs/electronBuilder.test.js`
- `npx eslint electron-builder.js app/utilities/updatePolicy.js`
- `npm run test:unit -- --run tests/utilities/updatePolicy.test.js tests/configs/electronBuilder.test.js`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"`
- `git diff --check`
- GitHub Actions CI run #291 passed for head `db381a7`

## Notes

Unsigned macOS builds will show Gatekeeper warnings, and unsigned Windows builds can show Microsoft Defender SmartScreen warnings. macOS/Windows auto-update metadata is published for stable releases, but unsigned update installation should be manually verified before it is advertised as a fully supported update path.

`main.js` still has existing style issues if linted directly, but the repository's configured `npm run lint` passes. The OAuth client secret remains packaged into the Electron app under the current auth architecture; this PR preserves existing behavior while making release packaging functional.