### PR TITLE
[codex] Document macOS .leptonrc path

### DIFF
--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -120,6 +120,16 @@ Set `logger.level` to `debug` when collecting logs for an issue report:
 
 ## Home Directory Notes
 
+### macOS
+
+On macOS, the home directory is your user folder under `/Users`. Place `.leptonrc` here:
+
+```text
+/Users/<CurrentUserName>/.leptonrc
+```
+
+In Finder, use `Go` > `Home` to open the home directory. Because `.leptonrc` starts with a dot, it is hidden by default; press `Command + Shift + .` to show hidden files.
+
 ### Windows
 
 The home directory can vary by Windows distribution, but it usually starts here:


### PR DESCRIPTION
## Summary

Adds macOS-specific guidance to the configuration wiki page for where users should place their `.leptonrc` file.

## Impact

Users on macOS can now find the expected home directory path and understand how to show hidden dotfiles in Finder.

## Validation

- `git diff --check`