### PR TITLE
[codex] Prepare 2.0.0 beta prerelease

### DIFF
--- a/license.json
+++ b/license.json
@@ -134,7 +134,7 @@
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "licenseFile": "node_modules/@types/use-sync-external-store/LICENSE"
     },
-    "Lepton@1.10.1-alpha.1": {
+    "Lepton@2.0.0-beta.1": {
         "licenses": "MIT",
         "repository": "https://github.com/hackjutsu/Lepton",
         "licenseFile": "LICENSE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "1.10.1-alpha.1",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "1.10.1-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "1.10.1-alpha.1",
+  "version": "2.0.0-beta.1",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

Prepares the repository for the `v2.0.0-beta.1` prerelease tag.

- Bumps `package.json` to `2.0.0-beta.1`.
- Updates the root package version in `package-lock.json`.
- Regenerates `license.json` so the root `Lepton@...` entry matches the prerelease version.

## Validation

- `npm run lint`
- `npm test` - 142 Vitest tests plus webpack development build
- `npm run test:packaged-smoke` - unsigned packaged app rendered login and fixture surfaces
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"`
- `git diff --check`

## Tagging

After this PR merges to `master`, create and push the prerelease tag:

```bash
git checkout master
git pull origin master
git tag v2.0.0-beta.1
git push origin v2.0.0-beta.1
```

That tag will trigger the Release workflow as a GitHub prerelease and Snap `edge` publish.