### PR TITLE
[codex] Fix release artifact validation

### DIFF
--- a/.github/scripts/assert-release-artifacts.js
+++ b/.github/scripts/assert-release-artifacts.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const path = require('path')
+
+const [platform, ...extensions] = process.argv.slice(2)
+
+if (!platform || extensions.length === 0) {
+  console.error('Usage: node .github/scripts/assert-release-artifacts.js <platform> <extension...>')
+  process.exit(1)
+}
+
+const distDir = path.join(process.cwd(), 'dist')
+const expectedExtensions = new Set(extensions.map(extension => (
+  extension.startsWith('.') ? extension : `.${extension}`
+)))
+
+function walk (directory) {
+  if (!fs.existsSync(directory)) return []
+
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const file = path.join(directory, entry.name)
+    return entry.isDirectory() ? walk(file) : [file]
+  })
+}
+
+function relativeToWorkspace (file) {
+  return path.relative(process.cwd(), file)
+}
+
+const files = walk(distDir).map(relativeToWorkspace)
+
+if (files.length === 0) {
+  console.log('No files found in dist.')
+} else {
+  console.log(`Files in dist for ${platform}:`)
+  files.forEach(file => console.log(file))
+}
+
+const topLevelArtifacts = fs.existsSync(distDir)
+  ? fs.readdirSync(distDir, { withFileTypes: true })
+    .filter(entry => entry.isFile())
+    .map(entry => path.join('dist', entry.name))
+    .filter(file => expectedExtensions.has(path.extname(file)))
+  : []
+
+if (topLevelArtifacts.length === 0) {
+  console.error(`No top-level ${platform} package artifacts were produced in dist.`)
+  console.error(`Expected one of: ${Array.from(expectedExtensions).join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`Found ${platform} package artifacts:`)
+topLevelArtifacts.forEach(file => console.log(file))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,9 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
-        run: npx electron-builder --mac --x64 --arm64 --publish ${{ needs.release-context.outputs.publish_policy }}
+        run: |
+          node ./node_modules/electron-builder/cli.js --mac --x64 --arm64 --publish ${{ needs.release-context.outputs.publish_policy }}
+          node ./.github/scripts/assert-release-artifacts.js macOS .dmg .zip
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
@@ -222,7 +224,9 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
-        run: npx electron-builder --win --x64 --ia32 --publish ${{ needs.release-context.outputs.publish_policy }}
+        run: |
+          node ./node_modules/electron-builder/cli.js --win --x64 --ia32 --publish ${{ needs.release-context.outputs.publish_policy }}
+          node ./.github/scripts/assert-release-artifacts.js Windows .exe .7z
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
@@ -282,7 +286,9 @@ jobs:
           LEPTON_GITHUB_RELEASE_TYPE: ${{ needs.release-context.outputs.github_release_type }}
           LEPTON_SNAP_CHANNELS: ${{ needs.release-context.outputs.snap_channels }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: npx electron-builder --linux --x64 --publish ${{ needs.release-context.outputs.publish_policy }}
+        run: |
+          node ./node_modules/electron-builder/cli.js --linux --x64 --publish ${{ needs.release-context.outputs.publish_policy }}
+          node ./.github/scripts/assert-release-artifacts.js Linux .AppImage .snap
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the release workflow after the `v2.0.0-beta.1` prerelease run exposed a Windows packaging/artifact gap.

- Invokes the installed `electron-builder` CLI directly instead of going through `npx` in platform release jobs.
- Adds `.github/scripts/assert-release-artifacts.js` to print produced `dist` files and fail the build step when no top-level package artifact exists.
- Keeps upload globs limited to top-level release artifacts so unpacked app internals do not mask missing installers.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"`
- `node --check .github/scripts/assert-release-artifacts.js`
- `git diff --check`
- `node ./.github/scripts/assert-release-artifacts.js macOS .dmg .zip` against stale local packaged output, to verify diagnostics/top-level artifact detection.

## Release note

After this merges, use a new prerelease tag from the fixed master commit, preferably `v2.0.0-beta.2`, rather than reusing the failed `v2.0.0-beta.1` tag.