### PR TITLE
[codex] Prepare 2.0.0 beta.2 prerelease

### DIFF
--- a/license.json
+++ b/license.json
@@ -134,7 +134,7 @@
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "licenseFile": "node_modules/@types/use-sync-external-store/LICENSE"
     },
-    "Lepton@2.0.0-beta.1": {
+    "Lepton@2.0.0-beta.2": {
         "licenses": "MIT",
         "repository": "https://github.com/hackjutsu/Lepton",
         "licenseFile": "LICENSE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

Prepares the next 2.0.0 prerelease after the `v2.0.0-beta.1` release run exposed a Windows artifact upload defect.

- Bumps app version from `2.0.0-beta.1` to `2.0.0-beta.2`.
- Updates the package lock root version.
- Regenerates `license.json` so the root package entry matches `Lepton@2.0.0-beta.2`.

## Validation

- `npm run lint`
- `npm test`
- `git diff --check`

## Release note

After this merges, tag the merged master commit as `v2.0.0-beta.2`. This avoids force-moving the already-pushed failed `v2.0.0-beta.1` tag.