### PR TITLE
[codex] Fix GitHub OAuth login failure handling

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -18,6 +18,7 @@ export const UPDATE_PINNED_TAGS = 'UPDATE_PINNED_TAGS'
 export const SELECT_GIST_TAG = 'SELECT_GIST_TAG'
 export const SELECT_GIST = 'SELECT_GIST'
 export const UPDATE_AUTHWINDOW_STATUS = 'UPDATE_AUTHWINDOW_STATUS'
+export const UPDATE_LOGIN_STATUS = 'UPDATE_LOGIN_STATUS'
 export const UPDATE_GIST_SYNC_STATUS = 'UPDATE_GIST_SYNC_STATUS'
 export const UPDATE_SEARCHWINDOW_STATUS = 'UPDATE_SEARCHWINDOW_STATUS'
 export const UPDATE_SCROLL_REQUEST_STATUS = 'UPDATE_SCROLL_REQUEST_STATUS'
@@ -121,6 +122,13 @@ export function updateGistSyncStatus (status) {
 export function updateAuthWindowStatus (status) {
   return {
     type: UPDATE_AUTHWINDOW_STATUS,
+    payload: status
+  }
+}
+
+export function updateLoginStatus (status) {
+  return {
+    type: UPDATE_LOGIN_STATUS,
     payload: status
   }
 }

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -20,6 +20,13 @@ const logger = electronBridge.logger
 
 const LoginModeEnum = { CREDENTIALS: 1, TOKEN: 2 }
 
+function getFileUrl (filePath) {
+  if (!filePath) return null
+  const normalizedPath = String(filePath).replace(/\\/g, '/')
+  const fileUrlPrefix = normalizedPath[0] === '/' ? 'file://' : 'file:///'
+  return fileUrlPrefix + encodeURI(normalizedPath)
+}
+
 class LoginPage extends Component {
   constructor (props) {
     super(props)
@@ -215,7 +222,28 @@ class LoginPage extends Component {
       <center>
         { this.renderAvatar() }
         { this.renderControlSection() }
+        { this.renderLoginStatus() }
       </center>
+    )
+  }
+
+  renderLoginStatus () {
+    const { loginStatus } = this.props
+    if (!loginStatus || !loginStatus.message) return null
+
+    const logFileUrl = getFileUrl(loginStatus.logFilePath)
+    const className = loginStatus.level === 'error'
+      ? 'login-status-line login-status-line-error'
+      : 'login-status-line'
+
+    return (
+      <div className={ className }>
+        <span>{ loginStatus.message }</span>
+        { logFileUrl
+          ? <span> <a href={ logFileUrl } title={ loginStatus.logFilePath }>See log</a></span>
+          : null
+        }
+      </div>
     )
   }
 
@@ -272,6 +300,7 @@ class LoginPage extends Component {
 function mapStateToProps (state) {
   return {
     authWindowStatus: state.authWindowStatus,
+    loginStatus: state.loginStatus,
     userSessionStatus: state.userSession.activeStatus
   }
 }

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -15,7 +15,7 @@
   .modal-content {
     animation: login-modal-fade-in 180ms ease-out;
     margin-top: 100px;
-    min-height: 400px;
+    min-height: 440px;
     opacity: 1;
     transition: opacity 180ms ease-in;
   }
@@ -96,6 +96,26 @@
     margin-top: 10px;
     margin-bottom: 10px;
     text-decoration: underline;
+  }
+
+  .login-status-line {
+    color: #888;
+    font-size: 11px;
+    line-height: 16px;
+    margin: 0 10px 18px 10px;
+    min-height: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .login-status-line a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  .login-status-line-error {
+    color: #a94442;
   }
 
   .login-alert {

--- a/app/index.js
+++ b/app/index.js
@@ -81,7 +81,7 @@ const LOGIN_STATUS = {
   exchangingOAuthCode: 'Exchanging token...',
   accessTokenReceived: 'Loading profile...',
   loadingGitHubProfile: 'Loading profile...',
-  profileLoadedSyncingGists: 'Syncing gists...',
+  syncingSnippetIndex: 'Syncing snippet index...',
   signInComplete: 'Signed in.',
   signInFailed: 'Sign-in failed.'
 }
@@ -255,6 +255,18 @@ function updateLoginStatusInfo (message) {
   }))
 }
 
+function updateSnippetDownloadStatus (downloaded, total) {
+  const message = `Downloading snippets (${downloaded}/${total})`
+  if (downloaded === 0 || downloaded === total) {
+    logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({ message, level: 'info' }))
+  }
+  reduxStore.dispatch(updateLoginStatus({
+    message,
+    level: 'info',
+    logFilePath: null
+  }))
+}
+
 function updateLoginStatusFailure () {
   const logFilePath = getLogFilePath()
   logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({
@@ -378,10 +390,19 @@ function downloadGistDetailsAfterListSync (gistList, token) {
     return Promise.resolve({})
   }
 
-  logger.info(`[sync] Downloading details for ${gistList.length} gists`)
+  const total = gistList.length
+  if (total === 0) {
+    return Promise.resolve({})
+  }
+
+  let downloaded = 0
+  updateSnippetDownloadStatus(downloaded, total)
+  logger.info(`[sync] Downloading details for ${total} gists`)
   return Promise.map(gistList, gist => {
     return getGitHubApi(GET_SINGLE_GIST)(token, gist.id)
       .then(details => {
+        downloaded += 1
+        updateSnippetDownloadStatus(downloaded, total)
         return {
           id: gist.id,
           details: details
@@ -399,6 +420,7 @@ function downloadGistDetailsAfterListSync (gistList, token) {
 
 function updateUserGists (userLoginId, token) {
   reduxStore.dispatch(updateGistSyncStatus('IN_PROGRESS'))
+  updateLoginStatusInfo(LOGIN_STATUS.syncingSnippetIndex)
   return getGitHubApi(GET_ALL_GISTS)(token, userLoginId)
     .then((gistList) => {
       return downloadGistDetailsAfterListSync(gistList, token)
@@ -513,7 +535,6 @@ function initUserSession (token, options = {}) {
     .then((profile) => {
       logger.debug('[auth] GET_USER_PROFILE succeeded ' + JSON.stringify(describeGitHubProfile(profile)))
       newProfile = profile
-      updateLoginStatusInfo(LOGIN_STATUS.profileLoadedSyncingGists)
       return updateUserGists(profile.login, token)
     })
     .then(() => {

--- a/app/index.js
+++ b/app/index.js
@@ -85,12 +85,19 @@ function getRenderFixtureName () {
 }
 
 function launchAuthWindow (token) {
-  logger.debug(`-----> Inside launchAuthWindow with token ${token}`)
+  logger.debug('[auth] launchAuthWindow called ' + JSON.stringify({ hasCachedCredential: Boolean(token) }))
   if (token) {
-    logger.debug('-----> calling initUserSession with cached token ' + token)
+    logger.debug('[auth] Starting session with cached credential')
     initUserSession(token)
     return
   }
+
+  logger.debug('[auth] Starting GitHub OAuth login ' + JSON.stringify({
+    hasClientId: Boolean(CONFIG_OPTIONS.client_id),
+    clientIdLength: CONFIG_OPTIONS.client_id ? CONFIG_OPTIONS.client_id.length : 0,
+    hasClientSecret: Boolean(CONFIG_OPTIONS.client_secret),
+    scopeCount: CONFIG_OPTIONS.scopes.length
+  }))
 
   updateAuthWindowStatusOn()
 
@@ -101,13 +108,14 @@ function launchAuthWindow (token) {
     .then(handleAuthResult)
     .catch((err) => {
       updateAuthWindowStatusOff()
-      logger.error('Failed to launch GitHub auth window: ' + err.message)
+      logger.error('Failed to launch GitHub auth window: ' + describeGitHubLoginError(err))
       notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
     })
 }
 
 function handleAuthResult (result) {
   updateAuthWindowStatusOff()
+  logger.debug('[auth] GitHub OAuth result received: ' + JSON.stringify(describeGitHubAuthResult(result)))
 
   if (!result || result.status === 'closed') {
     return
@@ -117,10 +125,20 @@ function handleAuthResult (result) {
     logger.info('[Dispatch] updateUserSession IN_PROGRESS')
     reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
 
+    logger.debug('[auth] Exchanging OAuth code for access credential ' + JSON.stringify({
+      codeLength: result.code.length,
+      hasClientId: Boolean(CONFIG_OPTIONS.client_id),
+      hasClientSecret: Boolean(CONFIG_OPTIONS.client_secret)
+    }))
+
     getGitHubApi(EXCHANGE_ACCESS_TOKEN)(
       CONFIG_OPTIONS.client_id, CONFIG_OPTIONS.client_secret, result.code)
       .then((payload) => {
-        logger.debug('-----> calling initUserSession with new token ' + payload.access_token)
+        logger.debug('[auth] OAuth credential exchange succeeded ' + JSON.stringify({
+          hasAccessCredential: Boolean(payload && payload.access_token),
+          credentialType: payload && payload.token_type,
+          scope: payload && payload.scope
+        }))
         return initUserSession(payload.access_token)
       })
       .catch((err) => {
@@ -152,6 +170,37 @@ function describeGitHubLoginError (err) {
   }
 
   return String(details)
+}
+
+function describeGitHubAuthResult (result) {
+  if (!result || typeof result !== 'object') {
+    return {
+      status: 'unknown'
+    }
+  }
+
+  return {
+    status: result.status,
+    hasCode: Boolean(result.code),
+    codeLength: result.code ? result.code.length : undefined,
+    error: result.error,
+    errorDescription: result.errorDescription
+  }
+}
+
+function describeGitHubProfile (profile) {
+  if (!profile || typeof profile !== 'object') {
+    return {
+      hasProfile: false
+    }
+  }
+
+  return {
+    hasProfile: true,
+    login: profile.login,
+    id: profile.id,
+    type: profile.type
+  }
 }
 
 function setSyncTime (time) {
@@ -392,13 +441,13 @@ function updateUserGists (userLoginId, token) {
 
 /** Start: User session management **/
 function initUserSession (token) {
-  logger.debug(`-----> Inside initUserSession with access token ${token}`)
+  logger.debug('[auth] initUserSession called ' + JSON.stringify({ hasCredential: Boolean(token) }))
   reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
   initAccessToken(token)
   let newProfile = null
   getGitHubApi(GET_USER_PROFILE)(token)
     .then((profile) => {
-      logger.debug('-----> from GET_USER_PROFILE with profile ' + JSON.stringify(profile))
+      logger.debug('[auth] GET_USER_PROFILE succeeded ' + JSON.stringify(describeGitHubProfile(profile)))
       newProfile = profile
       return updateUserGists(profile.login, token)
     })
@@ -440,9 +489,9 @@ function initUserSession (token) {
 /** Start: Local storage management **/
 function updateLocalStorage (data) {
   try {
-    logger.debug(`-----> Caching token ${data.token}`)
+    logger.debug('[auth] Caching credential metadata ' + JSON.stringify({ hasCredential: Boolean(data.token) }))
     let rst = electronBridge.localStorage.set('token', data.token)
-    logger.debug(`-----> [${rst.status}] Cached token ${data.token}`)
+    logger.debug(`[auth] [${rst.status}] Cached credential`)
 
     logger.debug(`-----> Caching profile ${data.profile}`)
     rst = electronBridge.localStorage.set('profile', data.profile)
@@ -459,7 +508,10 @@ function getCachedUserInfo () {
   const cachedProfile = electronBridge.localStorage.get('profile')
   logger.debug(`-----> [${cachedProfile.status}] cachedProfile is ${cachedProfile.data}`)
   const cachedToken = electronBridge.localStorage.get('token')
-  logger.debug(`-----> [${cachedToken.status}] cachedToken is ${cachedToken.data}`)
+  logger.debug('[auth] Cached credential lookup ' + JSON.stringify({
+    status: cachedToken.status,
+    hasCredential: Boolean(cachedToken.data)
+  }))
 
   if (cachedProfile.status && cachedToken.status) {
     return {

--- a/app/index.js
+++ b/app/index.js
@@ -124,7 +124,8 @@ function handleAuthResult (result) {
         return initUserSession(payload.access_token)
       })
       .catch((err) => {
-        logger.error('Failed: ' + JSON.stringify(err.error))
+        reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
+        logger.error('GitHub login failed: ' + describeGitHubLoginError(err))
         notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
       })
     return
@@ -132,6 +133,25 @@ function handleAuthResult (result) {
 
   logger.error('Oops! Something went wrong and we couldn\'t' +
     'log you in using Github. Please try again.')
+}
+
+function describeGitHubLoginError (err) {
+  if (!err) return 'unknown error'
+
+  const details = err.error || err.response || err
+  if (details && typeof details === 'object') {
+    return JSON.stringify({
+      name: err.name,
+      message: err.message,
+      statusCode: err.statusCode || (err.response && err.response.statusCode),
+      error: details.error || details.message,
+      errorDescription: details.error_description || err.errorDescription,
+      parseError: details.parseError,
+      bodyPrefix: details.bodyPrefix
+    })
+  }
+
+  return String(details)
 }
 
 function setSyncTime (time) {

--- a/app/index.js
+++ b/app/index.js
@@ -75,15 +75,15 @@ const CONFIG_OPTIONS = {
 }
 const GIST_DETAIL_SYNC_CONCURRENCY = 5
 const LOGIN_STATUS = {
-  openingOAuthWindow: 'Opening GitHub OAuth window...',
-  waitingGitHubAuthorization: 'Waiting for GitHub authorization...',
-  receivedOAuthCode: 'Received OAuth code.',
-  exchangingOAuthCode: 'Exchanging OAuth code for access token...',
-  accessTokenReceived: 'Access token received. Loading GitHub profile...',
-  loadingGitHubProfile: 'Loading GitHub profile...',
-  profileLoadedSyncingGists: 'GitHub profile loaded. Syncing gists...',
-  signInComplete: 'Sign-in complete.',
-  signInFailed: 'GitHub sign-in failed.'
+  openingOAuthWindow: 'Opening OAuth...',
+  waitingGitHubAuthorization: 'Awaiting auth...',
+  receivedOAuthCode: 'Code received.',
+  exchangingOAuthCode: 'Exchanging token...',
+  accessTokenReceived: 'Loading profile...',
+  loadingGitHubProfile: 'Loading profile...',
+  profileLoadedSyncingGists: 'Syncing gists...',
+  signInComplete: 'Signed in.',
+  signInFailed: 'Sign-in failed.'
 }
 
 let preSyncSnapshot = {

--- a/app/index.js
+++ b/app/index.js
@@ -247,7 +247,6 @@ function updateAuthWindowStatusOff () {
 }
 
 function updateLoginStatusInfo (message) {
-  logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({ message, level: 'info' }))
   reduxStore.dispatch(updateLoginStatus({
     message,
     level: 'info',
@@ -257,9 +256,6 @@ function updateLoginStatusInfo (message) {
 
 function updateSnippetDownloadStatus (downloaded, total) {
   const message = `Downloading snippets (${downloaded}/${total})`
-  if (downloaded === 0 || downloaded === total) {
-    logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({ message, level: 'info' }))
-  }
   reduxStore.dispatch(updateLoginStatus({
     message,
     level: 'info',
@@ -269,11 +265,6 @@ function updateSnippetDownloadStatus (downloaded, total) {
 
 function updateLoginStatusFailure () {
   const logFilePath = getLogFilePath()
-  logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({
-    message: LOGIN_STATUS.signInFailed,
-    level: 'error',
-    hasLogFilePath: Boolean(logFilePath)
-  }))
   reduxStore.dispatch(updateLoginStatus({
     message: LOGIN_STATUS.signInFailed,
     level: 'error',
@@ -282,7 +273,6 @@ function updateLoginStatusFailure () {
 }
 
 function clearLoginStatus () {
-  logger.info('[Dispatch] updateLoginStatus clear')
   reduxStore.dispatch(updateLoginStatus(null))
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,7 @@ import {
   fetchSingleGist,
   selectGist,
   updateAuthWindowStatus,
+  updateLoginStatus,
   updateGistSyncStatus,
   updateSearchWindowStatus,
   updateUpdateAvailableBarStatus,
@@ -73,6 +74,17 @@ const CONFIG_OPTIONS = {
   scopes: ['gist']
 }
 const GIST_DETAIL_SYNC_CONCURRENCY = 5
+const LOGIN_STATUS = {
+  openingOAuthWindow: 'Opening GitHub OAuth window...',
+  waitingGitHubAuthorization: 'Waiting for GitHub authorization...',
+  receivedOAuthCode: 'Received OAuth code.',
+  exchangingOAuthCode: 'Exchanging OAuth code for access token...',
+  accessTokenReceived: 'Access token received. Loading GitHub profile...',
+  loadingGitHubProfile: 'Loading GitHub profile...',
+  profileLoadedSyncingGists: 'GitHub profile loaded. Syncing gists...',
+  signInComplete: 'Sign-in complete.',
+  signInFailed: 'GitHub sign-in failed.'
+}
 
 let preSyncSnapshot = {
   activeGistTag: null,
@@ -100,14 +112,20 @@ function launchAuthWindow (token) {
   }))
 
   updateAuthWindowStatusOn()
+  updateLoginStatusInfo(LOGIN_STATUS.openingOAuthWindow)
 
-  electronBridge.auth.startGitHubLogin({
+  const gitHubLogin = electronBridge.auth.startGitHubLogin({
     clientId: CONFIG_OPTIONS.client_id,
     scopes: CONFIG_OPTIONS.scopes
   })
+
+  updateLoginStatusInfo(LOGIN_STATUS.waitingGitHubAuthorization)
+
+  gitHubLogin
     .then(handleAuthResult)
     .catch((err) => {
       updateAuthWindowStatusOff()
+      updateLoginStatusFailure()
       logger.error('Failed to launch GitHub auth window: ' + describeGitHubLoginError(err))
       notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
     })
@@ -118,12 +136,14 @@ function handleAuthResult (result) {
   logger.debug('[auth] GitHub OAuth result received: ' + JSON.stringify(describeGitHubAuthResult(result)))
 
   if (!result || result.status === 'closed') {
+    clearLoginStatus()
     return
   }
 
   if (result.status === 'success' && result.code) {
     logger.info('[Dispatch] updateUserSession IN_PROGRESS')
     reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
+    updateLoginStatusInfo(LOGIN_STATUS.receivedOAuthCode)
 
     logger.debug('[auth] Exchanging OAuth code for access credential ' + JSON.stringify({
       codeLength: result.code.length,
@@ -131,6 +151,7 @@ function handleAuthResult (result) {
       hasClientSecret: Boolean(CONFIG_OPTIONS.client_secret)
     }))
 
+    updateLoginStatusInfo(LOGIN_STATUS.exchangingOAuthCode)
     getGitHubApi(EXCHANGE_ACCESS_TOKEN)(
       CONFIG_OPTIONS.client_id, CONFIG_OPTIONS.client_secret, result.code)
       .then((payload) => {
@@ -139,16 +160,18 @@ function handleAuthResult (result) {
           credentialType: payload && payload.token_type,
           scope: payload && payload.scope
         }))
-        return initUserSession(payload.access_token)
+        return initUserSession(payload.access_token, { freshOAuthToken: true })
       })
       .catch((err) => {
         reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
+        updateLoginStatusFailure()
         logger.error('GitHub login failed: ' + describeGitHubLoginError(err))
         notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '03' }))
       })
     return
   }
 
+  updateLoginStatusFailure()
   logger.error('Oops! Something went wrong and we couldn\'t' +
     'log you in using Github. Please try again.')
 }
@@ -221,6 +244,44 @@ function updateAuthWindowStatusOn () {
 function updateAuthWindowStatusOff () {
   logger.info('[Dispatch] updateAuthWindowStatus OFF')
   reduxStore.dispatch(updateAuthWindowStatus('OFF'))
+}
+
+function updateLoginStatusInfo (message) {
+  logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({ message, level: 'info' }))
+  reduxStore.dispatch(updateLoginStatus({
+    message,
+    level: 'info',
+    logFilePath: null
+  }))
+}
+
+function updateLoginStatusFailure () {
+  const logFilePath = getLogFilePath()
+  logger.info('[Dispatch] updateLoginStatus ' + JSON.stringify({
+    message: LOGIN_STATUS.signInFailed,
+    level: 'error',
+    hasLogFilePath: Boolean(logFilePath)
+  }))
+  reduxStore.dispatch(updateLoginStatus({
+    message: LOGIN_STATUS.signInFailed,
+    level: 'error',
+    logFilePath
+  }))
+}
+
+function clearLoginStatus () {
+  logger.info('[Dispatch] updateLoginStatus clear')
+  reduxStore.dispatch(updateLoginStatus(null))
+}
+
+function getLogFilePath () {
+  try {
+    const paths = electronBridge.globals.getPaths()
+    return paths && paths.logFilePath ? paths.logFilePath : null
+  } catch (err) {
+    logger.warn('Unable to read log file path for login status: ' + describeGitHubLoginError(err))
+    return null
+  }
 }
 
 /** Start: Language tags management **/
@@ -440,15 +501,19 @@ function updateUserGists (userLoginId, token) {
 /** End: User gists management **/
 
 /** Start: User session management **/
-function initUserSession (token) {
+function initUserSession (token, options = {}) {
   logger.debug('[auth] initUserSession called ' + JSON.stringify({ hasCredential: Boolean(token) }))
   reduxStore.dispatch(updateUserSession({ activeStatus: 'IN_PROGRESS' }))
+  updateLoginStatusInfo(options.freshOAuthToken
+    ? LOGIN_STATUS.accessTokenReceived
+    : LOGIN_STATUS.loadingGitHubProfile)
   initAccessToken(token)
   let newProfile = null
   getGitHubApi(GET_USER_PROFILE)(token)
     .then((profile) => {
       logger.debug('[auth] GET_USER_PROFILE succeeded ' + JSON.stringify(describeGitHubProfile(profile)))
       newProfile = profile
+      updateLoginStatusInfo(LOGIN_STATUS.profileLoadedSyncingGists)
       return updateUserGists(profile.login, token)
     })
     .then(() => {
@@ -467,12 +532,14 @@ function initUserSession (token) {
 
       logger.info('[Dispatch] updateUserSession ACTIVE')
       reduxStore.dispatch(updateUserSession({ activeStatus: 'ACTIVE', profile: newProfile }))
+      updateLoginStatusInfo(LOGIN_STATUS.signInComplete)
 
       ipcRenderer.send('session-ready')
     })
     .catch((err) => {
       logger.debug('-----> Failure with ' + JSON.stringify(err))
       logger.error('The request has failed: \n' + JSON.stringify(err))
+      updateLoginStatusFailure()
 
       if (err.statusCode === 401) {
         logger.info('[Dispatch] updateUserSession EXPIRED')

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -14,6 +14,7 @@ import gists from './reducer_gists'
 import gistSyncStatus from './reducer_gist_sync_status'
 import gistTags from './reducer_gist_tags'
 import immersiveMode from './reducer_immersive_mode'
+import loginStatus from './reducer_login_status'
 import logoutModalStatus from './reducer_logout_modal'
 import newVersionInfo from './reducer_new_version_info'
 import pinnedTags from './reducer_pinned_tags'
@@ -40,6 +41,7 @@ const rootReducer = combineReducers({
   gistSyncStatus,
   gistTags,
   immersiveMode,
+  loginStatus,
   logoutModalStatus,
   newVersionInfo,
   pinnedTags,

--- a/app/reducers/reducer_login_status.js
+++ b/app/reducers/reducer_login_status.js
@@ -1,0 +1,17 @@
+import { UPDATE_LOGIN_STATUS } from '../actions'
+
+const DEFAULT_LOGIN_STATUS = {
+  message: '',
+  level: 'info',
+  logFilePath: null
+}
+
+export default function (state = DEFAULT_LOGIN_STATUS, action) {
+  switch (action.type) {
+    case UPDATE_LOGIN_STATUS:
+      return Object.assign({}, DEFAULT_LOGIN_STATUS, action.payload || {})
+    default:
+  }
+
+  return state
+}

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -327,6 +327,28 @@ function getFixtureOverrides (name) {
           activeStatus: 'IN_PROGRESS'
         }
       }
+    case 'login-index-sync':
+      return {
+        loginStatus: {
+          message: 'Syncing snippet index...',
+          level: 'info',
+          logFilePath: null
+        },
+        userSession: {
+          activeStatus: 'IN_PROGRESS'
+        }
+      }
+    case 'login-download-progress':
+      return {
+        loginStatus: {
+          message: 'Downloading snippets (12/252)',
+          level: 'info',
+          logFilePath: null
+        },
+        userSession: {
+          activeStatus: 'IN_PROGRESS'
+        }
+      }
     case 'raw':
       return {
         gistRawModal: {

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -308,7 +308,7 @@ function getFixtureOverrides (name) {
     case 'login-error-log':
       return {
         loginStatus: {
-          message: 'GitHub sign-in failed.',
+          message: 'Sign-in failed.',
           level: 'error',
           logFilePath: '/tmp/lepton-login.log'
         },
@@ -319,7 +319,7 @@ function getFixtureOverrides (name) {
     case 'login-progress':
       return {
         loginStatus: {
-          message: 'Exchanging OAuth code for access token...',
+          message: 'Exchanging token...',
           level: 'info',
           logFilePath: null
         },

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -256,6 +256,11 @@ function getBaseState () {
     gistSyncStatus: 'DONE',
     gistTags,
     immersiveMode: 'OFF',
+    loginStatus: {
+      message: '',
+      level: 'info',
+      logFilePath: null
+    },
     logoutModalStatus: 'OFF',
     newVersionInfo: {
       version: 'fixture-version',
@@ -299,6 +304,28 @@ function getFixtureOverrides (name) {
       return {
         activeGist: 'fixture-gist-6',
         activeGistTag: Prefixed('Jupyter Notebook')
+      }
+    case 'login-error-log':
+      return {
+        loginStatus: {
+          message: 'GitHub sign-in failed.',
+          level: 'error',
+          logFilePath: '/tmp/lepton-login.log'
+        },
+        userSession: {
+          activeStatus: 'INACTIVE'
+        }
+      }
+    case 'login-progress':
+      return {
+        loginStatus: {
+          message: 'Exchanging OAuth code for access token...',
+          level: 'info',
+          logFilePath: null
+        },
+        userSession: {
+          activeStatus: 'IN_PROGRESS'
+        }
       }
     case 'raw':
       return {

--- a/app/utilities/auth/githubAuthWindow.js
+++ b/app/utilities/auth/githubAuthWindow.js
@@ -1,0 +1,45 @@
+const noopLogger = {
+  debug: () => {},
+  warn: () => {}
+}
+
+async function clearGitHubAuthWindowStorageAndDestroy ({
+  authWindow,
+  logger = noopLogger
+} = {}) {
+  if (!authWindow || authWindow.isDestroyed()) return
+
+  let clearResult
+  try {
+    clearResult = authWindow.webContents.session.clearStorageData({})
+  } catch (err) {
+    logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
+    destroyGitHubAuthWindow(authWindow, logger)
+    return
+  }
+
+  if (clearResult && typeof clearResult.then === 'function') {
+    try {
+      await clearResult
+      logger.debug('[auth] OAuth session storage cleared')
+    } catch (err) {
+      logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
+    } finally {
+      destroyGitHubAuthWindow(authWindow, logger)
+    }
+    return
+  }
+
+  logger.debug('[auth] OAuth session storage clear requested')
+  destroyGitHubAuthWindow(authWindow, logger)
+}
+
+function destroyGitHubAuthWindow (authWindow, logger = noopLogger) {
+  if (!authWindow || authWindow.isDestroyed()) return
+  logger.debug('[auth] Destroying OAuth auth window')
+  authWindow.destroy()
+}
+
+module.exports = {
+  clearGitHubAuthWindowStorageAndDestroy
+}

--- a/app/utilities/auth/githubOAuth.js
+++ b/app/utilities/auth/githubOAuth.js
@@ -56,7 +56,51 @@ function parseGitHubOAuthCallback (callbackUrl) {
   return null
 }
 
+function describeGitHubOAuthUrl (callbackUrl) {
+  if (typeof callbackUrl !== 'string') {
+    return {
+      valid: false,
+      reason: 'not-string'
+    }
+  }
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(callbackUrl)
+  } catch (err) {
+    return {
+      valid: false,
+      reason: 'invalid-url'
+    }
+  }
+
+  const code = parsedUrl.searchParams.get('code')
+  const error = parsedUrl.searchParams.get('error')
+
+  return removeUndefinedProperties({
+    valid: true,
+    origin: parsedUrl.origin,
+    pathname: parsedUrl.pathname,
+    queryKeys: Array.from(parsedUrl.searchParams.keys()).sort(),
+    hasCode: Boolean(code),
+    codeLength: code ? code.length : undefined,
+    hasError: Boolean(error),
+    error: error || undefined,
+    errorDescription: parsedUrl.searchParams.get('error_description') || undefined
+  })
+}
+
+function removeUndefinedProperties (value) {
+  Object.keys(value).forEach(key => {
+    if (value[key] === undefined) {
+      delete value[key]
+    }
+  })
+  return value
+}
+
 module.exports = {
   buildGitHubOAuthUrl,
+  describeGitHubOAuthUrl,
   parseGitHubOAuthCallback
 }

--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -36,7 +36,12 @@ function createGitHubApi ({
   }
 
   function exchangeAccessToken (clientId, clientSecret, authCode) {
-    apiLogger.debug(TAG + 'Exchanging authCode with access token')
+    apiLogger.debug(TAG + 'Exchanging authCode with access credential ' + JSON.stringify({
+      hasClientId: Boolean(clientId),
+      clientIdLength: clientId ? clientId.length : 0,
+      hasClientSecret: Boolean(clientSecret),
+      codeLength: authCode ? authCode.length : 0
+    }))
     return apiRequest({
       method: 'POST',
       uri: 'https://github.com/login/oauth/access_token',
@@ -50,11 +55,14 @@ function createGitHubApi ({
       },
       json: true,
       timeout: 2 * kTimeoutUnit
-    }).then(validateOAuthAccessTokenResponse)
+    }).then(payload => {
+      apiLogger.debug(TAG + 'OAuth credential exchange response metadata ' + JSON.stringify(describeOAuthAccessTokenResponse(payload)))
+      return validateOAuthAccessTokenResponse(payload)
+    })
   }
 
   function getUserProfile (token) {
-    apiLogger.debug(TAG + 'Getting user profile with token ' + token)
+    apiLogger.debug(TAG + 'Getting user profile ' + JSON.stringify({ hasCredential: Boolean(token) }))
     return apiRequest({
       uri: `https://${gitHubHostApi}/user`,
       headers: {
@@ -68,7 +76,7 @@ function createGitHubApi ({
   }
 
   function getSingleGist (token, gistId) {
-    apiLogger.debug(TAG + `Getting single gist ${gistId} with token ${token}`)
+    apiLogger.debug(TAG + `Getting single gist ${gistId} ` + JSON.stringify({ hasCredential: Boolean(token) }))
     return apiRequest({
       uri: `https://${gitHubHostApi}/gists/${gistId}`,
       headers: {
@@ -82,7 +90,7 @@ function createGitHubApi ({
   }
 
   function getAllGistsV2 (token, userId) {
-    apiLogger.debug(TAG + `[V2] Getting all gists of ${userId} with token ${token}`)
+    apiLogger.debug(TAG + `[V2] Getting all gists of ${userId} ` + JSON.stringify({ hasCredential: Boolean(token) }))
     const gistList = []
     return requestGists(token, userId, 1, gistList)
       .then(res => {
@@ -135,7 +143,7 @@ function createGitHubApi ({
   }
 
   function getAllGistsV1 (token, userId) {
-    apiLogger.debug(TAG + `[V1] Getting all gists of ${userId} with token ${token}`)
+    apiLogger.debug(TAG + `[V1] Getting all gists of ${userId} ` + JSON.stringify({ hasCredential: Boolean(token) }))
     const gistList = []
     const maxPageNumber = 100
 
@@ -285,6 +293,31 @@ function validateOAuthAccessTokenResponse (payload) {
   error.errorDescription = errorDescription
 
   throw error
+}
+
+function describeOAuthAccessTokenResponse (payload) {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      hasPayload: Boolean(payload)
+    }
+  }
+
+  return removeUndefinedProperties({
+    hasAccessCredential: Boolean(payload.access_token),
+    credentialType: payload.token_type,
+    scope: payload.scope,
+    error: payload.error,
+    errorDescription: payload.error_description
+  })
+}
+
+function removeUndefinedProperties (value) {
+  Object.keys(value).forEach(key => {
+    if (value[key] === undefined) {
+      delete value[key]
+    }
+  })
+  return value
 }
 
 module.exports = {

--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -4,7 +4,7 @@ const { shouldDownloadAllSnippets } = require('../config')
 
 const TAG = '[REST] '
 const kTimeoutUnit = 10 * 1000 // ms
-const userAgent = 'hackjutsu-lepton-app'
+const userAgent = 'lepton-snippet-app'
 const GISTS_PER_PAGE = 100
 const EMPTY_PAGE_ERROR_MESSAGE = 'page empty (Not an error)'
 

--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -40,6 +40,9 @@ function createGitHubApi ({
     return apiRequest({
       method: 'POST',
       uri: 'https://github.com/login/oauth/access_token',
+      headers: {
+        'User-Agent': userAgent
+      },
       form: {
         client_id: clientId,
         client_secret: clientSecret,
@@ -47,7 +50,7 @@ function createGitHubApi ({
       },
       json: true,
       timeout: 2 * kTimeoutUnit
-    })
+    }).then(validateOAuthAccessTokenResponse)
   }
 
   function getUserProfile (token) {
@@ -264,6 +267,24 @@ function createGitHubApi ({
   return {
     getGitHubApi
   }
+}
+
+function validateOAuthAccessTokenResponse (payload) {
+  if (payload && payload.access_token) {
+    return payload
+  }
+
+  const errorCode = payload && payload.error ? payload.error : 'missing_access_token'
+  const errorDescription = payload && payload.error_description
+    ? payload.error_description
+    : 'GitHub OAuth did not return an access token.'
+  const error = new Error(`GitHub OAuth token exchange failed: ${errorCode}`)
+
+  error.name = 'OAuthTokenExchangeError'
+  error.error = payload || { error: errorCode, error_description: errorDescription }
+  error.errorDescription = errorDescription
+
+  throw error
 }
 
 module.exports = {

--- a/app/utilities/githubApi/fetchAdapter.js
+++ b/app/utilities/githubApi/fetchAdapter.js
@@ -128,7 +128,11 @@ function readResponseBody (response, shouldParseJson) {
     .then(text => {
       if (!shouldParseJson) return text
       if (!text) return null
-      return JSON.parse(text)
+      try {
+        return JSON.parse(text)
+      } catch (err) {
+        throw createResponseParseError(response, text, err)
+      }
     })
 }
 
@@ -152,6 +156,20 @@ function createStatusCodeError (response, body) {
     headers: headersToObject(response.headers),
     statusCode: statusCode,
     statusMessage: statusMessage
+  }
+
+  return error
+}
+
+function createResponseParseError (response, text, parseError) {
+  const error = new Error('GitHub API response was not valid JSON')
+
+  error.name = 'ResponseParseError'
+  error.status = response.status || 0
+  error.statusCode = response.status || 0
+  error.error = {
+    parseError: parseError.message,
+    bodyPrefix: typeof text === 'string' ? text.slice(0, 200) : ''
   }
 
   return error

--- a/app/utilities/githubApi/index.js
+++ b/app/utilities/githubApi/index.js
@@ -9,6 +9,34 @@ export const CREATE_SINGLE_GIST = 'CREATE_SINGLE_GIST'
 export const EDIT_SINGLE_GIST = 'EDIT_SINGLE_GIST'
 export const DELETE_SINGLE_GIST = 'DELETE_SINGLE_GIST'
 
+const GITHUB_API_BRIDGE_RESPONSE = '__leptonGitHubApiBridgeResponse'
+
 export function getGitHubApi (selection) {
   return (...args) => electronBridge.github.request(selection, args)
+    .then(unwrapGitHubApiBridgeResponse)
+}
+
+function unwrapGitHubApiBridgeResponse (response) {
+  if (!response || response[GITHUB_API_BRIDGE_RESPONSE] !== true) {
+    return response
+  }
+
+  if (response.ok) {
+    return response.data
+  }
+
+  throw createGitHubApiBridgeError(response.error)
+}
+
+function createGitHubApiBridgeError (payload = {}) {
+  const error = new Error(payload.message || 'GitHub API request failed')
+
+  error.name = payload.name || 'GitHubApiBridgeError'
+  Object.keys(payload).forEach(key => {
+    if (payload[key] !== undefined) {
+      error[key] = payload[key]
+    }
+  })
+
+  return error
 }

--- a/main.js
+++ b/main.js
@@ -776,19 +776,41 @@ function finishGitHubAuthFlow (result, options = {}) {
 
   if (options.destroyWindow === false || !authWindow || authWindow.isDestroyed()) return
 
+  clearGitHubAuthWindowStorageAndDestroy(authWindow)
+}
+
+function clearGitHubAuthWindowStorageAndDestroy (authWindow) {
+  let clearResult
   try {
-    authWindow.webContents.session.clearStorageData({}, () => {
-      if (!authWindow.isDestroyed()) {
-        logger.debug('[auth] OAuth session storage cleared; destroying auth window')
-        authWindow.destroy()
-      }
-    })
+    clearResult = authWindow.webContents.session.clearStorageData({})
   } catch (err) {
     logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
-    if (!authWindow.isDestroyed()) {
-      authWindow.destroy()
-    }
+    destroyGitHubAuthWindow(authWindow)
+    return
   }
+
+  if (clearResult && typeof clearResult.then === 'function') {
+    clearResult
+      .then(() => {
+        logger.debug('[auth] OAuth session storage cleared')
+      })
+      .catch(err => {
+        logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
+      })
+      .finally(() => {
+        destroyGitHubAuthWindow(authWindow)
+      })
+    return
+  }
+
+  logger.debug('[auth] OAuth session storage clear requested')
+  destroyGitHubAuthWindow(authWindow)
+}
+
+function destroyGitHubAuthWindow (authWindow) {
+  if (!authWindow || authWindow.isDestroyed()) return
+  logger.debug('[auth] Destroying OAuth auth window')
+  authWindow.destroy()
 }
 
 function describeGitHubAuthResult (result) {

--- a/main.js
+++ b/main.js
@@ -34,6 +34,9 @@ const {
   describeGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = require('./app/utilities/auth/githubOAuth')
+const {
+  clearGitHubAuthWindowStorageAndDestroy
+} = require('./app/utilities/auth/githubAuthWindow')
 
 const logger = createMainLogger()
 const electronLocalStorage = createElectronLocalStorage({
@@ -776,41 +779,7 @@ function finishGitHubAuthFlow (result, options = {}) {
 
   if (options.destroyWindow === false || !authWindow || authWindow.isDestroyed()) return
 
-  clearGitHubAuthWindowStorageAndDestroy(authWindow)
-}
-
-function clearGitHubAuthWindowStorageAndDestroy (authWindow) {
-  let clearResult
-  try {
-    clearResult = authWindow.webContents.session.clearStorageData({})
-  } catch (err) {
-    logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
-    destroyGitHubAuthWindow(authWindow)
-    return
-  }
-
-  if (clearResult && typeof clearResult.then === 'function') {
-    clearResult
-      .then(() => {
-        logger.debug('[auth] OAuth session storage cleared')
-      })
-      .catch(err => {
-        logger.warn('[auth] Failed to clear OAuth session data: ' + err.message)
-      })
-      .finally(() => {
-        destroyGitHubAuthWindow(authWindow)
-      })
-    return
-  }
-
-  logger.debug('[auth] OAuth session storage clear requested')
-  destroyGitHubAuthWindow(authWindow)
-}
-
-function destroyGitHubAuthWindow (authWindow) {
-  if (!authWindow || authWindow.isDestroyed()) return
-  logger.debug('[auth] Destroying OAuth auth window')
-  authWindow.destroy()
+  clearGitHubAuthWindowStorageAndDestroy({ authWindow, logger })
 }
 
 function describeGitHubAuthResult (result) {

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ const {
 } = require('./app/utilities/updatePolicy')
 const {
   buildGitHubOAuthUrl,
+  describeGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = require('./app/utilities/auth/githubOAuth')
 
@@ -633,6 +634,7 @@ function setUpBridgeIpcHandlers () {
 
 function startGitHubAuthFlow ({ clientId, scopes } = {}) {
   if (authFlow) {
+    logger.debug('[auth] Reusing active GitHub OAuth flow')
     if (authFlow.authWindow && !authFlow.authWindow.isDestroyed()) {
       authFlow.authWindow.focus()
     }
@@ -640,6 +642,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
   }
 
   if (typeof clientId !== 'string' || clientId.length === 0) {
+    logger.warn('[auth] GitHub OAuth flow cannot start: missing client id')
     return Promise.resolve({
       status: 'error',
       error: 'missing-client-id'
@@ -673,7 +676,16 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
   const authUrl = buildGitHubOAuthUrl({ clientId, scopes })
   const options = { extraHeaders: 'pragma: no-cache\n' }
 
-  function handleAuthNavigation (event, callbackUrl) {
+  logger.debug('[auth] Starting GitHub OAuth flow ' + JSON.stringify({
+    hasClientId: Boolean(clientId),
+    clientIdLength: clientId.length,
+    scopeCount: Array.isArray(scopes) ? scopes.length : 0,
+    authorizeUrl: describeGitHubOAuthUrl(authUrl)
+  }))
+
+  function handleAuthNavigation (event, callbackUrl, eventName) {
+    logger.debug('[auth] OAuth navigation ' + eventName + ': ' + JSON.stringify(describeGitHubOAuthUrl(callbackUrl)))
+
     const result = parseGitHubOAuthCallback(callbackUrl)
     if (!result) return
 
@@ -681,24 +693,42 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
       event.preventDefault()
     }
 
+    logger.debug('[auth] OAuth callback parsed: ' + JSON.stringify(describeGitHubAuthResult(result)))
     finishGitHubAuthFlow(result)
   }
 
   authWindow.webContents.on('will-navigate', (event, callbackUrl) => {
-    handleAuthNavigation(event, callbackUrl)
+    handleAuthNavigation(event, callbackUrl, 'will-navigate')
   })
 
   authWindow.webContents.on('will-redirect', (event, callbackUrl) => {
-    handleAuthNavigation(event, callbackUrl)
+    handleAuthNavigation(event, callbackUrl, 'will-redirect')
   })
 
   authWindow.webContents.on('did-get-redirect-request', (event, oldUrl, newUrl) => {
-    handleAuthNavigation(event, newUrl)
+    handleAuthNavigation(event, newUrl, 'did-get-redirect-request')
+  })
+
+  authWindow.webContents.on('did-navigate', (event, callbackUrl, httpResponseCode, httpStatusText) => {
+    logger.debug('[auth] OAuth did-navigate response: ' + JSON.stringify({
+      httpResponseCode,
+      httpStatusText,
+      url: describeGitHubOAuthUrl(callbackUrl)
+    }))
+    handleAuthNavigation(event, callbackUrl, 'did-navigate')
+  })
+
+  authWindow.webContents.on('did-finish-load', () => {
+    logger.debug('[auth] OAuth window finished load: ' + JSON.stringify(describeGitHubOAuthUrl(authWindow.webContents.getURL())))
   })
 
   authWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
     if (errorCode === -3) return
-    logger.error('[auth] OAuth window failed to load: ' + errorDescription)
+    logger.error('[auth] OAuth window failed to load: ' + JSON.stringify({
+      errorCode,
+      errorDescription,
+      url: describeGitHubOAuthUrl(authWindow.webContents.getURL())
+    }))
     finishGitHubAuthFlow({
       status: 'error',
       error: 'load-failed',
@@ -708,6 +738,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
 
   authWindow.once('closed', () => {
     if (authFlow && authFlow.authWindow === authWindow) {
+      logger.debug('[auth] OAuth window closed before completion')
       finishGitHubAuthFlow({
         status: 'closed'
       }, {
@@ -716,10 +747,13 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     }
   })
 
-  logger.debug('loading authUrl ' + authUrl)
+  logger.debug('[auth] Loading GitHub OAuth authorize URL')
   authWindow.loadURL(authUrl, options)
     .catch(err => {
-      logger.error('[auth] OAuth window failed to load: ' + err.message)
+      logger.error('[auth] OAuth window failed to load: ' + JSON.stringify({
+        errorDescription: err.message,
+        url: describeGitHubOAuthUrl(authUrl)
+      }))
       finishGitHubAuthFlow({
         status: 'error',
         error: 'load-failed',
@@ -727,6 +761,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
       })
     })
   authWindow.show()
+  logger.debug('[auth] OAuth window shown')
 
   return promise
 }
@@ -736,6 +771,7 @@ function finishGitHubAuthFlow (result, options = {}) {
 
   const { authWindow, resolve } = authFlow
   authFlow = null
+  logger.debug('[auth] Finishing GitHub OAuth flow: ' + JSON.stringify(describeGitHubAuthResult(result)))
   resolve(result)
 
   if (options.destroyWindow === false || !authWindow || authWindow.isDestroyed()) return
@@ -743,6 +779,7 @@ function finishGitHubAuthFlow (result, options = {}) {
   try {
     authWindow.webContents.session.clearStorageData({}, () => {
       if (!authWindow.isDestroyed()) {
+        logger.debug('[auth] OAuth session storage cleared; destroying auth window')
         authWindow.destroy()
       }
     })
@@ -752,6 +789,22 @@ function finishGitHubAuthFlow (result, options = {}) {
       authWindow.destroy()
     }
   }
+}
+
+function describeGitHubAuthResult (result) {
+  if (!result || typeof result !== 'object') {
+    return {
+      status: 'unknown'
+    }
+  }
+
+  return removeUndefinedProperties({
+    status: result.status,
+    hasCode: Boolean(result.code),
+    codeLength: result.code ? result.code.length : undefined,
+    error: result.error,
+    errorDescription: result.errorDescription
+  })
 }
 
 function createGitHubApiBridgeResponse (data, error) {

--- a/main.js
+++ b/main.js
@@ -557,17 +557,23 @@ function setUpBridgeIpcHandlers () {
     logger[method](...args)
   })
 
-  ipcMain.handle('lepton:github-api:request', (event, selection, args = []) => {
+  ipcMain.handle('lepton:github-api:request', async (event, selection, args = []) => {
     if (!isMainWindowSender(event) || typeof selection !== 'string' || !Array.isArray(args)) {
-      throw new Error('Invalid GitHub API bridge request')
+      return createGitHubApiBridgeResponse(null, createGitHubApiBridgeError(new Error('Invalid GitHub API bridge request')))
     }
 
-    const request = getGitHubApiBridge().getGitHubApi(selection)
-    if (typeof request !== 'function') {
-      throw new Error(`Unsupported GitHub API selection: ${selection}`)
-    }
+    try {
+      const request = getGitHubApiBridge().getGitHubApi(selection)
+      if (typeof request !== 'function') {
+        throw new Error(`Unsupported GitHub API selection: ${selection}`)
+      }
 
-    return request(...args)
+      return createGitHubApiBridgeResponse(await request(...args))
+    } catch (error) {
+      const serializedError = createGitHubApiBridgeError(error)
+      logger.error('[bridge] GitHub API request failed: ' + JSON.stringify(serializedError))
+      return createGitHubApiBridgeResponse(null, serializedError)
+    }
   })
 
   ipcMain.on('lepton:notebook:render', (event, content) => {
@@ -746,6 +752,53 @@ function finishGitHubAuthFlow (result, options = {}) {
       authWindow.destroy()
     }
   }
+}
+
+function createGitHubApiBridgeResponse (data, error) {
+  return {
+    __leptonGitHubApiBridgeResponse: true,
+    ok: !error,
+    data,
+    error
+  }
+}
+
+function createGitHubApiBridgeError (error) {
+  if (!error || typeof error !== 'object') {
+    return {
+      message: String(error || 'GitHub API request failed'),
+      name: 'Error'
+    }
+  }
+
+  return removeUndefinedProperties({
+    message: error.message || 'GitHub API request failed',
+    name: error.name || 'Error',
+    status: error.status,
+    statusCode: error.statusCode,
+    error: cloneSerializableValue(error.error),
+    errorDescription: error.errorDescription,
+    response: cloneSerializableValue(error.response)
+  })
+}
+
+function cloneSerializableValue (value) {
+  if (value === undefined) return undefined
+
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch (err) {
+    return String(value)
+  }
+}
+
+function removeUndefinedProperties (value) {
+  Object.keys(value).forEach(key => {
+    if (value[key] === undefined) {
+      delete value[key]
+    }
+  })
+  return value
 }
 
 function setUpTouchBar() {

--- a/main.js
+++ b/main.js
@@ -686,9 +686,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     authorizeUrl: describeGitHubOAuthUrl(authUrl)
   }))
 
-  function handleAuthNavigation (event, callbackUrl, eventName) {
-    logger.debug('[auth] OAuth navigation ' + eventName + ': ' + JSON.stringify(describeGitHubOAuthUrl(callbackUrl)))
-
+  function handleAuthNavigation (event, callbackUrl) {
     const result = parseGitHubOAuthCallback(callbackUrl)
     if (!result) return
 
@@ -701,28 +699,19 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
   }
 
   authWindow.webContents.on('will-navigate', (event, callbackUrl) => {
-    handleAuthNavigation(event, callbackUrl, 'will-navigate')
+    handleAuthNavigation(event, callbackUrl)
   })
 
   authWindow.webContents.on('will-redirect', (event, callbackUrl) => {
-    handleAuthNavigation(event, callbackUrl, 'will-redirect')
+    handleAuthNavigation(event, callbackUrl)
   })
 
   authWindow.webContents.on('did-get-redirect-request', (event, oldUrl, newUrl) => {
-    handleAuthNavigation(event, newUrl, 'did-get-redirect-request')
+    handleAuthNavigation(event, newUrl)
   })
 
-  authWindow.webContents.on('did-navigate', (event, callbackUrl, httpResponseCode, httpStatusText) => {
-    logger.debug('[auth] OAuth did-navigate response: ' + JSON.stringify({
-      httpResponseCode,
-      httpStatusText,
-      url: describeGitHubOAuthUrl(callbackUrl)
-    }))
-    handleAuthNavigation(event, callbackUrl, 'did-navigate')
-  })
-
-  authWindow.webContents.on('did-finish-load', () => {
-    logger.debug('[auth] OAuth window finished load: ' + JSON.stringify(describeGitHubOAuthUrl(authWindow.webContents.getURL())))
+  authWindow.webContents.on('did-navigate', (event, callbackUrl) => {
+    handleAuthNavigation(event, callbackUrl)
   })
 
   authWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
@@ -750,7 +739,6 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     }
   })
 
-  logger.debug('[auth] Loading GitHub OAuth authorize URL')
   authWindow.loadURL(authUrl, options)
     .catch(err => {
       logger.error('[auth] OAuth window failed to load: ' + JSON.stringify({
@@ -764,7 +752,6 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
       })
     })
   authWindow.show()
-  logger.debug('[auth] OAuth window shown')
 
   return promise
 }

--- a/tests/reducers/core.test.js
+++ b/tests/reducers/core.test.js
@@ -20,6 +20,7 @@ import {
   updateAccessToken,
   updateGists,
   updateGistTags,
+  updateLoginStatus,
   updateSingleGist,
   updateUpdateAvailableBarStatus,
   updateUserSession
@@ -28,6 +29,7 @@ import activeGist from '../../app/reducers/reducer_active_gist'
 import accessToken from '../../app/reducers/reducer_token'
 import gistTags from '../../app/reducers/reducer_gist_tags'
 import gists from '../../app/reducers/reducer_gists'
+import loginStatus from '../../app/reducers/reducer_login_status'
 import updateAvailableBarStatus from '../../app/reducers/reducer_update_available_bar_status'
 import userSession from '../../app/reducers/reducer_user_session'
 
@@ -70,5 +72,35 @@ describe('core reducers', () => {
   it('tracks update alert visibility', () => {
     expect(updateAvailableBarStatus(undefined, { type: '@@INIT' })).toBe('OFF')
     expect(updateAvailableBarStatus('OFF', updateUpdateAvailableBarStatus('ON'))).toBe('ON')
+  })
+
+  it('tracks login status details for authentication feedback', () => {
+    expect(loginStatus(undefined, { type: '@@INIT' })).toEqual({
+      message: '',
+      level: 'info',
+      logFilePath: null
+    })
+    expect(loginStatus(undefined, updateLoginStatus({
+      message: 'Exchanging OAuth code for access token...'
+    }))).toEqual({
+      message: 'Exchanging OAuth code for access token...',
+      level: 'info',
+      logFilePath: null
+    })
+    expect(loginStatus(undefined, updateLoginStatus({
+      message: 'GitHub sign-in failed.',
+      level: 'error',
+      logFilePath: '/tmp/lepton.log'
+    }))).toEqual({
+      message: 'GitHub sign-in failed.',
+      level: 'error',
+      logFilePath: '/tmp/lepton.log'
+    })
+    expect(loginStatus({ message: 'old', level: 'error', logFilePath: '/tmp/old.log' },
+      updateLoginStatus(null))).toEqual({
+      message: '',
+      level: 'info',
+      logFilePath: null
+    })
   })
 })

--- a/tests/reducers/core.test.js
+++ b/tests/reducers/core.test.js
@@ -81,18 +81,18 @@ describe('core reducers', () => {
       logFilePath: null
     })
     expect(loginStatus(undefined, updateLoginStatus({
-      message: 'Exchanging OAuth code for access token...'
+      message: 'Exchanging token...'
     }))).toEqual({
-      message: 'Exchanging OAuth code for access token...',
+      message: 'Exchanging token...',
       level: 'info',
       logFilePath: null
     })
     expect(loginStatus(undefined, updateLoginStatus({
-      message: 'GitHub sign-in failed.',
+      message: 'Sign-in failed.',
       level: 'error',
       logFilePath: '/tmp/lepton.log'
     }))).toEqual({
-      message: 'GitHub sign-in failed.',
+      message: 'Sign-in failed.',
       level: 'error',
       logFilePath: '/tmp/lepton.log'
     })

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -96,12 +96,12 @@ const RENDER_FIXTURES = [
   {
     name: 'login-progress',
     selector: '.login-status-line',
-    text: 'Exchanging OAuth code for access token...'
+    text: 'Exchanging token...'
   },
   {
     name: 'login-error-log',
     selector: '.login-status-line a[href="file:///tmp/lepton-login.log"]',
-    text: 'GitHub sign-in failed.|See log'
+    text: 'Sign-in failed.|See log'
   }
 ]
 

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -92,6 +92,16 @@ const RENDER_FIXTURES = [
     name: 'jupyter-notebook',
     selector: '.jupyterNotebook-section .nb-notebook',
     text: 'Notebook Fixture|hello from notebook|42'
+  },
+  {
+    name: 'login-progress',
+    selector: '.login-status-line',
+    text: 'Exchanging OAuth code for access token...'
+  },
+  {
+    name: 'login-error-log',
+    selector: '.login-status-line a[href="file:///tmp/lepton-login.log"]',
+    text: 'GitHub sign-in failed.|See log'
   }
 ]
 

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -99,6 +99,16 @@ const RENDER_FIXTURES = [
     text: 'Exchanging token...'
   },
   {
+    name: 'login-index-sync',
+    selector: '.login-status-line',
+    text: 'Syncing snippet index...'
+  },
+  {
+    name: 'login-download-progress',
+    selector: '.login-status-line',
+    text: 'Downloading snippets (12/252)'
+  },
+  {
     name: 'login-error-log',
     selector: '.login-status-line a[href="file:///tmp/lepton-login.log"]',
     text: 'Sign-in failed.|See log'

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -102,7 +102,7 @@ describe('GitHub API utility', () => {
     expect(init.headers).toEqual(expect.objectContaining({
       Accept: 'application/json',
       'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': 'hackjutsu-lepton-app'
+      'User-Agent': 'lepton-snippet-app'
     }))
     expect(init).not.toHaveProperty('agent')
   })
@@ -159,7 +159,7 @@ describe('GitHub API utility', () => {
     }))
     expect(init.headers).toEqual(expect.objectContaining({
       Accept: 'application/json',
-      'User-Agent': 'hackjutsu-lepton-app',
+      'User-Agent': 'lepton-snippet-app',
       Authorization: 'token token-1'
     }))
     expect(result).toEqual({ login: 'octo' })
@@ -207,7 +207,7 @@ describe('GitHub API utility', () => {
     expect(init.headers).toEqual(expect.objectContaining({
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      'User-Agent': 'hackjutsu-lepton-app',
+      'User-Agent': 'lepton-snippet-app',
       Authorization: 'token token-1'
     }))
     expect(result).toEqual({ id: 'gist-1' })
@@ -293,7 +293,7 @@ describe('GitHub API utility', () => {
     const [url, init] = fetch.mock.calls[0]
     expect(url).toBe('https://api.github.com/gists?per_page=100&page=1')
     expect(init.headers).toEqual(expect.objectContaining({
-      'User-Agent': 'hackjutsu-lepton-app',
+      'User-Agent': 'lepton-snippet-app',
       Authorization: 'token token-1'
     }))
   })

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -51,6 +51,20 @@ function createJsonResponse (body, {
   }
 }
 
+function createTextResponse (body, {
+  status = 200,
+  statusText = 'OK',
+  headers = {}
+} = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: createHeaders(headers),
+    text: () => Promise.resolve(body)
+  }
+}
+
 function loadGitHubApi ({
   confValues = {},
   fetchImpl
@@ -71,7 +85,9 @@ function loadGitHubApi ({
 
 describe('GitHub API utility', () => {
   it('builds the OAuth access-token exchange request', async () => {
-    const { api, fetch } = loadGitHubApi()
+    const { api, fetch } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse({ access_token: 'token-1' }))
+    })
 
     await api.getGitHubApi(EXCHANGE_ACCESS_TOKEN)('client-id', 'client-secret', 'auth-code')
 
@@ -85,9 +101,42 @@ describe('GitHub API utility', () => {
     }))
     expect(init.headers).toEqual(expect.objectContaining({
       Accept: 'application/json',
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'hackjutsu-lepton-app'
     }))
     expect(init).not.toHaveProperty('agent')
+  })
+
+  it('rejects OAuth token exchange responses without an access token', async () => {
+    const { api } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createJsonResponse({
+        error: 'incorrect_client_credentials',
+        error_description: 'The client credentials are incorrect.'
+      }))
+    })
+
+    await expect(api.getGitHubApi(EXCHANGE_ACCESS_TOKEN)('client-id', 'client-secret', 'auth-code'))
+      .rejects.toMatchObject({
+        name: 'OAuthTokenExchangeError',
+        errorDescription: 'The client credentials are incorrect.',
+        error: {
+          error: 'incorrect_client_credentials'
+        }
+      })
+  })
+
+  it('reports non-json GitHub API responses as parse errors', async () => {
+    const { api } = loadGitHubApi({
+      fetchImpl: () => Promise.resolve(createTextResponse('<html>nope</html>'))
+    })
+
+    await expect(api.getGitHubApi(EXCHANGE_ACCESS_TOKEN)('client-id', 'client-secret', 'auth-code'))
+      .rejects.toMatchObject({
+        name: 'ResponseParseError',
+        error: {
+          bodyPrefix: '<html>nope</html>'
+        }
+      })
   })
 
   it('uses GitHub Enterprise API host when configured', async () => {

--- a/tests/utilities/githubApiBridge.test.js
+++ b/tests/utilities/githubApiBridge.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const githubRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('../../app/utilities/electronBridge', () => ({
+  default: {
+    github: {
+      request: githubRequest
+    }
+  }
+}))
+
+import {
+  GET_USER_PROFILE,
+  getGitHubApi
+} from '../../app/utilities/githubApi'
+
+describe('GitHub API renderer bridge', () => {
+  beforeEach(() => {
+    githubRequest.mockReset()
+  })
+
+  it('unwraps successful GitHub API bridge responses', async () => {
+    githubRequest.mockResolvedValue({
+      __leptonGitHubApiBridgeResponse: true,
+      ok: true,
+      data: {
+        login: 'octo'
+      }
+    })
+
+    await expect(getGitHubApi(GET_USER_PROFILE)('token-1')).resolves.toEqual({
+      login: 'octo'
+    })
+    expect(githubRequest).toHaveBeenCalledWith(GET_USER_PROFILE, ['token-1'])
+  })
+
+  it('rejects failed GitHub API bridge responses with serialized details', async () => {
+    githubRequest.mockResolvedValue({
+      __leptonGitHubApiBridgeResponse: true,
+      ok: false,
+      error: {
+        message: 'GitHub API request failed with status 401 Unauthorized',
+        name: 'StatusCodeError',
+        statusCode: 401,
+        error: {
+          message: 'Bad credentials'
+        }
+      }
+    })
+
+    await expect(getGitHubApi(GET_USER_PROFILE)('token-1')).rejects.toMatchObject({
+      name: 'StatusCodeError',
+      message: 'GitHub API request failed with status 401 Unauthorized',
+      statusCode: 401,
+      error: {
+        message: 'Bad credentials'
+      }
+    })
+  })
+
+  it('passes through legacy raw bridge responses', async () => {
+    githubRequest.mockResolvedValue({
+      login: 'octo'
+    })
+
+    await expect(getGitHubApi(GET_USER_PROFILE)('token-1')).resolves.toEqual({
+      login: 'octo'
+    })
+  })
+})

--- a/tests/utilities/githubAuthWindow.test.js
+++ b/tests/utilities/githubAuthWindow.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import githubAuthWindow from '../../app/utilities/auth/githubAuthWindow'
+
+const {
+  clearGitHubAuthWindowStorageAndDestroy
+} = githubAuthWindow
+
+function createLogger () {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn()
+  }
+}
+
+function createAuthWindow ({
+  clearStorageData = () => Promise.resolve(),
+  destroyed = false
+} = {}) {
+  const state = {
+    destroyed
+  }
+  return {
+    destroy: vi.fn(() => {
+      state.destroyed = true
+    }),
+    isDestroyed: vi.fn(() => state.destroyed),
+    webContents: {
+      session: {
+        clearStorageData: vi.fn(clearStorageData)
+      }
+    }
+  }
+}
+
+describe('GitHub auth window cleanup', () => {
+  it('waits for Electron 42 Promise-based storage clearing before destroying the auth window', async () => {
+    const authWindow = createAuthWindow({
+      clearStorageData: () => Promise.resolve()
+    })
+    const logger = createLogger()
+
+    await clearGitHubAuthWindowStorageAndDestroy({ authWindow, logger })
+
+    expect(authWindow.webContents.session.clearStorageData).toHaveBeenCalledWith({})
+    expect(logger.debug).toHaveBeenCalledWith('[auth] OAuth session storage cleared')
+    expect(logger.debug).toHaveBeenCalledWith('[auth] Destroying OAuth auth window')
+    expect(authWindow.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('still destroys the auth window when Promise-based storage clearing rejects', async () => {
+    const authWindow = createAuthWindow({
+      clearStorageData: () => Promise.reject(new Error('clear failed'))
+    })
+    const logger = createLogger()
+
+    await clearGitHubAuthWindowStorageAndDestroy({ authWindow, logger })
+
+    expect(logger.warn).toHaveBeenCalledWith('[auth] Failed to clear OAuth session data: clear failed')
+    expect(authWindow.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys the auth window for legacy synchronous storage clearing behavior', async () => {
+    const authWindow = createAuthWindow({
+      clearStorageData: () => undefined
+    })
+    const logger = createLogger()
+
+    await clearGitHubAuthWindowStorageAndDestroy({ authWindow, logger })
+
+    expect(logger.debug).toHaveBeenCalledWith('[auth] OAuth session storage clear requested')
+    expect(authWindow.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear storage or destroy an already destroyed auth window', async () => {
+    const authWindow = createAuthWindow({
+      destroyed: true
+    })
+    const logger = createLogger()
+
+    await clearGitHubAuthWindowStorageAndDestroy({ authWindow, logger })
+
+    expect(authWindow.webContents.session.clearStorageData).not.toHaveBeenCalled()
+    expect(authWindow.destroy).not.toHaveBeenCalled()
+  })
+})

--- a/tests/utilities/githubOAuth.test.js
+++ b/tests/utilities/githubOAuth.test.js
@@ -3,6 +3,7 @@ import githubOAuth from '../../app/utilities/auth/githubOAuth'
 
 const {
   buildGitHubOAuthUrl,
+  describeGitHubOAuthUrl,
   parseGitHubOAuthCallback
 } = githubOAuth
 
@@ -36,5 +37,32 @@ describe('GitHub OAuth utility', () => {
   it('ignores URLs without OAuth callback data', () => {
     expect(parseGitHubOAuthCallback('https://github.com/login')).toBeNull()
     expect(parseGitHubOAuthCallback('not a url')).toBeNull()
+  })
+
+  it('describes OAuth URLs without exposing callback codes or client ids', () => {
+    expect(describeGitHubOAuthUrl('https://example.test/callback?code=secret-code&client_id=client-id&state=one'))
+      .toEqual({
+        valid: true,
+        origin: 'https://example.test',
+        pathname: '/callback',
+        queryKeys: ['client_id', 'code', 'state'],
+        hasCode: true,
+        codeLength: 11,
+        hasError: false
+      })
+  })
+
+  it('describes OAuth errors without exposing the full callback URL', () => {
+    expect(describeGitHubOAuthUrl('https://example.test/callback?error=access_denied&error_description=nope'))
+      .toEqual({
+        valid: true,
+        origin: 'https://example.test',
+        pathname: '/callback',
+        queryKeys: ['error', 'error_description'],
+        hasCode: false,
+        hasError: true,
+        error: 'access_denied',
+        errorDescription: 'nope'
+      })
   })
 })


### PR DESCRIPTION
## Summary

Fixes the GitHub login hang observed in the unsigned macOS beta build after OAuth authorization, and improves the login modal so users can see the current auth/sync state.

## Root Cause

[The 2.0.0-beta.3 app](https://github.com/hackjutsu/Lepton/releases#release-v2.0.0-beta.3) did receive the GitHub OAuth callback, but the follow-up token/profile API path failed. Because GitHub API requests now go through the Electron main-process bridge, custom error fields were lost across IPC, so the renderer logged `Failed: undefined`. The OAuth failure path also did not reset `userSession` from `IN_PROGRESS`, which left the login UI spinning.

## Validation

- `npm run test:unit -- tests/utilities/githubAuthWindow.test.js tests/utilities/githubOAuth.test.js`
- `npm run test:unit -- tests/utilities/githubOAuth.test.js tests/utilities/githubApi.test.js tests/utilities/githubApiBridge.test.js`
- `npm run lint`
- `npm test`
- `npm run test:smoke`

Smoke now covers the login status line, error log link, snippet-index sync status, and snippet download progress fixtures, in addition to the fixture-backed authenticated surfaces.

GitHub Actions are green for `lint-test-build`, `electron-smoke`, and `packaged-smoke` on the latest pushed commit.

Note: direct `eslint main.js` still reports pre-existing style issues because the project lint script currently scopes ESLint to `app` only.