### PR TITLE
[codex] Ad-hoc sign macOS release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ release workflow
     |
     +--> validate: lint, unit tests, webpack build
     |
-    +--> macOS Intel: unsigned dmg + zip
-    +--> macOS Apple Silicon: unsigned dmg + zip
+    +--> macOS Intel: ad-hoc signed dmg + zip
+    +--> macOS Apple Silicon: ad-hoc signed dmg + zip
     +--> Windows: unsigned NSIS installer + archive
     +--> Linux: AppImage + snap
     |
@@ -317,11 +317,23 @@ Release publishing requires repository secrets:
 - `SNAPCRAFT_STORE_CREDENTIALS`
 
 The workflow uses the built-in `GITHUB_TOKEN` for GitHub Release uploads.
-macOS and Windows artifacts are intentionally unsigned. macOS users should
-expect Gatekeeper warnings and may need to open the app from Finder's context
-menu or adjust Privacy & Security settings. Windows users should expect
-Microsoft Defender SmartScreen warnings. If signing is added later, update the
-workflow, `electron-builder.js`, and this documentation together.
+macOS artifacts are ad-hoc signed, which gives macOS a valid sealed app bundle
+without requiring a paid Apple Developer account. They are not Developer ID
+signed or notarized, so macOS users should still expect a Gatekeeper warning
+that Apple cannot verify the app is free of malware. Open Lepton from Finder's
+context menu or approve it in Privacy & Security. If macOS still reports the
+app as damaged after dragging it into Applications, advanced users can clear
+the downloaded-app quarantine flag:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Lepton.app
+open /Applications/Lepton.app
+```
+
+Windows artifacts are intentionally unsigned. Windows users should expect
+Microsoft Defender SmartScreen warnings. If Developer ID signing or
+notarization is added later, update the workflow, `electron-builder.js`, and
+this documentation together.
 
 Use environment-scoped secrets if prerelease and production should use different
 GitHub OAuth applications.

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -147,12 +147,13 @@ module.exports = {
   // the renderer. Add new locales in the shared i18n config first, then let this
   // derived list control the packaged Electron resources.
   electronLanguages: getElectronLanguages(getSupportedLocales()),
-  // macOS builds publish unsigned installer and archive artifacts for Intel and
-  // Apple Silicon users. A paid Apple Developer account is intentionally not
-  // required for the release flow.
+  // macOS builds use ad-hoc signing so Gatekeeper sees a structurally valid
+  // bundle without requiring a paid Apple Developer account. This still does
+  // not provide Developer ID trust or notarization.
   mac: {
     category: 'public.app-category.productivity',
-    identity: null,
+    identity: '-',
+    hardenedRuntime: false,
     target: [
       {
         target: 'dmg',

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -13,8 +13,9 @@ describe('electron-builder distribution config', () => {
     expect(builderConfig.files).toContain('app/utilities/updatePolicy.js')
   })
 
-  it('builds macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
-    expect(builderConfig.mac.identity).toBeNull()
+  it('ad-hoc signs macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
+    expect(builderConfig.mac.identity).toBe('-')
+    expect(builderConfig.mac.hardenedRuntime).toBe(false)
     expect(builderConfig.mac.target).toEqual([
       {
         target: 'dmg',

--- a/tests/smoke/electron-packaged-smoke.js
+++ b/tests/smoke/electron-packaged-smoke.js
@@ -124,15 +124,11 @@ function runCodesignDiagnostics (appPath) {
   const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim()
   const message = [
     'Packaged app strict codesign verification did not pass.',
-    'This is expected on unsigned local builds without a Developer ID identity.',
+    'macOS builds should be ad-hoc signed so Gatekeeper sees a structurally valid bundle.',
     output
   ].join('\n')
 
-  if (process.env.LEPTON_PACKAGED_SMOKE_REQUIRE_CODESIGN === '1') {
-    throw new Error(message)
-  }
-
-  console.warn(message)
+  throw new Error(message)
 }
 
 async function fetchJson (url) {

--- a/wiki/publish-flow.md
+++ b/wiki/publish-flow.md
@@ -84,7 +84,7 @@ Release workflow
     +--> build macOS:
     |       dmg + zip for x64
     |       dmg + zip for arm64
-    |       unsigned by policy
+    |       ad-hoc signed, not notarized
     |
     +--> build Windows:
     |       NSIS installer for x64 and ia32
@@ -108,24 +108,31 @@ stable auto-update metadata is available
 The macOS job builds Intel and Apple Silicon artifacts in one electron-builder
 run so `latest-mac.yml` is generated once for the full macOS artifact set.
 
-## Unsigned macOS And Windows Builds
+## macOS Gatekeeper And Windows SmartScreen
 
 Lepton does not require paid Apple Developer Program or Windows code-signing
-certificates for publishing. The release workflow intentionally disables
-macOS/Windows signing and does not read Apple or Windows certificate secrets.
+certificates for publishing. macOS artifacts are ad-hoc signed so the app
+bundle is structurally valid for local code-signing checks, but they are not
+Developer ID signed or notarized. The workflow does not read Apple certificate
+secrets.
 
 Expected user-facing behavior:
 
-- macOS users should expect Gatekeeper warnings. They may need to open Lepton
-  from Finder's context menu or approve it in Privacy & Security settings.
+- macOS users should expect Gatekeeper to say Apple cannot verify Lepton is
+  free of malware. They may need to open Lepton from Finder's context menu or
+  approve it in Privacy & Security settings.
+- If macOS still reports that Lepton is damaged after the app is dragged into
+  `/Applications`, advanced users can clear the downloaded-app quarantine flag:
+  `xattr -dr com.apple.quarantine /Applications/Lepton.app`.
 - Windows users should expect Microsoft Defender SmartScreen warnings until the
   unsigned app has enough reputation.
 - macOS and Windows auto-update metadata is still published for stable tags,
-  but unsigned update installation should be manually verified before it is
-  advertised as a fully supported update path.
+  but ad-hoc-signed macOS updates and unsigned Windows updates should be
+  manually verified before they are advertised as fully supported update paths.
 
-If signing is added later, update `.github/workflows/release.yml`,
-`electron-builder.js`, this wiki page, and the README together.
+If Developer ID signing or notarization is added later, update
+`.github/workflows/release.yml`, `electron-builder.js`, this wiki page, and the
+README together.
 
 Stable app builds are eligible to check for updates when the user's
 `.leptonrc` has:


### PR DESCRIPTION
## Summary

Reduce confusing macOS Gatekeeper failures for downloaded Lepton builds without requiring a paid Apple Developer account.

- Changes macOS electron-builder config from fully skipped signing to ad-hoc signing (`identity: "-"`) with hardened runtime disabled.
- Makes packaged smoke fail if strict macOS code-sign verification fails.
- Updates README and publish-flow docs with clear Gatekeeper guidance, including when `xattr -dr com.apple.quarantine /Applications/Lepton.app` is only an advanced fallback.

## Why

The `2.0.0-beta.3` DMG could show a scary "Lepton.app is damaged and can't be opened" dialog. Local diagnostics showed the current bundle was not just untrusted; strict code-sign verification failed because the app had no sealed resources. Ad-hoc signing does not provide Developer ID trust or notarization, but it does produce a structurally valid sealed bundle, which leads users toward the normal macOS "Apple could not verify this app is free of malware" flow instead of a damaged-app failure.

## Validation

- `npm run lint`
- `npm test` - 32 files, 164 tests
- `npm run test:packaged-smoke` - strict codesign verification passed and packaged UI smoke passed
- Temporary release-env package check with `CSC_IDENTITY_AUTO_DISCOVERY=false`: electron-builder used `identityName=-` and `codesign --verify --deep --strict` passed
- Manual Gatekeeper investigation on a quarantined ad-hoc-signed copy showed the expected Apple verification warning rather than the damaged-app dialog

## Notes

This still does not sign with Developer ID and does not notarize. Users should still expect Gatekeeper warnings on macOS and SmartScreen warnings on Windows until paid signing is introduced.