### PR TITLE
[codex] Add safeStorage cached token storage

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -568,7 +568,7 @@ function initUserSession (token, options = {}) {
 function updateLocalStorage (data) {
   try {
     logger.debug('[auth] Caching credential metadata ' + JSON.stringify({ hasCredential: Boolean(data.token) }))
-    let rst = electronBridge.localStorage.set('token', data.token)
+    let rst = electronBridge.credentials.setAccessToken(data.token)
     logger.debug(`[auth] [${rst.status}] Cached credential`)
 
     logger.debug(`-----> Caching profile ${data.profile}`)
@@ -585,7 +585,7 @@ function getCachedUserInfo () {
   logger.debug('-----> Inside getCachedUserInfo')
   const cachedProfile = electronBridge.localStorage.get('profile')
   logger.debug(`-----> [${cachedProfile.status}] cachedProfile is ${cachedProfile.data}`)
-  const cachedToken = electronBridge.localStorage.get('token')
+  const cachedToken = electronBridge.credentials.getAccessToken()
   logger.debug('[auth] Cached credential lookup ' + JSON.stringify({
     status: cachedToken.status,
     hasCredential: Boolean(cachedToken.data)

--- a/app/utilities/accessTokenStorage.js
+++ b/app/utilities/accessTokenStorage.js
@@ -1,0 +1,188 @@
+const LEGACY_TOKEN_KEY = 'token'
+const ENCRYPTED_TOKEN_KEY = 'encrypted-token'
+const SAFE_STORAGE_PROVIDER = 'electron-safeStorage'
+const DEFAULT_STORAGE_MODE = 'auto'
+const STORAGE_MODES = new Set(['auto', 'encrypted', 'file'])
+
+function createResult (status, data, error) {
+  const result = { status, data }
+  if (error) result.error = error
+  return result
+}
+
+function logWarn (logger, message) {
+  if (logger && typeof logger.warn === 'function') logger.warn(message)
+}
+
+function logInfo (logger, message) {
+  if (logger && typeof logger.info === 'function') logger.info(message)
+}
+
+function normalizeStorageMode (mode) {
+  return STORAGE_MODES.has(mode) ? mode : DEFAULT_STORAGE_MODE
+}
+
+function getConfiguredStorageMode (conf) {
+  if (!conf || typeof conf.get !== 'function') return DEFAULT_STORAGE_MODE
+  return normalizeStorageMode(conf.get('security:cachedAccessTokenStorage'))
+}
+
+function getEffectiveStorageMode ({ conf, isDev }) {
+  const configuredMode = getConfiguredStorageMode(conf)
+  if (configuredMode !== DEFAULT_STORAGE_MODE) return configuredMode
+  return isDev ? 'file' : 'encrypted'
+}
+
+function hasTokenValue (value) {
+  return typeof value === 'string' && value.length > 0
+}
+
+function getSafeStorageUnavailableReason ({ safeStorage, platform }) {
+  try {
+    if (!safeStorage || typeof safeStorage.isEncryptionAvailable !== 'function') {
+      return 'safeStorage unavailable'
+    }
+
+    if (!safeStorage.isEncryptionAvailable()) {
+      return 'safeStorage encryption unavailable'
+    }
+
+    if (platform === 'linux' && typeof safeStorage.getSelectedStorageBackend === 'function') {
+      const backend = safeStorage.getSelectedStorageBackend()
+      if (backend === 'basic_text') {
+        return 'Linux safeStorage selected the insecure basic_text backend'
+      }
+    }
+
+    return null
+  } catch (error) {
+    return `safeStorage availability check failed: ${error.message}`
+  }
+}
+
+function createAccessTokenStorage ({
+  conf,
+  getSafeStorage,
+  isDev,
+  localStorage,
+  logger,
+  platform = process.platform,
+  safeStorage
+}) {
+  function getMode () {
+    return getEffectiveStorageMode({ conf, isDev })
+  }
+
+  function resolveSafeStorage () {
+    return typeof getSafeStorage === 'function' ? getSafeStorage() : safeStorage
+  }
+
+  function ensureEncryptedStorageAvailable () {
+    const unavailableReason = getSafeStorageUnavailableReason({
+      safeStorage: resolveSafeStorage(),
+      platform
+    })
+    if (unavailableReason) {
+      logWarn(logger, `[auth] Encrypted cached access token storage unavailable: ${unavailableReason}`)
+    }
+    return unavailableReason
+  }
+
+  function clearEncryptedToken () {
+    const encryptedClear = localStorage.set(ENCRYPTED_TOKEN_KEY, null)
+    const legacyClear = localStorage.set(LEGACY_TOKEN_KEY, null)
+    return createResult(Boolean(encryptedClear.status && legacyClear.status), null, encryptedClear.error || legacyClear.error)
+  }
+
+  function writeEncryptedToken (token) {
+    if (!hasTokenValue(token)) return clearEncryptedToken()
+
+    const unavailableReason = ensureEncryptedStorageAvailable()
+    if (unavailableReason) return createResult(false, null, new Error(unavailableReason))
+
+    let encryptedToken
+    try {
+      encryptedToken = resolveSafeStorage().encryptString(token)
+    } catch (error) {
+      logWarn(logger, `[auth] Failed to encrypt cached access token: ${error.message}`)
+      return createResult(false, null, error)
+    }
+
+    const writeResult = localStorage.set(ENCRYPTED_TOKEN_KEY, {
+      version: 1,
+      provider: SAFE_STORAGE_PROVIDER,
+      data: encryptedToken.toString('base64')
+    })
+
+    if (!writeResult.status) return createResult(false, null, writeResult.error)
+
+    const legacyClear = localStorage.set(LEGACY_TOKEN_KEY, null)
+    if (!legacyClear.status) {
+      logWarn(logger, '[auth] Failed to clear legacy cached access token after encrypted write')
+    }
+
+    return createResult(true, token)
+  }
+
+  function readEncryptedTokenRecord (record) {
+    if (!record || record.version !== 1 ||
+      record.provider !== SAFE_STORAGE_PROVIDER ||
+      typeof record.data !== 'string') {
+      return createResult(false, null, new Error('Invalid encrypted token record'))
+    }
+
+    try {
+      return createResult(true, resolveSafeStorage().decryptString(Buffer.from(record.data, 'base64')))
+    } catch (error) {
+      logWarn(logger, `[auth] Failed to decrypt cached access token: ${error.message}`)
+      return createResult(false, null, error)
+    }
+  }
+
+  function migrateLegacyToken () {
+    const legacyToken = localStorage.get(LEGACY_TOKEN_KEY)
+    if (!legacyToken.status || !hasTokenValue(legacyToken.data)) {
+      return createResult(false, null, legacyToken.error)
+    }
+
+    const encryptedWrite = writeEncryptedToken(legacyToken.data)
+    if (!encryptedWrite.status) return encryptedWrite
+
+    logInfo(logger, '[auth] Migrated cached access token to encrypted storage')
+    return createResult(true, legacyToken.data)
+  }
+
+  function getEncryptedToken () {
+    const encryptedToken = localStorage.get(ENCRYPTED_TOKEN_KEY)
+    if (encryptedToken.status && encryptedToken.data) {
+      const unavailableReason = ensureEncryptedStorageAvailable()
+      if (unavailableReason) return createResult(false, null, new Error(unavailableReason))
+      return readEncryptedTokenRecord(encryptedToken.data)
+    }
+
+    return migrateLegacyToken()
+  }
+
+  return {
+    get () {
+      if (getMode() === 'file') return localStorage.get(LEGACY_TOKEN_KEY)
+      return getEncryptedToken()
+    },
+
+    set (token) {
+      if (!hasTokenValue(token)) return clearEncryptedToken()
+      if (getMode() === 'file') return localStorage.set(LEGACY_TOKEN_KEY, token)
+      return writeEncryptedToken(token)
+    }
+  }
+}
+
+module.exports = {
+  ENCRYPTED_TOKEN_KEY,
+  LEGACY_TOKEN_KEY,
+  SAFE_STORAGE_PROVIDER,
+  createAccessTokenStorage,
+  getConfiguredStorageMode,
+  getEffectiveStorageMode,
+  getSafeStorageUnavailableReason
+}

--- a/app/utilities/electronBridge/index.js
+++ b/app/utilities/electronBridge/index.js
@@ -30,6 +30,10 @@ function createUnavailableBridge () {
       get: unavailableBridgeMethod,
       set: unavailableBridgeMethod
     },
+    credentials: {
+      getAccessToken: unavailableBridgeMethod,
+      setAccessToken: unavailableBridgeMethod
+    },
     files: {
       ensureConfigFile: unavailableBridgeMethod
     },

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -15,6 +15,9 @@ module.exports = {
     "logger": {
         "level": "info"
     },
+    "security": {
+        "cachedAccessTokenStorage": "auto"
+    },
     "proxy": {
         "enable": false,
         "address": "socks://localhost:1080"

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -28,6 +28,7 @@ const snapStorePublishConfig = buildSnapStorePublishConfig()
 // Renderer source is compiled into bundle/app.bundle.js and does not need to
 // ship separately inside app.asar.
 const mainRuntimeAppFiles = [
+  'app/utilities/accessTokenStorage.js',
   'app/utilities/auth/**',
   'app/utilities/config/**',
   'app/utilities/electronLocalStorage.js',

--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ const { installLoggerRedaction } = require('./app/utilities/logging/redact')
 const { applyStartAtLoginSetting } = require('./app/utilities/startAtLogin')
 const { applyElectronProxy } = require('./app/utilities/electronProxy')
 const { configureI18n, t } = require('./app/utilities/i18n')
+const { createAccessTokenStorage } = require('./app/utilities/accessTokenStorage')
 const { createElectronLocalStorage } = require('./app/utilities/electronLocalStorage')
 const {
   getUpdateCheckDecision,
@@ -41,6 +42,13 @@ const {
 const logger = createMainLogger()
 const electronLocalStorage = createElectronLocalStorage({
   getUserDataPath: () => app.getPath('userData')
+})
+const accessTokenStorage = createAccessTokenStorage({
+  conf: nconf,
+  getSafeStorage: () => electron.safeStorage,
+  isDev,
+  localStorage: electronLocalStorage,
+  logger
 })
 
 const { autoUpdater } = require("electron-updater")
@@ -538,6 +546,22 @@ function setUpBridgeIpcHandlers () {
       return
     }
     event.returnValue = electronLocalStorage.set(key, value)
+  })
+
+  ipcMain.on('lepton:credentials:get-access-token', (event) => {
+    if (!isMainWindowSender(event)) {
+      event.returnValue = { status: false, data: null }
+      return
+    }
+    event.returnValue = accessTokenStorage.get()
+  })
+
+  ipcMain.on('lepton:credentials:set-access-token', (event, token) => {
+    if (!isMainWindowSender(event)) {
+      event.returnValue = { status: false }
+      return
+    }
+    event.returnValue = accessTokenStorage.set(token)
   })
 
   ipcMain.on('lepton:renderer-store:get', (event, configName, defaults) => {

--- a/preload.js
+++ b/preload.js
@@ -39,6 +39,10 @@ const leptonApi = {
     get: (key) => ipcRenderer.sendSync('lepton:config:get', key),
     set: (key, value) => ipcRenderer.invoke('lepton:config:set', key, value)
   },
+  credentials: {
+    getAccessToken: () => ipcRenderer.sendSync('lepton:credentials:get-access-token'),
+    setAccessToken: (token) => ipcRenderer.sendSync('lepton:credentials:set-access-token', token)
+  },
   files: {
     ensureConfigFile: (defaults) => ipcRenderer.invoke('lepton:files:ensure-config', defaults)
   },

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -10,7 +10,10 @@ describe('electron-builder distribution config', () => {
   })
 
   it('packages main-process runtime files used at startup', () => {
-    expect(builderConfig.files).toContain('app/utilities/updatePolicy.js')
+    expect(builderConfig.files).toEqual(expect.arrayContaining([
+      'app/utilities/accessTokenStorage.js',
+      'app/utilities/updatePolicy.js'
+    ]))
   })
 
   it('packages GitHub API bridge runtime dependencies', () => {

--- a/tests/utilities/accessTokenStorage.test.js
+++ b/tests/utilities/accessTokenStorage.test.js
@@ -1,0 +1,228 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const defaultConfig = require('../../configs/defaultConfig')
+const {
+  ENCRYPTED_TOKEN_KEY,
+  LEGACY_TOKEN_KEY,
+  SAFE_STORAGE_PROVIDER,
+  createAccessTokenStorage,
+  getConfiguredStorageMode,
+  getEffectiveStorageMode
+} = require('../../app/utilities/accessTokenStorage')
+
+function createConf (values = {}) {
+  return {
+    get: (key) => Object.prototype.hasOwnProperty.call(values, key) ? values[key] : undefined
+  }
+}
+
+function createMemoryStorage (initialValues = {}) {
+  const values = { ...initialValues }
+  return {
+    values,
+    get: vi.fn((key) => {
+      if (!Object.prototype.hasOwnProperty.call(values, key)) {
+        return { status: false, data: null }
+      }
+      return { status: true, data: values[key] }
+    }),
+    set: vi.fn((key, value) => {
+      values[key] = value
+      return { status: true, data: value }
+    })
+  }
+}
+
+function createSafeStorage (options = {}) {
+  const {
+    available = true,
+    backend = 'gnome_libsecret'
+  } = options
+
+  return {
+    isEncryptionAvailable: vi.fn(() => available),
+    getSelectedStorageBackend: vi.fn(() => backend),
+    encryptString: vi.fn((value) => Buffer.from(`encrypted:${value}`, 'utf8')),
+    decryptString: vi.fn((encrypted) => encrypted.toString('utf8').replace(/^encrypted:/, ''))
+  }
+}
+
+function createLogger () {
+  return {
+    info: vi.fn(),
+    warn: vi.fn()
+  }
+}
+
+describe('access token storage', () => {
+  it('defaults cached token storage to auto', () => {
+    expect(defaultConfig.security.cachedAccessTokenStorage).toBe('auto')
+  })
+
+  it('resolves auto mode to file storage in development and encrypted storage in packaged builds', () => {
+    expect(getConfiguredStorageMode(createConf())).toBe('auto')
+    expect(getConfiguredStorageMode(createConf({
+      'security:cachedAccessTokenStorage': 'invalid'
+    }))).toBe('auto')
+    expect(getEffectiveStorageMode({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'auto' }),
+      isDev: true
+    })).toBe('file')
+    expect(getEffectiveStorageMode({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'auto' }),
+      isDev: false
+    })).toBe('encrypted')
+  })
+
+  it('preserves legacy file storage when effective mode is file', () => {
+    const localStorage = createMemoryStorage()
+    const safeStorage = createSafeStorage()
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'auto' }),
+      isDev: true,
+      localStorage,
+      safeStorage
+    })
+
+    expect(accessTokenStorage.set('token-1')).toEqual({
+      status: true,
+      data: 'token-1'
+    })
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBe('token-1')
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY]).toBeUndefined()
+    expect(safeStorage.encryptString).not.toHaveBeenCalled()
+    expect(accessTokenStorage.get()).toEqual({
+      status: true,
+      data: 'token-1'
+    })
+  })
+
+  it('encrypts cached token storage when effective mode is encrypted', () => {
+    const localStorage = createMemoryStorage()
+    const safeStorage = createSafeStorage()
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      isDev: true,
+      localStorage,
+      safeStorage
+    })
+
+    expect(accessTokenStorage.set('token-1')).toEqual({
+      status: true,
+      data: 'token-1'
+    })
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBeNull()
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY]).toEqual({
+      version: 1,
+      provider: SAFE_STORAGE_PROVIDER,
+      data: Buffer.from('encrypted:token-1', 'utf8').toString('base64')
+    })
+    expect(accessTokenStorage.get()).toEqual({
+      status: true,
+      data: 'token-1'
+    })
+  })
+
+  it('does not resolve safeStorage when encrypted mode has no cached token', () => {
+    const localStorage = createMemoryStorage()
+    const getSafeStorage = vi.fn(() => createSafeStorage())
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      getSafeStorage,
+      isDev: false,
+      localStorage
+    })
+
+    expect(accessTokenStorage.get().status).toBe(false)
+    expect(getSafeStorage).not.toHaveBeenCalled()
+  })
+
+  it('migrates a legacy plaintext cached token into encrypted storage', () => {
+    const localStorage = createMemoryStorage({
+      [LEGACY_TOKEN_KEY]: 'legacy-token'
+    })
+    const logger = createLogger()
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      isDev: false,
+      localStorage,
+      logger,
+      safeStorage: createSafeStorage()
+    })
+
+    expect(accessTokenStorage.get()).toEqual({
+      status: true,
+      data: 'legacy-token'
+    })
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBeNull()
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY].provider).toBe(SAFE_STORAGE_PROVIDER)
+    expect(logger.info).toHaveBeenCalledWith('[auth] Migrated cached access token to encrypted storage')
+  })
+
+  it('does not use legacy plaintext token when encrypted storage is unavailable', () => {
+    const localStorage = createMemoryStorage({
+      [LEGACY_TOKEN_KEY]: 'legacy-token'
+    })
+    const logger = createLogger()
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      isDev: false,
+      localStorage,
+      logger,
+      safeStorage: createSafeStorage({ available: false })
+    })
+
+    expect(accessTokenStorage.get().status).toBe(false)
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBe('legacy-token')
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY]).toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[auth] Encrypted cached access token storage unavailable: safeStorage encryption unavailable'
+    )
+  })
+
+  it('does not cache tokens on Linux when safeStorage selects basic_text', () => {
+    const localStorage = createMemoryStorage()
+    const logger = createLogger()
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      isDev: false,
+      localStorage,
+      logger,
+      platform: 'linux',
+      safeStorage: createSafeStorage({ backend: 'basic_text' })
+    })
+
+    expect(accessTokenStorage.set('token-1').status).toBe(false)
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBeUndefined()
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY]).toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[auth] Encrypted cached access token storage unavailable: Linux safeStorage selected the insecure basic_text backend'
+    )
+  })
+
+  it('clears encrypted and legacy cached tokens on logout', () => {
+    const localStorage = createMemoryStorage({
+      [LEGACY_TOKEN_KEY]: 'legacy-token',
+      [ENCRYPTED_TOKEN_KEY]: {
+        version: 1,
+        provider: SAFE_STORAGE_PROVIDER,
+        data: Buffer.from('encrypted:token-1', 'utf8').toString('base64')
+      }
+    })
+    const accessTokenStorage = createAccessTokenStorage({
+      conf: createConf({ 'security:cachedAccessTokenStorage': 'encrypted' }),
+      isDev: false,
+      localStorage,
+      safeStorage: createSafeStorage()
+    })
+
+    expect(accessTokenStorage.set(null)).toEqual({
+      status: true,
+      data: null
+    })
+    expect(localStorage.values[LEGACY_TOKEN_KEY]).toBeNull()
+    expect(localStorage.values[ENCRYPTED_TOKEN_KEY]).toBeNull()
+  })
+})

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -24,6 +24,9 @@ The file is not generated automatically. Create it if you want to override the d
   "logger": {
     "level": "info"
   },
+  "security": {
+    "cachedAccessTokenStorage": "auto"
+  },
   "proxy": {
     "enable": false,
     "address": "socks://localhost:1080"
@@ -79,6 +82,7 @@ The file is not generated automatically. Create it if you want to override the d
 | | `boringAvatarVariant` | `beam` | Variant used when `avatar.type` is `boring`. |
 | `userPanel` | `hideProfilePhoto` | `false` | Hide the profile photo in the user panel. |
 | `logger` | `level` | `info` | Logging level. Use `info` for normal use or `debug` when collecting diagnostic logs. |
+| `security` | `cachedAccessTokenStorage` | `auto` | Cached GitHub OAuth token storage. Supported values: `auto`, `encrypted`, `file`. `auto` uses file storage in development builds and Electron safeStorage in packaged builds. |
 | `proxy` | `enable` | `false` | Route GitHub API requests and Electron sessions through a proxy. |
 | | `address` | `socks://localhost:1080` | Proxy address. Supports normal proxy URLs, Chromium proxy rule lists, and `pac+https://...` PAC URLs. |
 | `snippet` | `sorting` | `updated_at` | Snippet order. Supported values: `updated_at`, `created_at`, `description`. |
@@ -92,7 +96,7 @@ The file is not generated automatically. Create it if you want to override the d
 | | `validateFilename` | `true` | Validate gist filenames before saving. |
 | `enterprise` | `enable` | `false` | Enable GitHub Enterprise mode. |
 | | `host` | `""` | GitHub Enterprise host, for example `github.example.com`. |
-| | `token` | `""` | Personal access token with the `gist` scope. |
+| | `token` | `""` | Personal access token with the `gist` scope. This remains plain `.leptonrc` configuration and is not affected by `security.cachedAccessTokenStorage`. |
 | | `avatarUrl` | `""` | Optional avatar image URL for GitHub Enterprise users. |
 | `notifications` | `success` | `true` | Show notifications for successful actions. |
 | | `failure` | `true` | Show notifications for failed actions. |


### PR DESCRIPTION
## Summary

Adds an Electron safeStorage-backed path for Lepton's cached GitHub OAuth access token while preserving the existing development workflow.

- Adds `security.cachedAccessTokenStorage` with `auto`, `encrypted`, and `file` modes.
- Uses existing file storage in dev `auto` mode, and encrypted safeStorage-backed cached token storage in packaged `auto` mode.
- Adds a narrow preload credential bridge for cached OAuth token get/set, leaving generic local storage and `enterprise.token` unchanged.
- Migrates a legacy plaintext cached token into encrypted storage when encrypted mode is active, and clears both legacy and encrypted token slots on logout.
- Includes the new main-process storage utility in the packaged app allowlist so packaged startup can resolve it.
- Documents the new config option and explicitly notes that GitHub Enterprise token config remains plain `.leptonrc` scope.

## Validation

- `npm run lint`
- `npm run test:unit`
- `npm test`
- `npm run test:smoke`
- `npm run test:packaged-smoke`
- GitHub Actions `CI #358` passed: `lint-test-build`, `electron-smoke`, and `packaged-smoke`

## Manual verification

Launched the PR worktree locally with an isolated config/user-data directory and `security.cachedAccessTokenStorage: "encrypted"`. OAuth login succeeded with a local ignored `configs/account.js`; after login, `storage/encrypted-token.json` contained an `electron-safeStorage` record and legacy `storage/token.json` was `null`, confirming auto-login was restored from the encrypted cached token path.