### PR TITLE
[codex] Fix packaged GitHub login config dependency

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -29,6 +29,7 @@ const snapStorePublishConfig = buildSnapStorePublishConfig()
 // ship separately inside app.asar.
 const mainRuntimeAppFiles = [
   'app/utilities/auth/**',
+  'app/utilities/config/**',
   'app/utilities/electronLocalStorage.js',
   'app/utilities/electronProxy/**',
   'app/utilities/githubApi/core.js',

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -13,6 +13,14 @@ describe('electron-builder distribution config', () => {
     expect(builderConfig.files).toContain('app/utilities/updatePolicy.js')
   })
 
+  it('packages GitHub API bridge runtime dependencies', () => {
+    expect(builderConfig.files).toEqual(expect.arrayContaining([
+      'app/utilities/config/**',
+      'app/utilities/githubApi/core.js',
+      'app/utilities/githubApi/fetchAdapter.js'
+    ]))
+  })
+
   it('ad-hoc signs macOS DMG and ZIP artifacts for Intel and Apple Silicon', () => {
     expect(builderConfig.mac.identity).toBe('-')
     expect(builderConfig.mac.hardenedRuntime).toBe(false)


### PR DESCRIPTION
## Summary

Fixes the beta.4 packaged login failure where OAuth token exchange reaches the main-process GitHub API bridge, then fails with `Cannot find module '../config'` from `app/utilities/githubApi/core.js`.

- Ships `app/utilities/config/**` in `app.asar` alongside the GitHub API bridge files.
- Adds electron-builder config coverage for the GitHub API bridge runtime dependencies.

## Validation

- `npm run test:unit -- tests/configs/electronBuilder.test.js`
- `npm run lint`
- `npm test`
- `npm run test:packaged-smoke`
- `git diff --check`
- Verified `dist/mac-arm64/Lepton.app/Contents/Resources/app.asar` contains `/app/utilities/config/index.js`, `/app/utilities/githubApi/core.js`, and `/app/utilities/githubApi/fetchAdapter.js`.

## Release note

Beta.4 should not be retagged. After this merges, publish a new prerelease such as `v2.0.0-beta.5`.