### PR TITLE
[codex] Polish login and search modal layout

### DIFF
--- a/app/containers/appContainer/index.js
+++ b/app/containers/appContainer/index.js
@@ -80,10 +80,12 @@ class AppContainer extends Component {
   }
 
   renderSearchPage () {
-    const { searchWindowStatus, searchIndex } = this.props
+    const { initialSearchQuery, searchWindowStatus, searchIndex } = this.props
     return searchWindowStatus === 'OFF'
       ? null
-      : <SearchPage searchIndex = { searchIndex } />
+      : <SearchPage
+        initialSearchQuery = { initialSearchQuery }
+        searchIndex = { searchIndex } />
   }
 
   dismissUpdateAlert () {

--- a/app/containers/languageSelector/index.js
+++ b/app/containers/languageSelector/index.js
@@ -30,10 +30,12 @@ class LanguageSelector extends Component {
   render () {
     const { className, compact } = this.props
     const labelClassName = `${className || ''}${compact ? ' language-selector-compact' : ''}`.trim()
+    const label = t('i18n.language')
     return (
-      <label className={ labelClassName }>
-        <span>{ compact ? '🌐' : t('i18n.language') }</span>
+      <label className={ labelClassName } title={ compact ? label : undefined }>
+        <span aria-hidden={ compact ? true : undefined }>{ compact ? '🌐' : label }</span>
         <select
+          aria-label={ label }
           className='form-control'
           data-role='language-selector'
           value={ this.state.locale }

--- a/app/containers/languageSelector/index.js
+++ b/app/containers/languageSelector/index.js
@@ -1,6 +1,6 @@
 import electronBridge from '../../utilities/electronBridge'
 import React, { Component } from 'react'
-import { getLocale, getSupportedLocales, t } from '../../utilities/i18n'
+import { configureI18n, getLocale, getSupportedLocales, t, translate } from '../../utilities/i18n'
 
 const logger = electronBridge.logger
 
@@ -14,10 +14,17 @@ class LanguageSelector extends Component {
 
   handleLanguageChanged (event) {
     const locale = event.target.value
-    const { onBeforeChange, onChangeFailed } = this.props
+    const { onBeforeChange, onChangeComplete, onChangeFailed } = this.props
     this.setState({ locale })
     Promise.resolve(onBeforeChange ? onBeforeChange(locale) : null)
       .then(() => electronBridge.config.set('i18n:locale', locale))
+      .then(persistedLocale => {
+        const configuredLocale = configureI18n(persistedLocale || locale)
+        this.setState({ locale: configuredLocale })
+        if (onChangeComplete) {
+          onChangeComplete(configuredLocale)
+        }
+      })
       .catch(error => {
         logger.error(t('i18n.saveFailed'), error)
         this.setState({ locale: getLocale() })
@@ -28,9 +35,9 @@ class LanguageSelector extends Component {
   }
 
   render () {
-    const { className, compact } = this.props
+    const { className, compact, disabled, displayLocale, selectedLocale } = this.props
     const labelClassName = `${className || ''}${compact ? ' language-selector-compact' : ''}`.trim()
-    const label = t('i18n.language')
+    const label = displayLocale ? translate(displayLocale, 'i18n.language') : t('i18n.language')
     return (
       <label className={ labelClassName } title={ compact ? label : undefined }>
         <span aria-hidden={ compact ? true : undefined }>{ compact ? '🌐' : label }</span>
@@ -38,7 +45,9 @@ class LanguageSelector extends Component {
           aria-label={ label }
           className='form-control'
           data-role='language-selector'
-          value={ this.state.locale }
+          disabled={ disabled }
+          tabIndex={ disabled ? -1 : undefined }
+          value={ selectedLocale || this.state.locale }
           onChange={ this.handleLanguageChanged.bind(this) }>
           { getSupportedLocales().map(locale => (
             <option key={ locale.code } value={ locale.code }>

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -19,6 +19,8 @@ const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 
 const LoginModeEnum = { CREDENTIALS: 1, TOKEN: 2 }
+const LOGIN_MODAL_FLIP_DURATION_MS = 320
+const LOGIN_MODAL_FLIP_SWAP_MS = LOGIN_MODAL_FLIP_DURATION_MS / 2
 
 function getFileUrl (filePath) {
   if (!filePath) return null
@@ -33,7 +35,7 @@ class LoginPage extends Component {
     this.state = {
       inputTokenValue: '',
       loginMode: LoginModeEnum.CREDENTIALS,
-      languageChanging: false
+      modalFlipping: false
     }
   }
 
@@ -55,6 +57,8 @@ class LoginPage extends Component {
   componentWillUnmount () {
     logger.debug('-----> Removing listener for auto-login signal')
     unsubscribeIpc(this.ipcSubscriptions)
+    clearTimeout(this.loginModeFlipTimer)
+    clearTimeout(this.loginModeSwapTimer)
     clearTimeout(this.languageChangeTimer)
   }
 
@@ -74,16 +78,21 @@ class LoginPage extends Component {
     }
   }
 
-  handleLoginModeSwitched () {
-    if (this.state.loginMode === LoginModeEnum.CREDENTIALS) {
-      this.setState({
-        loginMode: LoginModeEnum.TOKEN
-      })
-    } else {
-      this.setState({
-        loginMode: LoginModeEnum.CREDENTIALS
-      })
-    }
+  handleLoginModeSwitched (event) {
+    if (event && typeof event.preventDefault === 'function') event.preventDefault()
+    if (this.state.modalFlipping) return
+
+    this.setState({ modalFlipping: true })
+    this.loginModeSwapTimer = setTimeout(() => {
+      this.setState(prevState => ({
+        loginMode: prevState.loginMode === LoginModeEnum.CREDENTIALS
+          ? LoginModeEnum.TOKEN
+          : LoginModeEnum.CREDENTIALS
+      }))
+    }, LOGIN_MODAL_FLIP_SWAP_MS)
+    this.loginModeFlipTimer = setTimeout(() => {
+      this.setState({ modalFlipping: false })
+    }, LOGIN_MODAL_FLIP_DURATION_MS)
   }
 
   renderControlSection () {
@@ -118,7 +127,7 @@ class LoginPage extends Component {
               onClick={ this.handleContinueButtonClicked.bind(this, token) }>
               { loggedInUserName ? t('login.continueAs', { username: loggedInUserName }) : t('login.happyCoding') }
             </Button>
-            : this.renderTokenLoginSection(false, userSessionStatus)}
+            : this.renderTokenLoginSection(userSessionStatus)}
         </div>
       )
     }
@@ -132,7 +141,7 @@ class LoginPage extends Component {
           </div>
           { loginMode === LoginModeEnum.CREDENTIALS
             ? this.renderCredentialLoginSection(authWindowStatus, userSessionStatus)
-            : this.renderTokenLoginSection(true, userSessionStatus)
+            : this.renderTokenLoginSection(userSessionStatus)
           }
         </div>
       )
@@ -153,14 +162,16 @@ class LoginPage extends Component {
   }
 
   handleLanguageChanging () {
-    this.setState({ languageChanging: true })
+    clearTimeout(this.loginModeFlipTimer)
+    clearTimeout(this.loginModeSwapTimer)
+    this.setState({ modalFlipping: true })
     return new Promise(resolve => {
-      this.languageChangeTimer = setTimeout(resolve, 180)
+      this.languageChangeTimer = setTimeout(resolve, LOGIN_MODAL_FLIP_DURATION_MS)
     })
   }
 
   handleLanguageChangeFailed () {
-    this.setState({ languageChanging: false })
+    this.setState({ modalFlipping: false })
   }
 
   updateInputValue (evt) {
@@ -182,14 +193,11 @@ class LoginPage extends Component {
           onClick={ this.handleLoginClicked.bind(this) }>
           { t('login.githubLogin') }
         </Button>
-        <div className="login-page-text-link">
-          <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>{ t('login.switchToToken') }</a>
-        </div>
       </div>
     )
   }
 
-  renderTokenLoginSection (showLoginSwitch, userSessionStatus) {
+  renderTokenLoginSection (userSessionStatus) {
     return (
       <form>
         { userSessionStatus === 'EXPIRED'
@@ -208,12 +216,33 @@ class LoginPage extends Component {
           onClick={ this.handleTokenLoginButtonClicked.bind(this, this.state.inputTokenValue) }>
           { t('login.tokenLogin') }
         </Button>
-        { showLoginSwitch
-          ? <div className="login-page-text-link">
-            <a href="#" onClick={ this.handleLoginModeSwitched.bind(this) }>{ t('login.switchToCredentials') }</a>
-          </div>
-          : null}
       </form>
+    )
+  }
+
+  shouldRenderLoginModeSwitch () {
+    const { loggedInUserInfo, userSessionStatus } = this.props
+    const loggedInUserName = loggedInUserInfo ? loggedInUserInfo.profile : null
+
+    return !conf.get('enterprise:enable') &&
+      (userSessionStatus === 'EXPIRED' || userSessionStatus === 'INACTIVE' ||
+      loggedInUserName === null || loggedInUserName === 'null')
+  }
+
+  renderLoginModeSwitch () {
+    if (!this.shouldRenderLoginModeSwitch()) return null
+
+    const label = this.state.loginMode === LoginModeEnum.CREDENTIALS
+      ? t('login.switchToToken')
+      : t('login.switchToCredentials')
+
+    return (
+      <a
+        className='login-mode-switch'
+        href="#"
+        onClick={ this.handleLoginModeSwitched.bind(this) }>
+        { label }
+      </a>
     )
   }
 
@@ -277,8 +306,8 @@ class LoginPage extends Component {
   }
 
   render () {
-    const className = this.state.languageChanging
-      ? 'login-modal login-modal-language-changing'
+    const className = this.state.modalFlipping
+      ? 'login-modal login-modal-flipping'
       : 'login-modal'
 
     return (
@@ -286,6 +315,7 @@ class LoginPage extends Component {
         <Modal.Dialog bsSize='small'>
           <Modal.Header>
             <Modal.Title>{ t('login.title') }</Modal.Title>
+            { this.renderLoginModeSwitch() }
             { this.renderLanguageSelector() }
           </Modal.Header>
           <Modal.Body>

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -235,20 +235,32 @@ class LoginPage extends Component {
     const label = this.state.loginMode === LoginModeEnum.CREDENTIALS
       ? t('login.switchToToken')
       : t('login.switchToCredentials')
+    const icon = this.state.loginMode === LoginModeEnum.CREDENTIALS ? '🔑' : '👤'
 
     return (
-      <a
-        className='login-mode-switch'
-        href="#"
-        onClick={ this.handleLoginModeSwitched.bind(this) }>
-        { label }
-      </a>
+      <button
+        aria-label={ label }
+        className='login-header-icon login-mode-switch'
+        onClick={ this.handleLoginModeSwitched.bind(this) }
+        title={ label }
+        type='button'>
+        <span aria-hidden='true'>{ icon }</span>
+      </button>
+    )
+  }
+
+  renderHeaderActions () {
+    return (
+      <div className='login-header-actions'>
+        { this.renderLoginModeSwitch() }
+        { this.renderLanguageSelector() }
+      </div>
     )
   }
 
   renderLoginModalBody () {
     return (
-      <center>
+      <center className='login-modal-body-flipper'>
         { this.renderAvatar() }
         { this.renderControlSection() }
         { this.renderLoginStatus() }
@@ -314,11 +326,10 @@ class LoginPage extends Component {
       <div className={ className }>
         <Modal.Dialog bsSize='small'>
           <Modal.Header>
-            <Modal.Title>{ t('login.title') }</Modal.Title>
-            { this.renderLoginModeSwitch() }
-            { this.renderLanguageSelector() }
+            <Modal.Title className='login-modal-title' title={ t('login.title') }>{ t('login.title') }</Modal.Title>
+            { this.renderHeaderActions() }
           </Modal.Header>
-          <Modal.Body>
+          <Modal.Body className='login-modal-body'>
             { this.renderLoginModalBody() }
           </Modal.Body>
         </Modal.Dialog>

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -6,7 +6,7 @@ import LanguageSelector from '../languageSelector'
 import Modal from '../compatModal'
 import React, { Component } from 'react'
 import { subscribeIpc, unsubscribeIpc } from '../../utilities/ipcSubscriptions'
-import { t } from '../../utilities/i18n'
+import { getLocale, translate } from '../../utilities/i18n'
 
 import dojocatImage from '../../utilities/octodex/dojocat.webp?inline'
 import privateinvestocatImage from '../../utilities/octodex/privateinvestocat.webp?inline'
@@ -19,8 +19,7 @@ const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 
 const LoginModeEnum = { CREDENTIALS: 1, TOKEN: 2 }
-const LOGIN_MODAL_FLIP_DURATION_MS = 320
-const LOGIN_MODAL_FLIP_SWAP_MS = LOGIN_MODAL_FLIP_DURATION_MS / 2
+const LOGIN_MODAL_FLIP_DURATION_MS = 520
 
 function getFileUrl (filePath) {
   if (!filePath) return null
@@ -34,8 +33,12 @@ class LoginPage extends Component {
     super(props)
     this.state = {
       inputTokenValue: '',
+      activeLocale: getLocale(),
       loginMode: LoginModeEnum.CREDENTIALS,
-      modalFlipping: false
+      modalFlipping: false,
+      pendingLoginMode: null,
+      pendingLocale: null,
+      pendingModalState: null
     }
   }
 
@@ -58,8 +61,6 @@ class LoginPage extends Component {
     logger.debug('-----> Removing listener for auto-login signal')
     unsubscribeIpc(this.ipcSubscriptions)
     clearTimeout(this.loginModeFlipTimer)
-    clearTimeout(this.loginModeSwapTimer)
-    clearTimeout(this.languageChangeTimer)
   }
 
   handleLoginClicked () {
@@ -78,28 +79,61 @@ class LoginPage extends Component {
     }
   }
 
-  handleLoginModeSwitched (event) {
-    if (event && typeof event.preventDefault === 'function') event.preventDefault()
-    if (this.state.modalFlipping) return
+  startModalFlip (getFinalState) {
+    if (this.state.modalFlipping) return Promise.resolve()
 
-    this.setState({ modalFlipping: true })
-    this.loginModeSwapTimer = setTimeout(() => {
-      this.setState(prevState => ({
-        loginMode: prevState.loginMode === LoginModeEnum.CREDENTIALS
-          ? LoginModeEnum.TOKEN
-          : LoginModeEnum.CREDENTIALS
-      }))
-    }, LOGIN_MODAL_FLIP_SWAP_MS)
-    this.loginModeFlipTimer = setTimeout(() => {
-      this.setState({ modalFlipping: false })
-    }, LOGIN_MODAL_FLIP_DURATION_MS)
+    clearTimeout(this.loginModeFlipTimer)
+
+    return new Promise(resolve => {
+      this.setState(prevState => {
+        const finalState = typeof getFinalState === 'function' ? getFinalState(prevState) : {}
+        const pendingLoginMode = Object.prototype.hasOwnProperty.call(finalState, 'loginMode')
+          ? finalState.loginMode
+          : prevState.loginMode
+        const pendingLocale = Object.prototype.hasOwnProperty.call(finalState, 'activeLocale')
+          ? finalState.activeLocale
+          : prevState.activeLocale
+
+        return {
+          modalFlipping: true,
+          pendingLoginMode,
+          pendingLocale,
+          pendingModalState: finalState
+        }
+      })
+
+      this.loginModeFlipTimer = setTimeout(() => {
+        this.setState(prevState => Object.assign(
+          {},
+          prevState.pendingModalState || {},
+          {
+            modalFlipping: false,
+            pendingLoginMode: null,
+            pendingLocale: null,
+            pendingModalState: null
+          }
+        ), resolve)
+      }, LOGIN_MODAL_FLIP_DURATION_MS)
+    })
   }
 
-  renderControlSection () {
+  handleLoginModeSwitched (event) {
+    if (event && typeof event.preventDefault === 'function') event.preventDefault()
+    this.startModalFlip(prevState => ({
+      loginMode: prevState.loginMode === LoginModeEnum.CREDENTIALS
+        ? LoginModeEnum.TOKEN
+        : LoginModeEnum.CREDENTIALS
+    }))
+  }
+
+  translate (locale, key, values) {
+    return translate(locale || this.state.activeLocale, key, values)
+  }
+
+  renderControlSection (loginMode = this.state.loginMode, locale = this.state.activeLocale, isInteractive = true) {
     const { authWindowStatus, loggedInUserInfo, userSessionStatus } = this.props
-    const { loginMode } = this.state
     const loggedInUserName = loggedInUserInfo ? loggedInUserInfo.profile : null
-    const welcomeMessage = t('login.welcome')
+    const welcomeMessage = this.translate(locale, 'login.welcome')
 
     if (userSessionStatus === 'IN_PROGRESS') {
       return (
@@ -121,13 +155,17 @@ class LoginPage extends Component {
           </div>
           { token
             ? <Button
-              autoFocus
+              autoFocus={ isInteractive }
               className='modal-button'
               bsStyle="default"
+              disabled={ !isInteractive }
               onClick={ this.handleContinueButtonClicked.bind(this, token) }>
-              { loggedInUserName ? t('login.continueAs', { username: loggedInUserName }) : t('login.happyCoding') }
+              { loggedInUserName
+                ? this.translate(locale, 'login.continueAs', { username: loggedInUserName })
+                : this.translate(locale, 'login.happyCoding')
+              }
             </Button>
-            : this.renderTokenLoginSection(userSessionStatus)}
+            : this.renderTokenLoginSection(userSessionStatus, locale, isInteractive)}
         </div>
       )
     }
@@ -140,8 +178,8 @@ class LoginPage extends Component {
             <a href="https://github.com/hackjutsu/Lepton">{ welcomeMessage }</a>
           </div>
           { loginMode === LoginModeEnum.CREDENTIALS
-            ? this.renderCredentialLoginSection(authWindowStatus, userSessionStatus)
-            : this.renderTokenLoginSection(userSessionStatus)
+            ? this.renderCredentialLoginSection(authWindowStatus, userSessionStatus, locale, isInteractive)
+            : this.renderTokenLoginSection(userSessionStatus, locale, isInteractive)
           }
         </div>
       )
@@ -150,28 +188,40 @@ class LoginPage extends Component {
     return null
   }
 
-  renderLanguageSelector () {
+  renderLanguageSelector (locale = this.state.activeLocale, isInteractive = true) {
     return (
       <LanguageSelector
         className='login-language-selector'
         compact
+        disabled={ !isInteractive }
+        displayLocale={ locale }
         onBeforeChange={ this.handleLanguageChanging.bind(this) }
+        onChangeComplete={ this.handleLanguageChangeComplete.bind(this) }
         onChangeFailed={ this.handleLanguageChangeFailed.bind(this) }
+        selectedLocale={ locale }
       />
     )
   }
 
-  handleLanguageChanging () {
-    clearTimeout(this.loginModeFlipTimer)
-    clearTimeout(this.loginModeSwapTimer)
-    this.setState({ modalFlipping: true })
-    return new Promise(resolve => {
-      this.languageChangeTimer = setTimeout(resolve, LOGIN_MODAL_FLIP_DURATION_MS)
-    })
+  handleLanguageChanging (locale) {
+    return this.startModalFlip(() => ({
+      activeLocale: locale
+    }))
+  }
+
+  handleLanguageChangeComplete (locale) {
+    this.setState({ activeLocale: locale })
   }
 
   handleLanguageChangeFailed () {
-    this.setState({ modalFlipping: false })
+    clearTimeout(this.loginModeFlipTimer)
+    this.setState({
+      activeLocale: getLocale(),
+      modalFlipping: false,
+      pendingLoginMode: null,
+      pendingLocale: null,
+      pendingModalState: null
+    })
   }
 
   updateInputValue (evt) {
@@ -180,41 +230,45 @@ class LoginPage extends Component {
     })
   }
 
-  renderCredentialLoginSection (authWindowStatus, userSessionStatus) {
+  renderCredentialLoginSection (authWindowStatus, userSessionStatus, locale = this.state.activeLocale, isInteractive = true) {
     return (
       <div>
         { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">{ t('login.tokenInvalid') }</Alert>
+          ? <Alert bsStyle="warning" className="login-alert">{ this.translate(locale, 'login.tokenInvalid') }</Alert>
           : null
         }
         <Button
-          autoFocus
+          autoFocus={ isInteractive }
           className={ authWindowStatus === 'OFF' ? 'modal-button' : 'modal-button-disabled' }
+          disabled={ !isInteractive }
           onClick={ this.handleLoginClicked.bind(this) }>
-          { t('login.githubLogin') }
+          { this.translate(locale, 'login.githubLogin') }
         </Button>
       </div>
     )
   }
 
-  renderTokenLoginSection (userSessionStatus) {
+  renderTokenLoginSection (userSessionStatus, locale = this.state.activeLocale, isInteractive = true) {
     return (
       <form>
         { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">{ t('login.tokenInvalid') }</Alert>
+          ? <Alert bsStyle="warning" className="login-alert">{ this.translate(locale, 'login.tokenInvalid') }</Alert>
           : null
         }
         <input
           className="form-control"
-          placeholder={ t('login.tokenPlaceholder') }
+          placeholder={ this.translate(locale, 'login.tokenPlaceholder') }
+          readOnly={ !isInteractive }
+          tabIndex={ isInteractive ? undefined : -1 }
           value={ this.state.inputTokenValue }
           onChange={ this.updateInputValue.bind(this) }
         />
         <Button
-          autoFocus
+          autoFocus={ isInteractive }
           className='modal-button'
+          disabled={ !isInteractive }
           onClick={ this.handleTokenLoginButtonClicked.bind(this, this.state.inputTokenValue) }>
-          { t('login.tokenLogin') }
+          { this.translate(locale, 'login.tokenLogin') }
         </Button>
       </form>
     )
@@ -229,18 +283,19 @@ class LoginPage extends Component {
       loggedInUserName === null || loggedInUserName === 'null')
   }
 
-  renderLoginModeSwitch () {
+  renderLoginModeSwitch (loginMode = this.state.loginMode, locale = this.state.activeLocale, isInteractive = true) {
     if (!this.shouldRenderLoginModeSwitch()) return null
 
-    const label = this.state.loginMode === LoginModeEnum.CREDENTIALS
-      ? t('login.switchToToken')
-      : t('login.switchToCredentials')
-    const icon = this.state.loginMode === LoginModeEnum.CREDENTIALS ? '🔑' : '👤'
+    const label = loginMode === LoginModeEnum.CREDENTIALS
+      ? this.translate(locale, 'login.switchToToken')
+      : this.translate(locale, 'login.switchToCredentials')
+    const icon = loginMode === LoginModeEnum.CREDENTIALS ? '🔑' : '👤'
 
     return (
       <button
         aria-label={ label }
         className='login-header-icon login-mode-switch'
+        disabled={ !isInteractive }
         onClick={ this.handleLoginModeSwitched.bind(this) }
         title={ label }
         type='button'>
@@ -249,20 +304,20 @@ class LoginPage extends Component {
     )
   }
 
-  renderHeaderActions () {
+  renderHeaderActions (loginMode = this.state.loginMode, locale = this.state.activeLocale, isInteractive = true) {
     return (
       <div className='login-header-actions'>
-        { this.renderLoginModeSwitch() }
-        { this.renderLanguageSelector() }
+        { this.renderLoginModeSwitch(loginMode, locale, isInteractive) }
+        { this.renderLanguageSelector(locale, isInteractive) }
       </div>
     )
   }
 
-  renderLoginModalBody () {
+  renderLoginModalBody (loginMode = this.state.loginMode, locale = this.state.activeLocale, isInteractive = true) {
     return (
-      <center className='login-modal-body-flipper'>
-        { this.renderAvatar() }
-        { this.renderControlSection() }
+      <center className='login-modal-body-content'>
+        { this.renderAvatar(loginMode) }
+        { this.renderControlSection(loginMode, locale, isInteractive) }
         { this.renderLoginStatus() }
       </center>
     )
@@ -288,9 +343,7 @@ class LoginPage extends Component {
     )
   }
 
-  renderAvatar () {
-    const { loginMode } = this.state
-
+  renderAvatar (loginMode = this.state.loginMode) {
     if (conf.get('avatar:type') === 'boring') {
       return <a href="https://github.com/hackjutsu/Lepton">
         <Avatar
@@ -317,21 +370,40 @@ class LoginPage extends Component {
     }
   }
 
+  renderModalFace (loginMode, locale, className, isInteractive = true) {
+    return (
+      <div className={ className } aria-hidden={ isInteractive ? undefined : true }>
+        <Modal.Header>
+          <Modal.Title className='login-modal-title' title={ this.translate(locale, 'login.title') }>
+            { this.translate(locale, 'login.title') }
+          </Modal.Title>
+          { this.renderHeaderActions(loginMode, locale, isInteractive) }
+        </Modal.Header>
+        <Modal.Body className='login-modal-body'>
+          { this.renderLoginModalBody(loginMode, locale, isInteractive) }
+        </Modal.Body>
+      </div>
+    )
+  }
+
   render () {
-    const className = this.state.modalFlipping
+    const { activeLocale, loginMode, modalFlipping, pendingLocale, pendingLoginMode } = this.state
+    const className = modalFlipping
       ? 'login-modal login-modal-flipping'
       : 'login-modal'
+    const backLoginMode = pendingLoginMode || loginMode
+    const backLocale = pendingLocale || activeLocale
 
     return (
       <div className={ className }>
         <Modal.Dialog bsSize='small'>
-          <Modal.Header>
-            <Modal.Title className='login-modal-title' title={ t('login.title') }>{ t('login.title') }</Modal.Title>
-            { this.renderHeaderActions() }
-          </Modal.Header>
-          <Modal.Body className='login-modal-body'>
-            { this.renderLoginModalBody() }
-          </Modal.Body>
+          <div className='login-modal-card'>
+            { this.renderModalFace(loginMode, activeLocale, 'login-modal-face login-modal-face-front', !modalFlipping) }
+            { modalFlipping
+              ? this.renderModalFace(backLoginMode, backLocale, 'login-modal-face login-modal-face-back', false)
+              : null
+            }
+          </div>
         </Modal.Dialog>
       </div>
     )

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -13,15 +13,67 @@
   }
 
   .modal-dialog {
-    perspective: 900px;
+    perspective: 1200px;
   }
 
   .modal-content {
     animation: login-modal-fade-in 180ms ease-out;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    height: 455px;
     margin-top: 100px;
-    min-height: 430px;
     opacity: 1;
+    overflow: visible;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
     transition: opacity 180ms ease-in;
+  }
+
+  .login-modal-card {
+    height: 100%;
+    position: relative;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    transform-origin: center center;
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
+    width: 100%;
+    will-change: transform;
+  }
+
+  &.login-modal-flipping .login-modal-card {
+    animation: login-modal-card-flip 520ms cubic-bezier(.22, .61, .36, 1) both;
+    pointer-events: none;
+  }
+
+  .login-modal-face {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, .2);
+    border-radius: 6px;
+    box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
+    height: 100%;
+    left: 0;
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
+    width: 100%;
+  }
+
+  .login-modal-face-front {
+    -webkit-transform: rotateY(0deg);
+    transform: rotateY(0deg);
+  }
+
+  .login-modal-face-back {
+    -webkit-transform: rotateY(180deg);
+    transform: rotateY(180deg);
   }
 
   .modal-header {
@@ -106,23 +158,13 @@
   }
 
   .login-modal-body {
-    min-height: 356px;
+    height: 394px;
     overflow: hidden;
     perspective: 900px;
   }
 
-  .login-modal-body-flipper {
-    backface-visibility: hidden;
+  .login-modal-body-content {
     display: block;
-    min-height: 326px;
-    transform: translateZ(0);
-    transform-origin: center center;
-    transform-style: preserve-3d;
-    will-change: transform;
-  }
-
-  &.login-modal-flipping .login-modal-body-flipper {
-    animation: login-modal-horizontal-flip 320ms cubic-bezier(.2, .7, .2, 1) both;
   }
 
   .button-group-modal {
@@ -190,26 +232,32 @@
   }
 }
 
-@keyframes login-modal-horizontal-flip {
+@keyframes login-modal-card-flip {
   0% {
+    -webkit-transform: translateZ(0) rotateY(0deg);
     transform: translateZ(0) rotateY(0deg);
-  }
-
-  47% {
-    transform: translateZ(0) rotateY(88deg);
-  }
-
-  53% {
-    transform: translateZ(0) rotateY(88deg);
   }
 
   100% {
+    -webkit-transform: translateZ(0) rotateY(-180deg);
+    transform: translateZ(0) rotateY(-180deg);
+  }
+}
+
+@-webkit-keyframes login-modal-card-flip {
+  0% {
+    -webkit-transform: translateZ(0) rotateY(0deg);
     transform: translateZ(0) rotateY(0deg);
+  }
+
+  100% {
+    -webkit-transform: translateZ(0) rotateY(-180deg);
+    transform: translateZ(0) rotateY(-180deg);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .login-modal.login-modal-flipping .login-modal-body-flipper {
+  .login-modal.login-modal-flipping .login-modal-card {
     animation: none;
   }
 }

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -18,49 +18,60 @@
 
   .modal-content {
     animation: login-modal-fade-in 180ms ease-out;
-    backface-visibility: hidden;
     margin-top: 100px;
-    min-height: 420px;
+    min-height: 430px;
     opacity: 1;
-    transform-origin: center center;
-    transform-style: preserve-3d;
     transition: opacity 180ms ease-in;
-    will-change: transform;
-  }
-
-  &.login-modal-flipping .modal-content {
-    animation: login-modal-horizontal-flip 320ms ease-in-out;
   }
 
   .modal-header {
     position: relative;
   }
 
-  .login-mode-switch {
-    -webkit-app-region: no-drag;
-    color: gray;
-    font-size: 12px;
-    font-style: italic;
-    left: 50%;
-    line-height: 24px;
-    max-width: 170px;
+  .login-modal-title {
     overflow: hidden;
-    position: absolute;
-    text-align: center;
-    text-decoration: underline;
+    padding-right: 74px;
     text-overflow: ellipsis;
-    top: 23px;
-    transform: translateX(-50%);
     white-space: nowrap;
+  }
+
+  .login-header-actions {
+    -webkit-app-region: no-drag;
+    position: absolute;
+    right: 18px;
+    top: 20px;
+    display: flex;
+    gap: 8px;
+  }
+
+  .login-header-icon {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: #555;
+    cursor: pointer;
+    display: flex;
+    filter: grayscale(1);
+    font-size: 16px;
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    opacity: .72;
+    padding: 0;
+    width: 24px;
+  }
+
+  .login-header-icon:hover,
+  .login-header-icon:focus {
+    opacity: 1;
+    outline: none;
   }
 
   .login-language-selector {
     -webkit-app-region: no-drag;
     display: block;
     height: 24px;
-    position: absolute;
-    right: 18px;
-    top: 20px;
+    position: relative;
     width: 24px;
   }
 
@@ -92,6 +103,26 @@
     width: 200px;
     height: 200px;
     margin: 5px;
+  }
+
+  .login-modal-body {
+    min-height: 356px;
+    overflow: hidden;
+    perspective: 900px;
+  }
+
+  .login-modal-body-flipper {
+    backface-visibility: hidden;
+    display: block;
+    min-height: 326px;
+    transform: translateZ(0);
+    transform-origin: center center;
+    transform-style: preserve-3d;
+    will-change: transform;
+  }
+
+  &.login-modal-flipping .login-modal-body-flipper {
+    animation: login-modal-horizontal-flip 320ms cubic-bezier(.2, .7, .2, 1) both;
   }
 
   .button-group-modal {
@@ -161,28 +192,24 @@
 
 @keyframes login-modal-horizontal-flip {
   0% {
-    opacity: 1;
-    transform: rotateY(0deg);
+    transform: translateZ(0) rotateY(0deg);
   }
 
-  49% {
-    opacity: .78;
-    transform: rotateY(90deg);
+  47% {
+    transform: translateZ(0) rotateY(88deg);
   }
 
-  50% {
-    opacity: .78;
-    transform: rotateY(-90deg);
+  53% {
+    transform: translateZ(0) rotateY(88deg);
   }
 
   100% {
-    opacity: 1;
-    transform: rotateY(0deg);
+    transform: translateZ(0) rotateY(0deg);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .login-modal.login-modal-flipping .modal-content {
+  .login-modal.login-modal-flipping .login-modal-body-flipper {
     animation: none;
   }
 }

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -12,20 +12,46 @@
     background: #808080;
   }
 
-  .modal-content {
-    animation: login-modal-fade-in 180ms ease-out;
-    margin-top: 100px;
-    min-height: 440px;
-    opacity: 1;
-    transition: opacity 180ms ease-in;
+  .modal-dialog {
+    perspective: 900px;
   }
 
-  &.login-modal-language-changing .modal-content {
-    opacity: 0;
+  .modal-content {
+    animation: login-modal-fade-in 180ms ease-out;
+    backface-visibility: hidden;
+    margin-top: 100px;
+    min-height: 420px;
+    opacity: 1;
+    transform-origin: center center;
+    transform-style: preserve-3d;
+    transition: opacity 180ms ease-in;
+    will-change: transform;
+  }
+
+  &.login-modal-flipping .modal-content {
+    animation: login-modal-horizontal-flip 320ms ease-in-out;
   }
 
   .modal-header {
     position: relative;
+  }
+
+  .login-mode-switch {
+    -webkit-app-region: no-drag;
+    color: gray;
+    font-size: 12px;
+    font-style: italic;
+    left: 50%;
+    line-height: 24px;
+    max-width: 170px;
+    overflow: hidden;
+    position: absolute;
+    text-align: center;
+    text-decoration: underline;
+    text-overflow: ellipsis;
+    top: 23px;
+    transform: translateX(-50%);
+    white-space: nowrap;
   }
 
   .login-language-selector {
@@ -102,7 +128,7 @@
     color: #888;
     font-size: 11px;
     line-height: 16px;
-    margin: 0 10px 18px 10px;
+    margin: 14px 10px 18px 10px;
     min-height: 16px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -130,5 +156,33 @@
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes login-modal-horizontal-flip {
+  0% {
+    opacity: 1;
+    transform: rotateY(0deg);
+  }
+
+  49% {
+    opacity: .78;
+    transform: rotateY(90deg);
+  }
+
+  50% {
+    opacity: .78;
+    transform: rotateY(-90deg);
+  }
+
+  100% {
+    opacity: 1;
+    transform: rotateY(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-modal.login-modal-flipping .modal-content {
+    animation: none;
   }
 }

--- a/app/containers/searchPage/index.js
+++ b/app/containers/searchPage/index.js
@@ -24,8 +24,9 @@ const logger = electronBridge.logger
 class SearchPage extends Component {
   constructor (props) {
     super(props)
+    const initialSearchQuery = props.initialSearchQuery || ''
     this.state = {
-      inputValue: '',
+      inputValue: initialSearchQuery,
       selectedIndex: 0,
       searchResults: []
     }
@@ -35,6 +36,11 @@ class SearchPage extends Component {
   componentDidMount () {
     const { searchIndex } = this.props
     searchIndex.initFuseSearch()
+    if (this.state.inputValue) {
+      this.setState({
+        searchResults: searchIndex.fuseSearch(this.state.inputValue)
+      })
+    }
   }
 
   selectPreGist () {
@@ -359,16 +365,18 @@ class SearchPage extends Component {
   renderSearchModalBody () {
     return (
       <div>
-        <input
-          type="text"
-          className='search-box'
-          placeholder={ t('search.placeholder') }
-          autoFocus
-          value={ this.state.inputValue }
-          onChange={ this.updateInputValue.bind(this) }
-          onKeyDown={ this.handleKeyDown.bind(this) }
-          onKeyUp={ this.queryInputValue.bind(this) }/>
-        { this.renderResultCount() }
+        <div className='search-header'>
+          <input
+            type="text"
+            className='search-box'
+            placeholder={ t('search.placeholder') }
+            autoFocus
+            value={ this.state.inputValue }
+            onChange={ this.updateInputValue.bind(this) }
+            onKeyDown={ this.handleKeyDown.bind(this) }
+            onKeyUp={ this.queryInputValue.bind(this) }/>
+          { this.renderResultCount() }
+        </div>
         <ul className='result-group'>
           { this.renderSearchResults() }
         </ul>

--- a/app/containers/searchPage/index.scss
+++ b/app/containers/searchPage/index.scss
@@ -5,11 +5,15 @@
     font-size: 13px;
   }
 
+  .search-header {
+    position: relative;
+  }
+
   .search-box {
     @extend .font-style-base;
     font-size: 16px;
     width: 100%;
-    padding: 10px;
+    padding: 10px 180px 10px 10px;
     border: 0;
     background: var(--bg-primary);
   }
@@ -28,7 +32,17 @@
 
   .search-result-count {
     @extend .font-style-base;
-    padding: 2px 14px 10px;
+    max-width: 160px;
+    overflow: hidden;
+    padding: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 14px;
+    text-align: right;
+    text-overflow: ellipsis;
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
     color: var(--text-secondary);
     font-size: 12px;
   }

--- a/app/index.js
+++ b/app/index.js
@@ -881,6 +881,7 @@ createRoot(document.getElementById('container')).render(
   <Provider store = { reduxStore }>
     <AppContainer
       searchIndex = { SearchIndex }
+      initialSearchQuery = { renderFixture ? renderFixture.initialSearchQuery : undefined }
       localPref = { localPref }
       updateLocalStorage = { updateLocalStorage }
       loggedInUserInfo = { getCachedUserInfo() }

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -360,6 +360,11 @@ function getFixtureOverrides (name) {
       }
     case 'search':
       return { searchWindowStatus: 'ON' }
+    case 'search-results':
+      return {
+        initialSearchQuery: 'fixture',
+        searchWindowStatus: 'ON'
+      }
     case 'active':
       return {}
     default:
@@ -370,10 +375,12 @@ function getFixtureOverrides (name) {
 export function getRenderFixture (name) {
   const overrides = getFixtureOverrides(name)
   if (!overrides) return null
+  const { initialSearchQuery, ...stateOverrides } = overrides
 
   return {
+    initialSearchQuery,
     name,
     searchIndexRecords,
-    state: Object.assign({}, getBaseState(), overrides)
+    state: Object.assign({}, getBaseState(), stateOverrides)
   }
 }

--- a/app/utilities/i18n/index.js
+++ b/app/utilities/i18n/index.js
@@ -64,7 +64,12 @@ function interpolate (message, values) {
 }
 
 function t (key, values) {
-  const activeMessage = readPath(catalogs[activeLocale], key)
+  return translate(activeLocale, key, values)
+}
+
+function translate (locale, key, values) {
+  const normalizedLocale = normalizeLocale(locale)
+  const activeMessage = readPath(catalogs[normalizedLocale], key)
   const fallbackMessage = readPath(catalogs[DEFAULT_LOCALE], key)
   const message = activeMessage !== undefined ? activeMessage : fallbackMessage
   return interpolate(message !== undefined ? message : key, values)
@@ -82,5 +87,6 @@ module.exports = {
   configureI18n,
   getLocale,
   getSupportedLocales,
-  t
+  t,
+  translate
 }

--- a/main.js
+++ b/main.js
@@ -478,7 +478,7 @@ function setUpBridgeIpcHandlers () {
     nconf.set(key, persistedValue)
     writeConfigValue(key, persistedValue)
     setUpApplicationMenu()
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (key !== 'i18n:locale' && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.reload()
     }
     return persistedValue

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -3,6 +3,7 @@ const path = require('path')
 const { app, BrowserWindow } = require('electron')
 
 const repoRoot = path.resolve(__dirname, '../..')
+const loginModalFlipSettleMs = 700
 
 app.getAppPath = () => repoRoot
 
@@ -288,6 +289,106 @@ function assertLoginRendererState (state) {
   }
 }
 
+async function assertLoginModeSwitchKeepsModalHeight (window) {
+  const result = await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      const modalContent = document.querySelector('.login-modal .modal-content')
+      const switchButton = document.querySelector('.login-mode-switch')
+
+      function getHeight() {
+        return modalContent ? Math.round(modalContent.getBoundingClientRect().height) : null
+      }
+
+      if (!modalContent || !switchButton) {
+        resolve({
+          reason: 'missing modal content or mode switch',
+          before: getHeight(),
+          hasSwitch: Boolean(switchButton)
+        })
+        return
+      }
+
+      const before = getHeight()
+      switchButton.click()
+
+      setTimeout(() => {
+        const afterSwitch = getHeight()
+        const hasTokenInput = Boolean(document.querySelector('.login-modal input.form-control'))
+        const updatedSwitchButton = document.querySelector('.login-mode-switch')
+
+        if (updatedSwitchButton) updatedSwitchButton.click()
+
+        setTimeout(() => {
+          resolve({
+            afterSwitch,
+            before,
+            hasTokenInput,
+            restored: getHeight()
+          })
+        }, ${loginModalFlipSettleMs})
+      }, ${loginModalFlipSettleMs})
+    })
+  `, true)
+
+  if (!result.hasTokenInput) {
+    throw new Error(`Expected login mode switch to render the token form: ${JSON.stringify(result)}`)
+  }
+
+  if (Math.abs(result.before - result.afterSwitch) > 1 || Math.abs(result.before - result.restored) > 1) {
+    throw new Error(`Expected login modal height to stay fixed across mode switches: ${JSON.stringify(result)}`)
+  }
+}
+
+async function assertLoginLocaleSwitchRendersInPlace (window) {
+  const result = await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      const modalContent = document.querySelector('.login-modal .modal-content')
+      const languageSelector = document.querySelector('[data-role="language-selector"]')
+
+      function getHeight() {
+        return modalContent ? Math.round(modalContent.getBoundingClientRect().height) : null
+      }
+
+      if (!modalContent || !languageSelector) {
+        resolve({
+          reason: 'missing modal content or language selector',
+          before: getHeight(),
+          hasLanguageSelector: Boolean(languageSelector)
+        })
+        return
+      }
+
+      const before = getHeight()
+      const targetLocale = languageSelector.value === 'ja' ? 'en' : 'ja'
+      const expectedTitle = targetLocale === 'ja' ? 'ログイン' : 'Login'
+      languageSelector.value = targetLocale
+      languageSelector.dispatchEvent(new Event('change', { bubbles: true }))
+
+      setTimeout(() => {
+        resolve({
+          afterSwitch: getHeight(),
+          bodyText: document.body ? document.body.innerText : '',
+          expectedTitle,
+          selectedLocale: languageSelector.value,
+          targetLocale
+        })
+      }, ${loginModalFlipSettleMs})
+    })
+  `, true)
+
+  if (result.selectedLocale !== result.targetLocale) {
+    throw new Error(`Expected language selector to keep the selected locale: ${JSON.stringify(result)}`)
+  }
+
+  if (!result.bodyText || !result.bodyText.includes(result.expectedTitle)) {
+    throw new Error(`Expected login modal to render the selected locale in place: ${JSON.stringify(result)}`)
+  }
+
+  if (Math.abs(result.before - result.afterSwitch) > 1) {
+    throw new Error(`Expected login modal height to stay fixed across locale switches: ${JSON.stringify(result)}`)
+  }
+}
+
 function assertFixtureRendererState (state) {
   assertSharedRendererState(state)
   assertNoBlockingRendererEvents()
@@ -320,6 +421,8 @@ async function main () {
     } else {
       await waitForLoginUi(window)
       assertLoginRendererState(await getRendererState(window))
+      await assertLoginModeSwitchKeepsModalHeight(window)
+      await assertLoginLocaleSwitchRendersInPlace(window)
       await captureScreenshot(window, 'electron-render-smoke-success.png')
       console.log('electron render smoke test passed')
     }

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -131,6 +131,8 @@ async function getRendererState (window) {
       const expectedSelector = ${JSON.stringify(expectedSelector)}
       const appBounds = appContainer ? appContainer.getBoundingClientRect() : null
       const languageSelector = document.querySelector('[data-role="language-selector"]')
+      const languageSelectorLabel = document.querySelector('.login-language-selector')
+      const loginModeSwitch = document.querySelector('.login-mode-switch')
       const images = Array.from(document.images).map(image => {
         const bounds = image.getBoundingClientRect()
         return {
@@ -159,6 +161,14 @@ async function getRendererState (window) {
         languageOptions: languageSelector
           ? Array.from(languageSelector.options).map(option => option.value)
           : [],
+        languageSelectorTitle: languageSelectorLabel ? languageSelectorLabel.getAttribute('title') : '',
+        loginModeSwitch: loginModeSwitch
+          ? {
+              ariaLabel: loginModeSwitch.getAttribute('aria-label') || '',
+              text: loginModeSwitch.innerText || '',
+              title: loginModeSwitch.getAttribute('title') || ''
+            }
+          : null,
         images,
         appBounds: appBounds ? {
           width: appBounds.width,
@@ -259,6 +269,22 @@ function assertLoginRendererState (state) {
   const expectedLocales = ['en', 'es', 'fr', 'ja', 'ko', 'zh-Hans', 'zh-Hant']
   if (expectedLocales.some(locale => !state.languageOptions.includes(locale))) {
     throw new Error(`Expected language selector options were not visible: ${JSON.stringify(state.languageOptions)}`)
+  }
+
+  if (!state.loginModeSwitch) {
+    throw new Error(`Expected login mode switch icon to be visible: ${JSON.stringify(state)}`)
+  }
+
+  if (!state.loginModeSwitch.title || state.loginModeSwitch.title !== state.loginModeSwitch.ariaLabel) {
+    throw new Error(`Expected login mode switch to expose its tooltip as the accessible label: ${JSON.stringify(state.loginModeSwitch)}`)
+  }
+
+  if ((state.loginModeSwitch.text || '').trim().length > 3) {
+    throw new Error(`Expected login mode switch to render as a compact icon: ${JSON.stringify(state.loginModeSwitch)}`)
+  }
+
+  if (!state.languageSelectorTitle) {
+    throw new Error(`Expected compact language selector to expose a tooltip: ${JSON.stringify(state)}`)
   }
 }
 

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -64,6 +64,11 @@ const RENDER_FIXTURES = [
     text: ''
   },
   {
+    name: 'search-results',
+    selector: '.search-modal .search-result-count',
+    text: '6 snippets found|React 19 render fixture'
+  },
+  {
     name: 'delete',
     selector: '.modal-footer .btn-danger',
     text: 'Delete the gist?'

--- a/tests/utilities/i18n.test.js
+++ b/tests/utilities/i18n.test.js
@@ -4,7 +4,8 @@ import {
   configureI18n,
   getLocale,
   getSupportedLocales,
-  t
+  t,
+  translate
 } from '../../app/utilities/i18n'
 import builderConfig from '../../electron-builder'
 import { getElectronLanguages } from '../../configs/electronLanguages'
@@ -94,6 +95,13 @@ describe('i18n utilities', () => {
   it('interpolates named values', () => {
     configureI18n('en')
     expect(t('login.continueAs', { username: 'octocat' })).toBe('Continue as octocat')
+  })
+
+  it('translates a specific locale without changing the active locale', () => {
+    configureI18n('en')
+    expect(translate('ja', 'login.title')).toBe('ログイン')
+    expect(getLocale()).toBe('en')
+    expect(t('login.title')).toBe('Login')
   })
 
   it('falls back to English for missing keys in a supported locale', () => {


### PR DESCRIPTION
## Summary

Applies the requested UI polish for the search and login modals.

- Moves the search result count to the top-right of the search input row.
- Moves the login mode switch into the login modal header, centered and slightly lower for visual balance.
- Uses a shared horizontal flip animation for switching between token/credentials and for language changes.
- Sets the login modal height to leave room for one-line status logs and adds spacing above the log/status line.
- Adds a populated search render fixture so smoke tests cover the result-count placement.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`

## Render verification

- Login status spacing: `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-QT4uvO/electron-render-login-error-log-success.png`
- Search with results: `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-jp4ksq/electron-render-search-results-success.png`