### PR TITLE
[codex] Add configurable default zoom percent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,7 @@ Register your application at https://github.com/settings/applications/new
 - **Styling**: Uses Sass with component-level SCSS files
 - **State Management**: Redux store handles application state, actions use Redux Thunk for async operations
 - **Shortcuts**: Customizable keyboard shortcuts defined in config, registered via electron-localshortcut
+- **Packaged Runtime Files**: `electron-builder.js` allowlists the main-process runtime files shipped in packaged apps. When `main.js`, `preload.js`, or another packaged runtime file starts requiring a new local helper, add that helper path to `mainRuntimeAppFiles` in `electron-builder.js` and update `tests/configs/electronBuilder.test.js`.
 - **Locales/i18n**: Adding a UI locale is not just a renderer code change. Update the locale catalog and package configuration together so packaged Electron builds keep the right Chromium locale resources.
 
 ### Adding A Locale
@@ -227,6 +228,7 @@ When working with this codebase:
 - Focus code changes on the `/app` directory, `/configs`, `main.js`, and configuration files
 - Avoid searching or reading files in `node_modules/`, `/bundle`, `/build`, `/dist` directories unless absolutely necessary
 - Avoid bypassing the global logger for auth-related values; logger methods automatically redact known token and secret patterns
+- When adding new files used by the Electron main process at packaged-app startup, update `electron-builder.js` so packaged builds include them; otherwise `npm run test:packaged-smoke` can fail even when dev builds work.
 - Do not reintroduce `@electron/remote`, `nodeIntegration`, renderer `require`, or renderer `process` access. Add preload bridge methods instead.
 - Do not reintroduce Redux Form or other React 19-incompatible form patterns.
 - Do not use `ReactDOM.render`; use the existing React 19 root setup.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Lepton's can be customized by `<home_dir>/.leptonrc`! You can find its exact pat
 - Logger
 - Proxy
 - Shortcuts
+- Zoom
 - Enterprise
 - Notifications
 - Interface language (`i18n.locale`: `en`, `es`, `fr`, `ja`, `ko`, `tr`, `zh-Hans`, or `zh-Hant`)

--- a/app/utilities/zoom/index.js
+++ b/app/utilities/zoom/index.js
@@ -1,0 +1,52 @@
+const DEFAULT_ZOOM_PERCENT = 100
+const ELECTRON_ZOOM_STEP = 1.2
+
+function parseZoomPercent (value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : null
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim()
+    if (trimmedValue.length === 0) {
+      return null
+    }
+
+    const parsedValue = Number(trimmedValue)
+    return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : null
+  }
+
+  return null
+}
+
+function normalizeZoomPercent (value) {
+  const zoomPercent = parseZoomPercent(value)
+  return zoomPercent === null ? DEFAULT_ZOOM_PERCENT : zoomPercent
+}
+
+function zoomPercentToLevel (percent) {
+  return Math.log(percent / 100) / Math.log(ELECTRON_ZOOM_STEP)
+}
+
+function applyDefaultZoomPercent ({ webContents, percent, logger }) {
+  const zoomPercent = parseZoomPercent(percent)
+  const normalizedZoomPercent = zoomPercent === null ? DEFAULT_ZOOM_PERCENT : zoomPercent
+
+  if (zoomPercent === null && percent !== undefined && logger && typeof logger.warn === 'function') {
+    logger.warn(`[zoom] Invalid default zoom percent ${JSON.stringify(percent)}; using ${DEFAULT_ZOOM_PERCENT}`)
+  }
+
+  if (!webContents || typeof webContents.setZoomLevel !== 'function') {
+    return false
+  }
+
+  webContents.setZoomLevel(zoomPercentToLevel(normalizedZoomPercent))
+  return true
+}
+
+module.exports = {
+  DEFAULT_ZOOM_PERCENT,
+  normalizeZoomPercent,
+  zoomPercentToLevel,
+  applyDefaultZoomPercent
+}

--- a/configs/defaultConfig.js
+++ b/configs/defaultConfig.js
@@ -47,6 +47,9 @@ module.exports = {
         "success": true,
         "failure": true
     },
+    "zoom": {
+        "percent": 100
+    },
     "shortcuts": {
         "keyShortcutForSearch": "Shift+Space",
         "keyNewGist": "CommandOrControl+N",

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -40,7 +40,8 @@ const mainRuntimeAppFiles = [
   'app/utilities/logging/**',
   'app/utilities/menu/**',
   'app/utilities/startAtLogin/**',
-  'app/utilities/updatePolicy.js'
+  'app/utilities/updatePolicy.js',
+  'app/utilities/zoom/**'
 ]
 
 // Packages in this list are renderer-only dependencies that webpack already

--- a/main.js
+++ b/main.js
@@ -38,6 +38,7 @@ const {
 const {
   clearGitHubAuthWindowStorageAndDestroy
 } = require('./app/utilities/auth/githubAuthWindow')
+const { applyDefaultZoomPercent } = require('./app/utilities/zoom')
 
 const logger = createMainLogger()
 const electronLocalStorage = createElectronLocalStorage({
@@ -190,6 +191,11 @@ function createWindow (autoLogin) {
   })
 
   mainWindow.once('ready-to-show', () => {
+    applyDefaultZoomPercent({
+      webContents: mainWindow.webContents,
+      percent: nconf.get('zoom:percent'),
+      logger
+    })
     mainWindow.show()
     console.timeEnd('init')
     autoUpdater.on('error', data => {

--- a/tests/configs/electronBuilder.test.js
+++ b/tests/configs/electronBuilder.test.js
@@ -12,7 +12,8 @@ describe('electron-builder distribution config', () => {
   it('packages main-process runtime files used at startup', () => {
     expect(builderConfig.files).toEqual(expect.arrayContaining([
       'app/utilities/accessTokenStorage.js',
-      'app/utilities/updatePolicy.js'
+      'app/utilities/updatePolicy.js',
+      'app/utilities/zoom/**'
     ]))
   })
 

--- a/tests/utilities/zoom.test.js
+++ b/tests/utilities/zoom.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaultZoomPercent, normalizeZoomPercent, zoomPercentToLevel } from '../../app/utilities/zoom'
+
+describe('zoom utilities', () => {
+  it('normalizes numeric zoom percentages', () => {
+    expect(normalizeZoomPercent(100)).toBe(100)
+    expect(normalizeZoomPercent(125)).toBe(125)
+    expect(normalizeZoomPercent('80')).toBe(80)
+  })
+
+  it('falls back to 100 percent for invalid zoom percentages', () => {
+    expect(normalizeZoomPercent('')).toBe(100)
+    expect(normalizeZoomPercent('large')).toBe(100)
+    expect(normalizeZoomPercent(0)).toBe(100)
+    expect(normalizeZoomPercent(Number.NaN)).toBe(100)
+  })
+
+  it('converts percentages to Electron zoom levels', () => {
+    expect(zoomPercentToLevel(100)).toBe(0)
+    expect(zoomPercentToLevel(120)).toBeCloseTo(1)
+    expect(zoomPercentToLevel(144)).toBeCloseTo(2)
+  })
+
+  it('applies the configured zoom percent to webContents', () => {
+    const webContents = { setZoomLevel: vi.fn() }
+
+    expect(applyDefaultZoomPercent({ webContents, percent: '120' })).toBe(true)
+
+    expect(webContents.setZoomLevel).toHaveBeenCalledWith(1)
+  })
+
+  it('logs and uses the default zoom percent when config is invalid', () => {
+    const webContents = { setZoomLevel: vi.fn() }
+    const logger = { warn: vi.fn() }
+
+    expect(applyDefaultZoomPercent({ webContents, percent: 'large', logger })).toBe(true)
+
+    expect(webContents.setZoomLevel).toHaveBeenCalledWith(0)
+    expect(logger.warn).toHaveBeenCalledWith('[zoom] Invalid default zoom percent "large"; using 100')
+  })
+})

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -56,6 +56,9 @@ The file is not generated automatically. Create it if you want to override the d
     "success": true,
     "failure": true
   },
+  "zoom": {
+    "percent": 100
+  },
   "shortcuts": {
     "keyShortcutForSearch": "Shift+Space",
     "keyNewGist": "CommandOrControl+N",
@@ -100,6 +103,7 @@ The file is not generated automatically. Create it if you want to override the d
 | | `avatarUrl` | `""` | Optional avatar image URL for GitHub Enterprise users. |
 | `notifications` | `success` | `true` | Show notifications for successful actions. |
 | | `failure` | `true` | Show notifications for failed actions. |
+| `zoom` | `percent` | `100` | Default page zoom percentage. `100` is original size; use values like `80`, `120`, or `150`. |
 | `shortcuts` | `keyShortcutForSearch` | `Shift+Space` | Open snippet metadata and downloaded-content search. |
 | | `keyNewGist` | `CommandOrControl+N` | Create a snippet. |
 | | `keyEditGist` | `CommandOrControl+E` | Edit the selected snippet. |


### PR DESCRIPTION
## Summary

Adds a default page zoom setting that can be configured from `.leptonrc` as a percentage.

- Adds `zoom.percent` with a default of `100`.
- Converts user-facing percentages, such as `80`, `120`, or `150`, into Electron `setZoomLevel` values internally.
- Applies the configured zoom before the main window is shown.
- Packages the new main-process zoom helper in Electron builds.
- Documents the new setting and adds focused unit coverage for parsing, fallback behavior, conversion, and packaged runtime inclusion.
- Updates `AGENTS.md` to remind future agents to add new main-process runtime helper files to `electron-builder.js` and the matching builder config test.

## Why

Issue #531 asks for a configurable default zoom level. Electron's native zoom level values are not intuitive for users, so this PR exposes the setting as a percentage while keeping Electron-specific conversion inside a small utility.

## Validation

- `git diff --check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:packaged-smoke`
- `npm start` with `LEPTON_RENDER_FIXTURE=active` and an isolated `.leptonrc` containing `"zoom": { "percent": 120 }`; verified the fixture-backed Lepton UI rendered visibly and scaled without a blank window.
- GitHub Actions CI run 366 passed: `lint-test-build`, `electron-smoke`, and `packaged-smoke` before the AGENTS.md-only follow-up commit.

## Notes

This does not change or add configurable zoom shortcuts; it only adds the default startup zoom percentage.