### PR TITLE
Release v2.0.0-beta.5

### DIFF
--- a/license.json
+++ b/license.json
@@ -134,7 +134,7 @@
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "licenseFile": "node_modules/@types/use-sync-external-store/LICENSE"
     },
-    "Lepton@2.0.0-beta.4": {
+    "Lepton@2.0.0-beta.5": {
         "licenses": "MIT",
         "repository": "https://github.com/hackjutsu/Lepton",
         "licenseFile": "LICENSE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Bump Lepton to 2.0.0-beta.5.
- Update package-lock root version metadata.
- Regenerate license.json so the app license entry matches beta.5.

## Validation

- npm run lint
- npm test
- npm run test:smoke
- git diff --check

## Release note draft

User-facing changes since v2.0.0-beta.4:

- Cache GitHub access tokens with Electron safeStorage when available.
- Polish the login modal, login progress/error messaging, and search result count layout.
- Add configurable default zoom percent.
- Clean up duplicate release documentation.