### PR TITLE
[codex] Clear stale login status on logout

### DIFF
--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -324,8 +324,11 @@ class LoginPage extends Component {
   }
 
   renderLoginStatus () {
-    const { loginStatus } = this.props
+    const { authWindowStatus, loginStatus, userSessionStatus } = this.props
     if (!loginStatus || !loginStatus.message) return null
+
+    const isIdleLoggedOut = userSessionStatus === 'INACTIVE' && authWindowStatus === 'OFF'
+    if (isIdleLoggedOut && loginStatus.level !== 'error') return null
 
     const logFileUrl = getFileUrl(loginStatus.logFilePath)
     const className = loginStatus.level === 'error'

--- a/app/reducers/reducer_login_status.js
+++ b/app/reducers/reducer_login_status.js
@@ -1,4 +1,4 @@
-import { UPDATE_LOGIN_STATUS } from '../actions'
+import { LOGOUT_USER_SESSION, UPDATE_LOGIN_STATUS } from '../actions'
 
 const DEFAULT_LOGIN_STATUS = {
   message: '',
@@ -8,6 +8,8 @@ const DEFAULT_LOGIN_STATUS = {
 
 export default function (state = DEFAULT_LOGIN_STATUS, action) {
   switch (action.type) {
+    case LOGOUT_USER_SESSION:
+      return DEFAULT_LOGIN_STATUS
     case UPDATE_LOGIN_STATUS:
       return Object.assign({}, DEFAULT_LOGIN_STATUS, action.payload || {})
     default:

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -316,6 +316,17 @@ function getFixtureOverrides (name) {
           activeStatus: 'INACTIVE'
         }
       }
+    case 'login-stale-success-logged-out':
+      return {
+        loginStatus: {
+          message: 'Signed in.',
+          level: 'info',
+          logFilePath: null
+        },
+        userSession: {
+          activeStatus: 'INACTIVE'
+        }
+      }
     case 'login-progress':
       return {
         loginStatus: {

--- a/tests/reducers/core.test.js
+++ b/tests/reducers/core.test.js
@@ -102,5 +102,11 @@ describe('core reducers', () => {
       level: 'info',
       logFilePath: null
     })
+    expect(loginStatus({ message: 'Signed in.', level: 'info', logFilePath: null },
+      logoutUserSession())).toEqual({
+      message: '',
+      level: 'info',
+      logFilePath: null
+    })
   })
 })

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -403,6 +403,55 @@ function assertFixtureRendererState (state) {
   if (missingText) {
     throw new Error(`Expected fixture UI text "${missingText}" was not visible. Body text: ${state.bodyText}`)
   }
+
+  assertForbiddenFixtureTextAbsent(state)
+}
+
+function assertForbiddenFixtureTextAbsent (state) {
+  const forbiddenTexts = (process.env.LEPTON_SMOKE_FORBIDDEN_TEXT || '').split('|').filter(Boolean)
+  const visibleForbiddenText = forbiddenTexts.find(text => state.bodyText.includes(text))
+  if (visibleForbiddenText) {
+    throw new Error(`Forbidden fixture UI text "${visibleForbiddenText}" was visible. Body text: ${state.bodyText}`)
+  }
+}
+
+async function assertFixtureLoginModeSwitch (window) {
+  if (process.env.LEPTON_SMOKE_SWITCH_LOGIN_MODE !== '1') return
+
+  const result = await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      const switchButton = document.querySelector('.login-mode-switch')
+
+      if (!switchButton) {
+        resolve({
+          reason: 'missing login mode switch',
+          bodyText: document.body ? document.body.innerText : ''
+        })
+        return
+      }
+
+      switchButton.click()
+
+      setTimeout(() => {
+        resolve({
+          bodyText: document.body ? document.body.innerText : '',
+          hasTokenInput: Boolean(document.querySelector('.login-modal input.form-control'))
+        })
+      }, ${loginModalFlipSettleMs})
+    })
+  `, true)
+
+  if (!result.hasTokenInput) {
+    throw new Error(`Expected fixture login mode switch to render the token form: ${JSON.stringify(result)}`)
+  }
+
+  const expectedTexts = (process.env.LEPTON_SMOKE_AFTER_SWITCH_TEXT || '').split('|').filter(Boolean)
+  const missingText = expectedTexts.find(text => !result.bodyText.includes(text))
+  if (missingText) {
+    throw new Error(`Expected fixture UI text "${missingText}" after login mode switch was not visible. Body text: ${result.bodyText}`)
+  }
+
+  assertForbiddenFixtureTextAbsent(result)
 }
 
 async function main () {
@@ -416,6 +465,7 @@ async function main () {
     if (process.env.LEPTON_RENDER_FIXTURE) {
       await waitForFixtureUi(window)
       assertFixtureRendererState(await getRendererState(window))
+      await assertFixtureLoginModeSwitch(window)
       await captureScreenshot(window, `electron-render-${process.env.LEPTON_RENDER_FIXTURE}-success.png`)
       console.log(`electron render fixture smoke test passed: ${process.env.LEPTON_RENDER_FIXTURE}`)
     } else {

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -117,6 +117,14 @@ const RENDER_FIXTURES = [
     name: 'login-error-log',
     selector: '.login-status-line a[href="file:///tmp/lepton-login.log"]',
     text: 'Sign-in failed.|See log'
+  },
+  {
+    name: 'login-stale-success-logged-out',
+    selector: '.login-modal',
+    text: 'Login|GitHub Login',
+    forbiddenText: 'Signed in.',
+    switchLoginMode: true,
+    switchText: 'Token Login'
   }
 ]
 
@@ -134,6 +142,9 @@ function runSmokeProcess (tempHome, options) {
     const env = Object.assign({}, process.env, {
       ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
       LEPTON_SMOKE_ARTIFACT_DIR: tempHome.root,
+      LEPTON_SMOKE_AFTER_SWITCH_TEXT: options.switchText || '',
+      LEPTON_SMOKE_FORBIDDEN_TEXT: options.forbiddenText || '',
+      LEPTON_SMOKE_SWITCH_LOGIN_MODE: options.switchLoginMode ? '1' : '',
       LEPTON_SMOKE_EXPECTED_TEXT: options.expectedText,
       XDG_CONFIG_HOME: tempHome.configHome
     })
@@ -192,8 +203,11 @@ async function main () {
   for (const fixture of RENDER_FIXTURES) {
     await runSmokeProcess(createTempHome('en'), {
       expectedSelector: fixture.selector,
+      forbiddenText: fixture.forbiddenText,
       expectedText: fixture.text,
-      renderFixture: fixture.name
+      renderFixture: fixture.name,
+      switchLoginMode: fixture.switchLoginMode,
+      switchText: fixture.switchText
     })
   }
 }


### PR DESCRIPTION
## Summary

Keeps the logged-out login modal status line blank instead of showing stale success text.

- Reset `loginStatus` on `LOGOUT_USER_SESSION`.
- Suppress non-error login status text when the session is idle/logged out and no auth window is active.
- Add reducer coverage for the stale `Signed in.` message after logout.
- Add an Electron smoke fixture that intentionally renders `INACTIVE` session state with stale `Signed in.` status. It verifies the credentials screen is blank, switches to token login, and verifies the token screen is blank too.

## Root Cause

`loginStatus` is separate Redux state from `userSession`. Logout reset `userSession` to `INACTIVE`, but left the previous login status message untouched, so a successful sign-in message could reappear on the logged-out login modal.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:smoke`
- `git diff --check`

Render smoke screenshot for the stale-success token-login fixture: `/var/folders/hs/zzn3y99s1w5dfvgmb1h21zh40000gn/T/lepton-smoke-9axrxH/electron-render-login-stale-success-logged-out-success.png`