### PR TITLE
[codex] Speed up login header tooltips

### DIFF
--- a/app/containers/languageSelector/index.js
+++ b/app/containers/languageSelector/index.js
@@ -39,7 +39,7 @@ class LanguageSelector extends Component {
     const labelClassName = `${className || ''}${compact ? ' language-selector-compact' : ''}`.trim()
     const label = displayLocale ? translate(displayLocale, 'i18n.language') : t('i18n.language')
     return (
-      <label className={ labelClassName } title={ compact ? label : undefined }>
+      <label className={ labelClassName } data-tooltip={ compact ? label : undefined }>
         <span aria-hidden={ compact ? true : undefined }>{ compact ? '🌐' : label }</span>
         <select
           aria-label={ label }

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -191,7 +191,7 @@ class LoginPage extends Component {
   renderLanguageSelector (locale = this.state.activeLocale, isInteractive = true) {
     return (
       <LanguageSelector
-        className='login-language-selector'
+        className='login-language-selector login-header-tooltip'
         compact
         disabled={ !isInteractive }
         displayLocale={ locale }
@@ -294,10 +294,10 @@ class LoginPage extends Component {
     return (
       <button
         aria-label={ label }
-        className='login-header-icon login-mode-switch'
+        className='login-header-icon login-mode-switch login-header-tooltip'
+        data-tooltip={ label }
         disabled={ !isInteractive }
         onClick={ this.handleLoginModeSwitched.bind(this) }
-        title={ label }
         type='button'>
         <span aria-hidden='true'>{ icon }</span>
       </button>

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -119,6 +119,39 @@
     outline: none;
   }
 
+  .login-header-tooltip {
+    position: relative;
+  }
+
+  .login-header-tooltip::after {
+    background: rgba(40, 40, 40, .96);
+    border-radius: 3px;
+    color: #fff;
+    content: attr(data-tooltip);
+    font-size: 11px;
+    font-style: normal;
+    font-weight: normal;
+    left: 50%;
+    line-height: 1.3;
+    opacity: 0;
+    padding: 4px 7px;
+    pointer-events: none;
+    position: absolute;
+    top: 32px;
+    transform: translateX(-50%) translateY(-2px);
+    transition: opacity 80ms ease, transform 80ms ease;
+    transition-delay: 120ms;
+    white-space: nowrap;
+    z-index: 5;
+  }
+
+  .login-header-tooltip:hover::after,
+  .login-header-tooltip:focus::after,
+  .login-header-tooltip:focus-within::after {
+    opacity: .96;
+    transform: translateX(-50%) translateY(0);
+  }
+
   .login-language-selector {
     -webkit-app-region: no-drag;
     display: block;

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -162,10 +162,12 @@ async function getRendererState (window) {
         languageOptions: languageSelector
           ? Array.from(languageSelector.options).map(option => option.value)
           : [],
+        languageSelectorTooltip: languageSelectorLabel ? languageSelectorLabel.getAttribute('data-tooltip') : '',
         languageSelectorTitle: languageSelectorLabel ? languageSelectorLabel.getAttribute('title') : '',
         loginModeSwitch: loginModeSwitch
           ? {
               ariaLabel: loginModeSwitch.getAttribute('aria-label') || '',
+              dataTooltip: loginModeSwitch.getAttribute('data-tooltip') || '',
               text: loginModeSwitch.innerText || '',
               title: loginModeSwitch.getAttribute('title') || ''
             }
@@ -276,17 +278,79 @@ function assertLoginRendererState (state) {
     throw new Error(`Expected login mode switch icon to be visible: ${JSON.stringify(state)}`)
   }
 
-  if (!state.loginModeSwitch.title || state.loginModeSwitch.title !== state.loginModeSwitch.ariaLabel) {
-    throw new Error(`Expected login mode switch to expose its tooltip as the accessible label: ${JSON.stringify(state.loginModeSwitch)}`)
+  if (state.loginModeSwitch.title) {
+    throw new Error(`Expected login mode switch to avoid native delayed title tooltips: ${JSON.stringify(state.loginModeSwitch)}`)
+  }
+
+  if (!state.loginModeSwitch.dataTooltip || state.loginModeSwitch.dataTooltip !== state.loginModeSwitch.ariaLabel) {
+    throw new Error(`Expected login mode switch to expose a custom tooltip matching its accessible label: ${JSON.stringify(state.loginModeSwitch)}`)
   }
 
   if ((state.loginModeSwitch.text || '').trim().length > 3) {
     throw new Error(`Expected login mode switch to render as a compact icon: ${JSON.stringify(state.loginModeSwitch)}`)
   }
 
-  if (!state.languageSelectorTitle) {
-    throw new Error(`Expected compact language selector to expose a tooltip: ${JSON.stringify(state)}`)
+  if (state.languageSelectorTitle) {
+    throw new Error(`Expected compact language selector to avoid native delayed title tooltips: ${JSON.stringify(state)}`)
   }
+
+  if (!state.languageSelectorTooltip) {
+    throw new Error(`Expected compact language selector to expose a custom tooltip: ${JSON.stringify(state)}`)
+  }
+}
+
+async function assertHeaderTooltipContract (window, selector) {
+  const tooltipState = await window.webContents.executeJavaScript(`
+    (() => {
+      const element = document.querySelector(${JSON.stringify(selector)})
+      if (!element) return null
+
+      function delayToMs(value) {
+        return value.split(',').reduce((maxDelay, rawDelay) => {
+          const delay = rawDelay.trim()
+          const multiplier = delay.endsWith('ms') ? 1 : 1000
+          const parsed = Number.parseFloat(delay)
+          return Number.isFinite(parsed) ? Math.max(maxDelay, parsed * multiplier) : maxDelay
+        }, 0)
+      }
+
+      const restingStyle = window.getComputedStyle(element, '::after')
+      return {
+        content: restingStyle.content,
+        dataTooltip: element.getAttribute('data-tooltip') || '',
+        delayMs: delayToMs(restingStyle.transitionDelay || ''),
+        title: element.getAttribute('title') || ''
+      }
+    })()
+  `, true)
+
+  if (!tooltipState) {
+    throw new Error(`Expected tooltip target to exist: ${selector}`)
+  }
+
+  if (!tooltipState.dataTooltip) {
+    throw new Error(`Expected tooltip target to expose data-tooltip: ${JSON.stringify({ selector, tooltipState })}`)
+  }
+
+  if (tooltipState.title) {
+    throw new Error(`Expected tooltip target to avoid native title tooltip: ${JSON.stringify({ selector, tooltipState })}`)
+  }
+
+  if (tooltipState.delayMs > 200) {
+    throw new Error(`Expected custom tooltip delay to stay short: ${JSON.stringify({ selector, tooltipState })}`)
+  }
+
+  if (!tooltipState.content.includes(tooltipState.dataTooltip)) {
+    throw new Error(`Expected custom tooltip text to be rendered by CSS: ${JSON.stringify({
+      selector,
+      tooltipState
+    })}`)
+  }
+}
+
+async function assertLoginHeaderTooltips (window) {
+  await assertHeaderTooltipContract(window, '.login-mode-switch')
+  await assertHeaderTooltipContract(window, '.login-language-selector')
 }
 
 async function assertLoginModeSwitchKeepsModalHeight (window) {
@@ -471,6 +535,7 @@ async function main () {
     } else {
       await waitForLoginUi(window)
       assertLoginRendererState(await getRendererState(window))
+      await assertLoginHeaderTooltips(window)
       await assertLoginModeSwitchKeepsModalHeight(window)
       await assertLoginLocaleSwitchRendersInPlace(window)
       await captureScreenshot(window, 'electron-render-smoke-success.png')


### PR DESCRIPTION
## Summary

- Replace native title tooltips on the login option and language icons with app-rendered CSS tooltips.
- Keep aria labels for accessibility while removing the browser/native tooltip delay.
- Add Electron smoke coverage that verifies the custom tooltip path and short delay.

## Validation

- npm run lint
- npm test
- npm run test:smoke
- git diff --check