### PR TITLE
[codex] Run CI only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@ on:
     branches:
       - master
       - dev
-      - 'codex/**'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   lint-test-build:


### PR DESCRIPTION
## Summary

- Remove the `codex/**` branch push trigger from the CI workflow.
- Keep push CI for integration branches (`master` and `dev`).
- Make pull request CI lifecycle events explicit, including `ready_for_review`.

## Why

PR branches were running the same CI jobs twice: once for `push` and once for `pull_request`. This keeps CI focused on draft and ready-to-review PRs while preserving post-merge validation on integration branches.

## Validation

- `git diff --check`
- Parsed `.github/workflows/ci.yml` with Ruby YAML loader