### PR TITLE
Release v2.0.0-beta.6

### DIFF
--- a/license.json
+++ b/license.json
@@ -134,7 +134,7 @@
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "licenseFile": "node_modules/@types/use-sync-external-store/LICENSE"
     },
-    "Lepton@2.0.0-beta.5": {
+    "Lepton@2.0.0-beta.6": {
         "licenses": "MIT",
         "repository": "https://github.com/hackjutsu/Lepton",
         "licenseFile": "LICENSE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Bump app version to 2.0.0-beta.6.
- Refresh package-lock metadata for 2.0.0-beta.6.
- Regenerate license.json for the prerelease version.

## Validation

- npm run lint
- npm test
- git diff --check

## Notes

- npm run check-outdated currently reports existing dependency updates; the tag-driven release workflow does not run this check and this PR intentionally does not change dependencies.