### PR TITLE
[codex] Stabilize selected snippet card styling

### DIFF
--- a/app/containers/navigationPanelDetails/index.scss
+++ b/app/containers/navigationPanelDetails/index.scss
@@ -63,8 +63,11 @@
   .active-snippet-thumnail-base {
     @extend .font-style-base;
     padding: 6px;
-    font-weight: 500;
     background: var(--bg-secondary);
+    box-shadow: 0 2px 8px var(--shadow-color);
+    position: relative;
+    transform: translateY(-1px);
+    z-index: 1;
   }
 
   .active-snippet-thumnail-public {


### PR DESCRIPTION
## Summary

Stabilizes selected snippet cards in the middle panel by removing the active-row font-weight change that caused text reflow and row-height shifts.

- Keeps selected snippet text at the same weight as inactive rows.
- Preserves the existing active background cue.
- Adds a subtle raised treatment using shadow, relative stacking, and a tiny transform so the selected card is still easy to find without changing layout metrics.

## Root Cause

The active snippet thumbnail class used `font-weight: 500`. In the fixed-width snippet list, wider selected glyphs could wrap onto additional lines, expanding the selected row and shifting the surrounding layout.

## Validation

- `npm run test:build`
- `npm run test:smoke`
- `git diff --check`
- Launched `LEPTON_RENDER_FIXTURE=active npm start` and verified the selected card remains visually distinct without bold text or layout shift.