### PR TITLE
[codex] Bump prerelease version to 2.0.0-beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.6",
+      "version": "2.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Bumps the app version from `2.0.0-beta.6` to `2.0.0-beta.7` in `package.json` and `package-lock.json`.
- Prepares `master` for the next tag-driven prerelease publish as `v2.0.0-beta.7`.

## Validation

- `git diff --check`
- `npm run lint`
- `npm test`

## Release Plan

After this PR is green and merged, create and push tag `v2.0.0-beta.7` from latest `master`. The Release workflow should publish a GitHub prerelease and edge-channel Snap artifacts.