### PR TITLE
[codex] Fix gist editor tips controls

### DIFF
--- a/app/containers/gistEditorForm/index.js
+++ b/app/containers/gistEditorForm/index.js
@@ -29,6 +29,7 @@ const conf = electronBridge.config
 const ipcRenderer = electronBridge.ipc
 const logger = electronBridge.logger
 
+const DESCRIPTION_TIPS_ID = 'gist-editor-description-tips'
 const getDescriptionTips = () => t('editor.descriptionPlaceholder')
 
 function preventDefault (event) {
@@ -246,29 +247,40 @@ const renderTitleInputField = ({ value, placeholder, type, touched, error, warni
   </div>
 )
 
-const renderDescriptionField = ({ value, type, touched, error, warning, onChange, onBlur }) => (
-  <div className='gist-editor-section gist-editor-name'>
-    <input
-      className='gist-editor-input-area'
-      value={ value }
-      type={ type }
-      placeholder={ getDescriptionTips() }
-      onChange={ onChange }
-      onBlur={ onBlur }/>
-    { touched && ((error && <span className='error-msg'>{ error }</span>) ||
-        (warning && <span className='error-msg'>{ warning }</span>)) }
-    <a
-      className='tips'
-      href='#'
-      title={ getDescriptionTips() }
-      onClick={ event => event.preventDefault() }>
-      <div
-        className='tips-icon'
-        dangerouslySetInnerHTML={{ __html: tipsIcon }} />
-      <span>{ t('editor.tips') }</span>
-    </a>
-  </div>
-)
+const renderDescriptionField = ({ value, type, touched, error, warning, onChange, onBlur }) => {
+  const descriptionTips = getDescriptionTips()
+  const tipsLabel = t('editor.tips')
+
+  return (
+    <div className='gist-editor-section gist-editor-name'>
+      <input
+        className='gist-editor-input-area'
+        value={ value }
+        type={ type }
+        placeholder={ descriptionTips }
+        onChange={ onChange }
+        onBlur={ onBlur }/>
+      { touched && ((error && <span className='error-msg'>{ error }</span>) ||
+          (warning && <span className='error-msg'>{ warning }</span>)) }
+      <button
+        className='tips'
+        type='button'
+        aria-label={ `${tipsLabel}: ${descriptionTips}` }
+        aria-describedby={ DESCRIPTION_TIPS_ID }>
+        <span
+          className='tips-icon'
+          dangerouslySetInnerHTML={{ __html: tipsIcon }} />
+        <span className='tips-label'>{ tipsLabel }</span>
+        <span
+          className='tips-popover'
+          id={ DESCRIPTION_TIPS_ID }
+          role='tooltip'>
+          { descriptionTips }
+        </span>
+      </button>
+    </div>
+  )
+}
 
 const renderContentField = ({ value, type, touched, error, warning, filename, onChange }) => (
   <div>
@@ -368,16 +380,17 @@ const renderGistFiles = ({
         onClick={ onAddFile }>
         { t('editor.addFile') }
       </a>
-      <div className='gist-editor-privacy-checkbox'>
+      <label className='gist-editor-privacy-checkbox'>
         <input
+          className='gist-editor-privacy-input'
           name='private'
           id='private'
           type='checkbox'
           checked={ privateValue }
           onChange={ onPrivateChange }
           disabled={ formStyle === UPDATE_GIST }/>
-         &nbsp;{ t('editor.secret') }
-      </div>
+        <span>{ t('editor.secret') }</span>
+      </label>
     </div>
   </ListGroup>
 )

--- a/app/containers/gistEditorForm/index.scss
+++ b/app/containers/gistEditorForm/index.scss
@@ -100,8 +100,19 @@
 
   .gist-editor-privacy-checkbox {
     @extend .font-style-base;
-    display: inline;
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
     float: right;
+    font-weight: normal;
+    gap: 6px;
+    line-height: 20px;
+    margin-bottom: 0px;
+  }
+
+  .gist-editor-privacy-input {
+    flex: 0 0 auto;
+    margin: 0px;
   }
 
   .title-input-field {
@@ -123,13 +134,30 @@
 
   .tips {
     @extend .font-style-base;
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    cursor: help;
+    display: inline-flex;
     font-size: 13px;
     font-style: italic;
     flex: 0 0 auto;
+    gap: 2px;
+    padding: 0px 2px;
     position: relative;
+    text-decoration: none;
 
-    & > span {
-      vertical-align: middle;
+    &:hover,
+    &:focus {
+      color: var(--text-primary);
+      text-decoration: none;
+    }
+
+    &:hover .tips-popover,
+    &:focus .tips-popover {
+      opacity: 1;
+      visibility: visible;
     }
   }
 
@@ -139,6 +167,33 @@
     display: inline-block;
     vertical-align: middle;
     fill: currentColor;
+  }
+
+  .tips-label {
+    vertical-align: middle;
+  }
+
+  .tips-popover {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-style: normal;
+    line-height: 1.4;
+    max-width: 260px;
+    opacity: 0;
+    padding: 6px 8px;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 6px);
+    transition: opacity 120ms ease-in-out;
+    visibility: hidden;
+    white-space: normal;
+    width: max-content;
+    z-index: 20;
   }
 
   hr {

--- a/tests/containers/gistEditorFormTips.test.js
+++ b/tests/containers/gistEditorFormTips.test.js
@@ -1,0 +1,58 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+const formSource = readFileSync(
+  new URL('../../app/containers/gistEditorForm/index.js', import.meta.url),
+  'utf8'
+)
+const formStyles = readFileSync(
+  new URL('../../app/containers/gistEditorForm/index.scss', import.meta.url),
+  'utf8'
+)
+
+function getTipsButtonSource () {
+  const match = formSource.match(/<button\s+className='tips'[\s\S]+?<\/button>/)
+  return match ? match[0] : ''
+}
+
+function getPrivacyCheckboxSource () {
+  const match = formSource.match(/<label\s+className='gist-editor-privacy-checkbox'[\s\S]+?<\/label>/)
+  return match ? match[0] : ''
+}
+
+describe('gist editor form controls', () => {
+  it('renders tips as a non-submit button with inline tooltip content', () => {
+    const tipsButtonSource = getTipsButtonSource()
+
+    expect(formSource).toContain("const DESCRIPTION_TIPS_ID = 'gist-editor-description-tips'")
+    expect(formSource).toContain('const descriptionTips = getDescriptionTips()')
+    expect(formSource).toContain('placeholder={ descriptionTips }')
+    expect(tipsButtonSource).toContain("type='button'")
+    expect(tipsButtonSource).toContain('aria-label={ `${tipsLabel}: ${descriptionTips}` }')
+    expect(tipsButtonSource).toContain('aria-describedby={ DESCRIPTION_TIPS_ID }')
+    expect(tipsButtonSource).toContain("className='tips-popover'")
+    expect(tipsButtonSource).toContain('id={ DESCRIPTION_TIPS_ID }')
+    expect(tipsButtonSource).toContain("role='tooltip'")
+    expect(tipsButtonSource).not.toContain('href=')
+    expect(tipsButtonSource).not.toContain('onClick=')
+  })
+
+  it('shows the inline tooltip on hover and focus', () => {
+    expect(formStyles).toContain('&:hover .tips-popover')
+    expect(formStyles).toContain('&:focus .tips-popover')
+    expect(formStyles).toMatch(/opacity:\s*1;/)
+    expect(formStyles).toMatch(/visibility:\s*visible;/)
+  })
+
+  it('keeps the secret checkbox and label text aligned', () => {
+    const privacyCheckboxSource = getPrivacyCheckboxSource()
+
+    expect(privacyCheckboxSource).toContain("className='gist-editor-privacy-input'")
+    expect(privacyCheckboxSource).toContain("<span>{ t('editor.secret') }</span>")
+    expect(privacyCheckboxSource).not.toContain('&nbsp;')
+    expect(formStyles).toMatch(/\.gist-editor-privacy-checkbox\s*\{[\s\S]+align-items:\s*center;/)
+    expect(formStyles).toMatch(/\.gist-editor-privacy-checkbox\s*\{[\s\S]+display:\s*inline-flex;/)
+    expect(formStyles).toMatch(/\.gist-editor-privacy-checkbox\s*\{[\s\S]+gap:\s*6px;/)
+    expect(formStyles).toMatch(/\.gist-editor-privacy-input\s*\{[\s\S]+margin:\s*0px;/)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the gist editor controls shown beside the description and file editor fields.

- Replaces the dead `tips` anchor with a non-submit button that exposes an inline tooltip on hover/focus/click-focus.
- Aligns the `secret` checkbox and text with a flex label so the control reads cleanly and clicking the label toggles the checkbox.
- Adds regression coverage for the tips control shape, tooltip visibility rules, and checkbox alignment rules.

## Why

The `tips` UI looked interactive but only prevented the default anchor behavior and relied on native `title` handling, so clicking appeared to do nothing. The `secret` checkbox used inline text plus `&nbsp;`, which left the native checkbox and label visually misaligned.

## Validation

- `npm run lint`
- `npm run test:unit` - 35 files, 183 tests
- `npm run build`
- Electron app-scoped fixture render for the new gist editor modal, including screenshot verification of the tips tooltip and checkbox alignment

## Notes

The branch was rebased onto `origin/master` before pushing so this PR contains only the editor control fix.