### PR TITLE
[codex] Fix invalid token login recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           LEPTON_SMOKE_NO_SANDBOX: '1'
         run: xvfb-run --auto-servernum npm run test:smoke
 
+      - name: Electron login-flow smoke test
+        env:
+          LEPTON_SMOKE_NO_SANDBOX: '1'
+        run: xvfb-run --auto-servernum npm run test:login-flow
+
   packaged-smoke:
     runs-on: macos-latest
     continue-on-error: true

--- a/app/containers/loginPage/index.js
+++ b/app/containers/loginPage/index.js
@@ -1,4 +1,4 @@
-import { Alert, Button, Image, ProgressBar } from 'react-bootstrap'
+import { Button, Image, ProgressBar } from 'react-bootstrap'
 import Avatar from 'boring-avatars'
 import { connect } from 'react-redux'
 import electronBridge from '../../utilities/electronBridge'
@@ -55,6 +55,21 @@ class LoginPage extends Component {
 
     logger.debug('-----> sending login-page-ready signal')
     ipcRenderer.send('login-page-ready')
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.userSessionStatus === 'IN_PROGRESS' &&
+      this.props.userSessionStatus === 'INACTIVE') {
+      clearTimeout(this.loginModeFlipTimer)
+      this.setState({
+        inputTokenValue: '',
+        loginMode: LoginModeEnum.CREDENTIALS,
+        modalFlipping: false,
+        pendingLoginMode: null,
+        pendingLocale: null,
+        pendingModalState: null
+      })
+    }
   }
 
   componentWillUnmount () {
@@ -165,7 +180,7 @@ class LoginPage extends Component {
                 : this.translate(locale, 'login.happyCoding')
               }
             </Button>
-            : this.renderTokenLoginSection(userSessionStatus, locale, isInteractive)}
+            : this.renderTokenLoginSection(locale, isInteractive)}
         </div>
       )
     }
@@ -178,8 +193,8 @@ class LoginPage extends Component {
             <a href="https://github.com/hackjutsu/Lepton">{ welcomeMessage }</a>
           </div>
           { loginMode === LoginModeEnum.CREDENTIALS
-            ? this.renderCredentialLoginSection(authWindowStatus, userSessionStatus, locale, isInteractive)
-            : this.renderTokenLoginSection(userSessionStatus, locale, isInteractive)
+            ? this.renderCredentialLoginSection(authWindowStatus, locale, isInteractive)
+            : this.renderTokenLoginSection(locale, isInteractive)
           }
         </div>
       )
@@ -230,13 +245,9 @@ class LoginPage extends Component {
     })
   }
 
-  renderCredentialLoginSection (authWindowStatus, userSessionStatus, locale = this.state.activeLocale, isInteractive = true) {
+  renderCredentialLoginSection (authWindowStatus, locale = this.state.activeLocale, isInteractive = true) {
     return (
       <div>
-        { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">{ this.translate(locale, 'login.tokenInvalid') }</Alert>
-          : null
-        }
         <Button
           autoFocus={ isInteractive }
           className={ authWindowStatus === 'OFF' ? 'modal-button' : 'modal-button-disabled' }
@@ -248,13 +259,9 @@ class LoginPage extends Component {
     )
   }
 
-  renderTokenLoginSection (userSessionStatus, locale = this.state.activeLocale, isInteractive = true) {
+  renderTokenLoginSection (locale = this.state.activeLocale, isInteractive = true) {
     return (
       <form>
-        { userSessionStatus === 'EXPIRED'
-          ? <Alert bsStyle="warning" className="login-alert">{ this.translate(locale, 'login.tokenInvalid') }</Alert>
-          : null
-        }
         <input
           className="form-control"
           placeholder={ this.translate(locale, 'login.tokenPlaceholder') }

--- a/app/containers/loginPage/index.scss
+++ b/app/containers/loginPage/index.scss
@@ -250,9 +250,6 @@
     color: #a94442;
   }
 
-  .login-alert {
-    margin-bottom: 5px !important;
-  }
 }
 
 @keyframes login-modal-fade-in {

--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,7 @@ import {
   fetchSingleGist,
   selectGist,
   updateAuthWindowStatus,
+  removeAccessToken,
   updateLoginStatus,
   updateGistSyncStatus,
   updateSearchWindowStatus,
@@ -83,6 +84,7 @@ const LOGIN_STATUS = {
   loadingGitHubProfile: 'Loading profile...',
   syncingSnippetIndex: 'Syncing snippet index...',
   signInComplete: 'Signed in.',
+  tokenInvalid: 'Token invalid. Please try again.',
   signInFailed: 'Sign-in failed.'
 }
 
@@ -136,6 +138,7 @@ function handleAuthResult (result) {
   logger.debug('[auth] GitHub OAuth result received: ' + JSON.stringify(describeGitHubAuthResult(result)))
 
   if (!result || result.status === 'closed') {
+    logger.info('[auth] GitHub OAuth flow ended without authorization; returning to login modal')
     clearLoginStatus()
     return
   }
@@ -163,6 +166,7 @@ function handleAuthResult (result) {
         return initUserSession(payload.access_token, { freshOAuthToken: true })
       })
       .catch((err) => {
+        logger.warn('[auth] OAuth credential exchange failed; returning to login modal')
         reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
         updateLoginStatusFailure()
         logger.error('GitHub login failed: ' + describeGitHubLoginError(err))
@@ -171,8 +175,9 @@ function handleAuthResult (result) {
     return
   }
 
+  logger.warn('[auth] GitHub OAuth flow returned a non-success result: ' + JSON.stringify(describeGitHubAuthResult(result)))
   updateLoginStatusFailure()
-  logger.error('Oops! Something went wrong and we couldn\'t' +
+  logger.error('Oops! Something went wrong and we couldn\'t ' +
     'log you in using Github. Please try again.')
 }
 
@@ -263,12 +268,20 @@ function updateSnippetDownloadStatus (downloaded, total) {
   }))
 }
 
-function updateLoginStatusFailure () {
+function updateLoginStatusFailure (message = LOGIN_STATUS.signInFailed) {
   const logFilePath = getLogFilePath()
   reduxStore.dispatch(updateLoginStatus({
-    message: LOGIN_STATUS.signInFailed,
+    message,
     level: 'error',
     logFilePath
+  }))
+}
+
+function updateLoginStatusUserError (message) {
+  reduxStore.dispatch(updateLoginStatus({
+    message,
+    level: 'error',
+    logFilePath: null
   }))
 }
 
@@ -550,17 +563,28 @@ function initUserSession (token, options = {}) {
     .catch((err) => {
       logger.debug('-----> Failure with ' + JSON.stringify(err))
       logger.error('The request has failed: \n' + JSON.stringify(err))
-      updateLoginStatusFailure()
-
-      if (err.statusCode === 401) {
-        logger.info('[Dispatch] updateUserSession EXPIRED')
-        reduxStore.dispatch(updateUserSession({ activeStatus: 'EXPIRED' }))
-      } else {
+      if (isUnauthorizedGitHubError(err)) {
+        logger.warn('[auth] GitHub rejected the active credential with 401; clearing cached auth and returning to login modal')
+        clearCachedUserInfo()
+        updateLoginStatusUserError(LOGIN_STATUS.tokenInvalid)
         logger.info('[Dispatch] updateUserSession INACTIVE')
         reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
+        return
       }
+
+      updateLoginStatusFailure()
+      logger.info('[Dispatch] updateUserSession INACTIVE')
+      reduxStore.dispatch(updateUserSession({ activeStatus: 'INACTIVE' }))
       notifyFailure(t('notification.syncFailed'), t('notification.networkFailure', { code: '00' }))
     })
+}
+
+function isUnauthorizedGitHubError (err) {
+  return Boolean(err && (
+    err.statusCode === 401 ||
+    err.status === 401 ||
+    (err.response && err.response.statusCode === 401)
+  ))
 }
 /** End: User session management **/
 
@@ -579,6 +603,22 @@ function updateLocalStorage (data) {
   } catch (e) {
     logger.error(`-----> Failed to cache user info. ${JSON.stringify(e)}`)
   }
+}
+
+function clearCachedUserInfo () {
+  try {
+    logger.debug('[auth] Clearing cached credential metadata after unauthorized response')
+    const credentialClear = electronBridge.credentials.setAccessToken(null)
+    logger.debug(`[auth] [${credentialClear.status}] Cleared cached credential`)
+
+    const profileClear = electronBridge.localStorage.set('profile', null)
+    logger.debug(`[auth] [${profileClear.status}] Cleared cached profile`)
+  } catch (e) {
+    logger.error(`-----> Failed to clear cached user info. ${JSON.stringify(e)}`)
+  }
+
+  logger.info('[Dispatch] removeAccessToken')
+  reduxStore.dispatch(removeAccessToken())
 }
 
 function getCachedUserInfo () {

--- a/app/renderFixtures.js
+++ b/app/renderFixtures.js
@@ -318,6 +318,17 @@ function getFixtureOverrides (name) {
           activeStatus: 'INACTIVE'
         }
       }
+    case 'login-expired-token':
+      return {
+        loginStatus: {
+          message: 'Token invalid. Please try again.',
+          level: 'error',
+          logFilePath: null
+        },
+        userSession: {
+          activeStatus: 'INACTIVE'
+        }
+      }
     case 'login-stale-success-logged-out':
       return {
         loginStatus: {

--- a/app/utilities/auth/githubOAuth.js
+++ b/app/utilities/auth/githubOAuth.js
@@ -1,4 +1,5 @@
 const GITHUB_OAUTH_URL = 'https://github.com/login/oauth/authorize'
+const ELECTRON_ABORTED_LOAD_ERROR_CODE = -3
 
 function normalizeScopes (scopes = []) {
   if (Array.isArray(scopes)) {
@@ -12,7 +13,7 @@ function normalizeScopes (scopes = []) {
   return ''
 }
 
-function buildGitHubOAuthUrl ({ clientId, scopes }) {
+function buildGitHubOAuthUrl ({ authorizeUrl = GITHUB_OAUTH_URL, clientId, scopes }) {
   const params = new URLSearchParams()
   params.set('client_id', clientId)
 
@@ -21,7 +22,7 @@ function buildGitHubOAuthUrl ({ clientId, scopes }) {
     params.set('scope', scope)
   }
 
-  return `${GITHUB_OAUTH_URL}?${params.toString()}`
+  return `${authorizeUrl}?${params.toString()}`
 }
 
 function parseGitHubOAuthCallback (callbackUrl) {
@@ -90,6 +91,19 @@ function describeGitHubOAuthUrl (callbackUrl) {
   })
 }
 
+function shouldIgnoreGitHubOAuthLoadFailure ({
+  errorCode,
+  errorDescription,
+  isMainFrame
+} = {}) {
+  return isAbortedLoadError(errorCode, errorDescription) || isMainFrame === false
+}
+
+function isAbortedLoadError (errorCode, errorDescription) {
+  return Number(errorCode) === ELECTRON_ABORTED_LOAD_ERROR_CODE ||
+    /\bERR_ABORTED\b|\(-3\)/.test(String(errorDescription || ''))
+}
+
 function removeUndefinedProperties (value) {
   Object.keys(value).forEach(key => {
     if (value[key] === undefined) {
@@ -102,5 +116,6 @@ function removeUndefinedProperties (value) {
 module.exports = {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
-  parseGitHubOAuthCallback
+  parseGitHubOAuthCallback,
+  shouldIgnoreGitHubOAuthLoadFailure
 }

--- a/app/utilities/githubApi/core.js
+++ b/app/utilities/githubApi/core.js
@@ -19,7 +19,9 @@ const DELETE_SINGLE_GIST = 'DELETE_SINGLE_GIST'
 
 function createGitHubApi ({
   conf,
+  gitHubApiBaseUrl,
   logger,
+  oauthAccessTokenUrl,
   fetchImpl
 } = {}) {
   const apiLogger = logger || {
@@ -34,6 +36,8 @@ function createGitHubApi ({
     const gitHubHost = conf.get('enterprise:host')
     gitHubHostApi = `${gitHubHost}/api/v3`
   }
+  const apiBaseUrl = normalizeBaseUrl(gitHubApiBaseUrl || `https://${gitHubHostApi}`)
+  const accessTokenUrl = oauthAccessTokenUrl || 'https://github.com/login/oauth/access_token'
 
   function exchangeAccessToken (clientId, clientSecret, authCode) {
     apiLogger.debug(TAG + 'Exchanging authCode with access credential ' + JSON.stringify({
@@ -44,7 +48,7 @@ function createGitHubApi ({
     }))
     return apiRequest({
       method: 'POST',
-      uri: 'https://github.com/login/oauth/access_token',
+      uri: accessTokenUrl,
       headers: {
         'User-Agent': userAgent
       },
@@ -64,7 +68,7 @@ function createGitHubApi ({
   function getUserProfile (token) {
     apiLogger.debug(TAG + 'Getting user profile ' + JSON.stringify({ hasCredential: Boolean(token) }))
     return apiRequest({
-      uri: `https://${gitHubHostApi}/user`,
+      uri: `${apiBaseUrl}/user`,
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
@@ -78,7 +82,7 @@ function createGitHubApi ({
   function getSingleGist (token, gistId) {
     apiLogger.debug(TAG + `Getting single gist ${gistId} ` + JSON.stringify({ hasCredential: Boolean(token) }))
     return apiRequest({
-      uri: `https://${gitHubHostApi}/gists/${gistId}`,
+      uri: `${apiBaseUrl}/gists/${gistId}`,
       headers: {
         'User-Agent': userAgent,
         Authorization: 'token ' + token
@@ -178,8 +182,8 @@ function createGitHubApi ({
   function makeOptionForGetAllGists (token, userId, page) {
     const shouldDownloadAllGists = shouldDownloadAllSnippets(conf)
     const uri = shouldDownloadAllGists
-      ? `https://${gitHubHostApi}/gists`
-      : `https://${gitHubHostApi}/users/${userId}/gists`
+      ? `${apiBaseUrl}/gists`
+      : `${apiBaseUrl}/users/${userId}/gists`
 
     return {
       uri: uri,
@@ -206,7 +210,7 @@ function createGitHubApi ({
         Authorization: 'token ' + token
       },
       method: 'POST',
-      uri: `https://${gitHubHostApi}/gists`,
+      uri: `${apiBaseUrl}/gists`,
       body: {
         description: description,
         public: isPublic,
@@ -225,7 +229,7 @@ function createGitHubApi ({
         Authorization: 'token ' + token
       },
       method: 'PATCH',
-      uri: `https://${gitHubHostApi}/gists/${gistId}`,
+      uri: `${apiBaseUrl}/gists/${gistId}`,
       body: {
         description: updatedDescription,
         files: updatedFiles
@@ -243,7 +247,7 @@ function createGitHubApi ({
         Authorization: 'token ' + token
       },
       method: 'DELETE',
-      uri: `https://${gitHubHostApi}/gists/${gistId}`,
+      uri: `${apiBaseUrl}/gists/${gistId}`,
       json: true,
       timeout: 2 * kTimeoutUnit
     })
@@ -275,6 +279,10 @@ function createGitHubApi ({
   return {
     getGitHubApi
   }
+}
+
+function normalizeBaseUrl (baseUrl) {
+  return String(baseUrl || '').replace(/\/+$/, '')
 }
 
 function validateOAuthAccessTokenResponse (payload) {

--- a/app/utilities/i18n/locales/en.js
+++ b/app/utilities/i18n/locales/en.js
@@ -51,7 +51,7 @@ module.exports = {
     tokenInvalid: 'Token invalid',
     tokenLogin: 'Token Login',
     tokenPlaceholder: 'scope: gist',
-    welcome: 'Lepton is FREE. Like us on GitHub!'
+    welcome: 'Lepton is FREE. Like us on GitHub ⭐'
   },
   i18n: {
     language: 'Language',

--- a/main.js
+++ b/main.js
@@ -33,7 +33,8 @@ const {
 const {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
-  parseGitHubOAuthCallback
+  parseGitHubOAuthCallback,
+  shouldIgnoreGitHubOAuthLoadFailure
 } = require('./app/utilities/auth/githubOAuth')
 const {
   clearGitHubAuthWindowStorageAndDestroy
@@ -463,10 +464,12 @@ function setUpBridgeIpcHandlers () {
   function getGitHubApiBridge () {
     if (!githubApi) {
       const { createGitHubApi } = require('./app/utilities/githubApi/core')
-      githubApi = createGitHubApi({
-        conf: nconf,
-        logger
-      })
+    githubApi = createGitHubApi({
+      conf: nconf,
+      gitHubApiBaseUrl: process.env.LEPTON_TEST_GITHUB_API_BASE_URL,
+      oauthAccessTokenUrl: process.env.LEPTON_TEST_GITHUB_OAUTH_ACCESS_TOKEN_URL,
+      logger
+    })
     }
     return githubApi
   }
@@ -725,7 +728,11 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     resolve: resolveAuthFlow
   }
 
-  const authUrl = buildGitHubOAuthUrl({ clientId, scopes })
+  const authUrl = buildGitHubOAuthUrl({
+    authorizeUrl: process.env.LEPTON_TEST_GITHUB_OAUTH_AUTHORIZE_URL,
+    clientId,
+    scopes
+  })
   const options = { extraHeaders: 'pragma: no-cache\n' }
 
   logger.debug('[auth] Starting GitHub OAuth flow ' + JSON.stringify({
@@ -748,38 +755,87 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
   }
 
   authWindow.webContents.on('will-navigate', (event, callbackUrl) => {
+    logger.debug('[auth] OAuth window will-navigate: ' + JSON.stringify(describeGitHubOAuthUrl(callbackUrl)))
     handleAuthNavigation(event, callbackUrl)
   })
 
   authWindow.webContents.on('will-redirect', (event, callbackUrl) => {
+    logger.debug('[auth] OAuth window will-redirect: ' + JSON.stringify(describeGitHubOAuthUrl(callbackUrl)))
     handleAuthNavigation(event, callbackUrl)
   })
 
   authWindow.webContents.on('did-get-redirect-request', (event, oldUrl, newUrl) => {
+    logger.debug('[auth] OAuth window did-get-redirect-request: ' + JSON.stringify({
+      from: describeGitHubOAuthUrl(oldUrl),
+      to: describeGitHubOAuthUrl(newUrl)
+    }))
     handleAuthNavigation(event, newUrl)
   })
 
   authWindow.webContents.on('did-navigate', (event, callbackUrl) => {
+    logger.debug('[auth] OAuth window did-navigate: ' + JSON.stringify(describeGitHubOAuthUrl(callbackUrl)))
     handleAuthNavigation(event, callbackUrl)
   })
 
-  authWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
-    if (errorCode === -3) return
-    logger.error('[auth] OAuth window failed to load: ' + JSON.stringify({
+  authWindow.webContents.on('did-start-navigation', (event, navigationUrl, isInPlace, isMainFrame) => {
+    logger.debug('[auth] OAuth window did-start-navigation: ' + JSON.stringify({
+      url: describeGitHubOAuthUrl(navigationUrl),
+      isInPlace,
+      isMainFrame
+    }))
+  })
+
+  authWindow.webContents.on('did-finish-load', () => {
+    logger.debug('[auth] OAuth window did-finish-load: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+  })
+
+  authWindow.webContents.on('did-stop-loading', () => {
+    logger.debug('[auth] OAuth window did-stop-loading: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+  })
+
+  authWindow.webContents.on('render-process-gone', (event, details) => {
+    logger.error('[auth] OAuth window render process gone: ' + JSON.stringify(removeUndefinedProperties({
+      reason: details && details.reason,
+      exitCode: details && details.exitCode,
+      window: describeGitHubAuthWindow(authWindow)
+    })))
+  })
+
+  authWindow.webContents.on('unresponsive', () => {
+    logger.warn('[auth] OAuth window webContents became unresponsive: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+  })
+
+  authWindow.webContents.on('responsive', () => {
+    logger.debug('[auth] OAuth window webContents became responsive: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+  })
+
+  authWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    const loadFailure = {
       errorCode,
       errorDescription,
-      url: describeGitHubOAuthUrl(authWindow.webContents.getURL())
-    }))
+      validatedURL,
+      isMainFrame,
+      currentURL: authWindow.webContents.getURL()
+    }
+
+    if (shouldIgnoreGitHubOAuthLoadFailure(loadFailure)) {
+      logger.debug('[auth] Ignoring OAuth window load failure: ' + JSON.stringify(describeGitHubOAuthLoadFailure(loadFailure)))
+      return
+    }
+
+    logger.error('[auth] OAuth window failed to load: ' + JSON.stringify(describeGitHubOAuthLoadFailure(loadFailure)))
     finishGitHubAuthFlow({
       status: 'error',
       error: 'load-failed',
       errorDescription
+    }, {
+      destroyWindow: false
     })
   })
 
   authWindow.once('closed', () => {
     if (authFlow && authFlow.authWindow === authWindow) {
-      logger.debug('[auth] OAuth window closed before completion')
+      logger.debug('[auth] OAuth window closed before completion: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
       finishGitHubAuthFlow({
         status: 'closed'
       }, {
@@ -788,19 +844,46 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     }
   })
 
+  authWindow.once('ready-to-show', () => {
+    logger.debug('[auth] OAuth window ready-to-show: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+  })
+
+  logger.debug('[auth] OAuth window loadURL start: ' + JSON.stringify({
+    target: describeGitHubOAuthUrl(authUrl),
+    window: describeGitHubAuthWindow(authWindow)
+  }))
   authWindow.loadURL(authUrl, options)
+    .then(() => {
+      logger.debug('[auth] OAuth window loadURL resolved: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
+    })
     .catch(err => {
-      logger.error('[auth] OAuth window failed to load: ' + JSON.stringify({
-        errorDescription: err.message,
-        url: describeGitHubOAuthUrl(authUrl)
-      }))
+      if (!authFlow || authFlow.authWindow !== authWindow) return
+
+      const errorDescription = err && err.message
+        ? err.message
+        : String(err || 'unknown load failure')
+      const loadFailure = {
+        errorCode: err && err.code,
+        errorDescription,
+        validatedURL: authUrl,
+        isMainFrame: true
+      }
+      if (shouldIgnoreGitHubOAuthLoadFailure(loadFailure)) {
+        logger.debug('[auth] Ignoring OAuth window load failure: ' + JSON.stringify(describeGitHubOAuthLoadFailure(loadFailure)))
+        return
+      }
+
+      logger.error('[auth] OAuth window failed to load: ' + JSON.stringify(describeGitHubOAuthLoadFailure(loadFailure)))
       finishGitHubAuthFlow({
         status: 'error',
         error: 'load-failed',
-        errorDescription: err.message
+        errorDescription
+      }, {
+        destroyWindow: false
       })
     })
   authWindow.show()
+  logger.debug('[auth] OAuth window show called: ' + JSON.stringify(describeGitHubAuthWindow(authWindow)))
 
   return promise
 }
@@ -810,7 +893,11 @@ function finishGitHubAuthFlow (result, options = {}) {
 
   const { authWindow, resolve } = authFlow
   authFlow = null
-  logger.debug('[auth] Finishing GitHub OAuth flow: ' + JSON.stringify(describeGitHubAuthResult(result)))
+  logger.debug('[auth] Finishing GitHub OAuth flow: ' + JSON.stringify({
+    result: describeGitHubAuthResult(result),
+    destroyWindow: options.destroyWindow !== false,
+    window: describeGitHubAuthWindow(authWindow)
+  }))
   resolve(result)
 
   if (options.destroyWindow === false || !authWindow || authWindow.isDestroyed()) return
@@ -831,6 +918,47 @@ function describeGitHubAuthResult (result) {
     codeLength: result.code ? result.code.length : undefined,
     error: result.error,
     errorDescription: result.errorDescription
+  })
+}
+
+function describeGitHubOAuthLoadFailure (failure) {
+  const validatedURL = failure && failure.validatedURL
+  const currentURL = failure && failure.currentURL
+
+  return removeUndefinedProperties({
+    errorCode: failure && failure.errorCode,
+    errorDescription: failure && failure.errorDescription,
+    isMainFrame: failure && failure.isMainFrame,
+    failedUrl: describeGitHubOAuthUrl(validatedURL),
+    currentUrl: currentURL ? describeGitHubOAuthUrl(currentURL) : undefined
+  })
+}
+
+function describeGitHubAuthWindow (authWindow) {
+  if (!authWindow) {
+    return {
+      exists: false
+    }
+  }
+
+  const destroyed = authWindow.isDestroyed()
+  if (destroyed) {
+    return {
+      exists: true,
+      destroyed: true
+    }
+  }
+
+  const webContents = authWindow.webContents
+  return removeUndefinedProperties({
+    exists: true,
+    destroyed: false,
+    visible: authWindow.isVisible(),
+    focused: authWindow.isFocused(),
+    minimized: authWindow.isMinimized(),
+    loading: webContents ? webContents.isLoading() : undefined,
+    crashed: webContents ? webContents.isCrashed() : undefined,
+    currentUrl: webContents ? describeGitHubOAuthUrl(webContents.getURL()) : undefined
   })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.7",
+      "version": "2.0.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",
@@ -17,6 +17,7 @@
     "test:unit:watch": "vitest",
     "test:build": "webpack --mode development",
     "test:smoke": "npm run test:build && node tests/smoke/electron-render-smoke.js",
+    "test:login-flow": "npm run test:build && node tests/smoke/electron-login-flow-smoke.js",
     "test:packaged-smoke": "npm run pack && node tests/smoke/electron-packaged-smoke.js",
     "package:prepare": "npm run license && npm run webpack-prod",
     "dist": "npm run package:prepare && electron-builder",

--- a/tests/smoke/electron-login-flow-smoke-main.js
+++ b/tests/smoke/electron-login-flow-smoke-main.js
@@ -1,0 +1,372 @@
+const fs = require('fs')
+const path = require('path')
+const { app, BrowserWindow } = require('electron')
+
+const repoRoot = path.resolve(__dirname, '../..')
+const scenario = process.env.LEPTON_LOGIN_FLOW_SCENARIO
+const artifactDir = process.env.LEPTON_LOGIN_FLOW_ARTIFACT_DIR
+const loginModalFlipSettleMs = 700
+const invalidTokenMessage = 'Token invalid. Please try again.'
+
+app.getAppPath = () => repoRoot
+
+require(path.join(repoRoot, 'main.js'))
+
+const rendererEvents = []
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForMainWindow () {
+  const deadline = Date.now() + 30000
+
+  while (Date.now() < deadline) {
+    const window = BrowserWindow.getAllWindows()
+      .find(candidate => candidate && !candidate.isDestroyed() && !candidate.getParentWindow())
+    if (window) return window
+    await wait(100)
+  }
+
+  throw new Error('Timed out waiting for the main Electron window.')
+}
+
+async function waitForRendererLoad (window) {
+  if (!window.webContents.isLoading()) return
+
+  await Promise.race([
+    new Promise(resolve => window.webContents.once('did-finish-load', resolve)),
+    wait(30000)
+  ])
+}
+
+function attachRendererDiagnostics (window) {
+  window.webContents.on('console-message', function (event) {
+    const details = typeof event.message !== 'undefined'
+      ? event
+      : {
+          level: arguments[1],
+          lineNumber: arguments[3],
+          message: arguments[2],
+          sourceId: arguments[4]
+        }
+    rendererEvents.push(`console:${details.level}:${details.sourceId}:${details.lineNumber}: ${details.message}`)
+  })
+  window.webContents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL) => {
+    rendererEvents.push(`did-fail-load:${errorCode}:${validatedURL}: ${errorDescription}`)
+  })
+  window.webContents.on('render-process-gone', (event, details) => {
+    rendererEvents.push(`render-process-gone: ${JSON.stringify(details)}`)
+  })
+  window.webContents.on('crashed', () => {
+    rendererEvents.push('renderer crashed')
+  })
+}
+
+async function waitForCondition (window, expression, description, timeoutMs = 30000) {
+  const found = await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      const deadline = Date.now() + ${timeoutMs}
+      function check() {
+        if (${expression}) {
+          resolve(true)
+          return
+        }
+        if (Date.now() > deadline) {
+          resolve(false)
+          return
+        }
+        setTimeout(check, 100)
+      }
+      check()
+    })
+  `, true)
+
+  if (found) return
+
+  const state = await getRendererState(window)
+  throw new Error([
+    `Timed out waiting for ${description}.`,
+    `Renderer state: ${JSON.stringify(state)}`,
+    `Renderer events: ${rendererEvents.join('\n') || '(none)'}`
+  ].join('\n'))
+}
+
+async function getRendererState (window) {
+  return window.webContents.executeJavaScript(`
+    (() => {
+      const loginModal = document.querySelector('.login-modal')
+      const activeLayout = document.querySelector('.active-layout')
+      const loginStatus = document.querySelector('.login-status-line')
+      const tokenInput = document.querySelector('.login-modal input.form-control')
+      const buttons = Array.from(document.querySelectorAll('button')).map(button => ({
+        disabled: button.disabled,
+        text: button.innerText.trim()
+      }))
+
+      return {
+        bodyText: document.body ? document.body.innerText : '',
+        hasActiveLayout: Boolean(activeLayout),
+        hasLoginModal: Boolean(loginModal),
+        hasTokenInput: Boolean(tokenInput),
+        location: window.location ? window.location.href : '',
+        loginStatus: loginStatus ? loginStatus.innerText : '',
+        buttons
+      }
+    })()
+  `, true)
+}
+
+async function clickButton (window, text) {
+  const result = await window.webContents.executeJavaScript(`
+    (() => {
+      const button = Array.from(document.querySelectorAll('button'))
+        .find(candidate => candidate.innerText.trim() === ${JSON.stringify(text)})
+      if (!button) {
+        return {
+          clicked: false,
+          reason: 'missing-button',
+          bodyText: document.body ? document.body.innerText : ''
+        }
+      }
+      if (button.disabled) {
+        return {
+          clicked: false,
+          reason: 'disabled-button',
+          bodyText: document.body ? document.body.innerText : ''
+        }
+      }
+      button.click()
+      return { clicked: true }
+    })()
+  `, true)
+
+  if (!result.clicked) {
+    throw new Error(`Unable to click button "${text}": ${JSON.stringify(result)}`)
+  }
+}
+
+async function clickLoginModeSwitch (window) {
+  const result = await window.webContents.executeJavaScript(`
+    (() => {
+      const button = document.querySelector('.login-mode-switch')
+      if (!button || button.disabled) {
+        return {
+          clicked: false,
+          hasButton: Boolean(button),
+          disabled: button ? button.disabled : null,
+          bodyText: document.body ? document.body.innerText : ''
+        }
+      }
+      button.click()
+      return { clicked: true }
+    })()
+  `, true)
+
+  if (!result.clicked) {
+    throw new Error(`Unable to switch login mode: ${JSON.stringify(result)}`)
+  }
+
+  await waitForCondition(
+    window,
+    "Boolean(document.querySelector('.login-modal:not(.login-modal-flipping) input.form-control'))",
+    'interactive token login form',
+    loginModalFlipSettleMs + 3000
+  )
+}
+
+async function submitToken (window, token) {
+  await clickLoginModeSwitch(window)
+
+  const result = await window.webContents.executeJavaScript(`
+    (() => {
+      const input = document.querySelector('.login-modal input.form-control')
+      if (!input) return { submitted: false, reason: 'missing-input' }
+
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
+      valueSetter.call(input, ${JSON.stringify(token)})
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+
+      const button = Array.from(document.querySelectorAll('button'))
+        .find(candidate => candidate.innerText.trim() === 'Token Login')
+      if (!button || button.disabled) {
+        return {
+          submitted: false,
+          reason: 'missing-or-disabled-button',
+          hasButton: Boolean(button),
+          disabled: button ? button.disabled : null
+        }
+      }
+      button.click()
+      return { submitted: true }
+    })()
+  `, true)
+
+  if (!result.submitted) {
+    throw new Error(`Unable to submit token login: ${JSON.stringify(result)}`)
+  }
+}
+
+async function waitForInitialLogin (window) {
+  await waitForCondition(
+    window,
+    [
+      "Boolean(document.querySelector('.login-modal'))",
+      "document.body && document.body.innerText.includes('Login')",
+      "document.body && document.body.innerText.includes('GitHub Login')",
+      "!document.querySelector('.login-status-line')",
+      "!document.querySelector('.login-modal input.form-control')"
+    ].join(' && '),
+    'initial credentials login modal'
+  )
+}
+
+async function waitForLoginFailure (window) {
+  await waitForCondition(
+    window,
+    [
+      "Boolean(document.querySelector('.login-modal'))",
+      "document.body && document.body.innerText.includes('Sign-in failed.')",
+      "Array.from(document.querySelectorAll('button')).some(button => button.innerText.trim() === 'GitHub Login' && !button.disabled)"
+    ].join(' && '),
+    'recoverable login failure'
+  )
+}
+
+async function waitForActiveUser (window, login) {
+  await waitForCondition(
+    window,
+    [
+      "Boolean(document.querySelector('.active-layout'))",
+      `document.body && document.body.innerText.toLowerCase().includes(${JSON.stringify(login.toLowerCase())})`
+    ].join(' && '),
+    `active session for ${login}`
+  )
+}
+
+function storagePath (key) {
+  const fileName = path.basename(key, '.json') + '.json'
+  return path.join(app.getPath('userData'), 'storage', encodeURIComponent(fileName))
+}
+
+function readStorageValue (key) {
+  try {
+    return JSON.parse(fs.readFileSync(storagePath(key), 'utf8'))
+  } catch (error) {
+    return undefined
+  }
+}
+
+async function waitForCachedCredentialClear () {
+  const deadline = Date.now() + 10000
+
+  while (Date.now() < deadline) {
+    if (readStorageValue('token') === null && readStorageValue('profile') === null) return
+    await wait(100)
+  }
+
+  throw new Error(`Timed out waiting for cached credential clear: ${JSON.stringify({
+    token: readStorageValue('token'),
+    profile: readStorageValue('profile')
+  })}`)
+}
+
+async function captureScreenshot (window, fileName) {
+  if (!artifactDir || !window || window.isDestroyed()) return
+
+  const screenshotPath = path.join(artifactDir, fileName)
+  await window.webContents.executeJavaScript(`
+    new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    })
+  `, true)
+  await wait(250)
+  const image = await window.capturePage()
+  fs.writeFileSync(screenshotPath, image.toPNG())
+  console.log(`Saved login-flow screenshot to ${screenshotPath}`)
+}
+
+async function assertInitialLoginAfterInvalidCredential (window) {
+  await waitForCondition(
+    window,
+    [
+      "Boolean(document.querySelector('.login-modal'))",
+      "document.body && document.body.innerText.includes('Login')",
+      "document.body && document.body.innerText.includes('GitHub Login')",
+      `document.body && document.body.innerText.includes(${JSON.stringify(invalidTokenMessage)})`,
+      "!document.querySelector('.login-modal input.form-control')"
+    ].join(' && '),
+    'retryable credentials login modal with invalid token message'
+  )
+  const state = await getRendererState(window)
+  if (!state.bodyText.includes(invalidTokenMessage)) {
+    throw new Error(`Invalid credential should explain the token failure: ${JSON.stringify(state)}`)
+  }
+  if (/See log|Please check your network condition/.test(state.bodyText)) {
+    throw new Error(`Invalid credential should not show system-level error affordances: ${JSON.stringify(state)}`)
+  }
+}
+
+async function runScenario (window) {
+  switch (scenario) {
+    case 'oauth-success':
+      await waitForInitialLogin(window)
+      await clickButton(window, 'GitHub Login')
+      await waitForActiveUser(window, 'oauth-user')
+      return
+    case 'oauth-denied-retry':
+      await waitForInitialLogin(window)
+      await clickButton(window, 'GitHub Login')
+      await waitForLoginFailure(window)
+      await clickButton(window, 'GitHub Login')
+      await waitForActiveUser(window, 'oauth-user')
+      return
+    case 'oauth-exchange-failure-retry':
+      await waitForInitialLogin(window)
+      await clickButton(window, 'GitHub Login')
+      await waitForLoginFailure(window)
+      await clickButton(window, 'GitHub Login')
+      await waitForActiveUser(window, 'oauth-user')
+      return
+    case 'manual-token-success':
+      await waitForInitialLogin(window)
+      await submitToken(window, 'manual-good-token')
+      await waitForActiveUser(window, 'manual-user')
+      return
+    case 'manual-token-invalid':
+      await waitForInitialLogin(window)
+      await submitToken(window, 'manual-bad-token')
+      await assertInitialLoginAfterInvalidCredential(window)
+      return
+    case 'cached-token-success':
+      await waitForActiveUser(window, 'cached-user')
+      return
+    case 'cached-token-invalid':
+      await waitForCachedCredentialClear()
+      await assertInitialLoginAfterInvalidCredential(window)
+      return
+    default:
+      throw new Error(`Unsupported login-flow scenario: ${scenario}`)
+  }
+}
+
+async function main () {
+  let window
+
+  try {
+    window = await waitForMainWindow()
+    attachRendererDiagnostics(window)
+    await waitForRendererLoad(window)
+    await runScenario(window)
+    await captureScreenshot(window, `electron-login-flow-${scenario}-success.png`)
+    console.log(`electron login-flow smoke test passed: ${scenario}`)
+    app.exit(0)
+  } catch (error) {
+    await captureScreenshot(window, `electron-login-flow-${scenario || 'unknown'}-failure.png`)
+    console.error(error)
+    app.exit(1)
+  }
+}
+
+app.whenReady().then(main)

--- a/tests/smoke/electron-login-flow-smoke.js
+++ b/tests/smoke/electron-login-flow-smoke.js
@@ -1,0 +1,328 @@
+const fs = require('fs')
+const http = require('http')
+const os = require('os')
+const path = require('path')
+const { spawn } = require('child_process')
+const electronPath = require('electron')
+
+const repoRoot = path.resolve(__dirname, '../..')
+const bundlePath = path.join(repoRoot, 'bundle', 'app.bundle.js')
+const smokeMainPath = path.join(__dirname, 'electron-login-flow-smoke-main.js')
+
+const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACw='
+
+const scenarios = [
+  {
+    name: 'oauth-success'
+  },
+  {
+    name: 'oauth-denied-retry'
+  },
+  {
+    name: 'oauth-exchange-failure-retry'
+  },
+  {
+    name: 'manual-token-success'
+  },
+  {
+    name: 'manual-token-invalid'
+  },
+  {
+    name: 'cached-token-success',
+    cachedUserInfo: {
+      profile: 'cached-user',
+      token: 'cached-good-token'
+    }
+  },
+  {
+    name: 'cached-token-invalid',
+    cachedUserInfo: {
+      profile: 'cached-user',
+      token: 'cached-bad-token'
+    }
+  }
+]
+
+function assertBuiltBundleExists () {
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error('Missing bundle/app.bundle.js. Run `npm run test:build` before the login-flow smoke test.')
+  }
+}
+
+function createTempHome (scenario) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lepton-login-flow-'))
+  const configHome = path.join(root, 'config')
+  const userData = path.join(root, 'user-data')
+  fs.mkdirSync(configHome, { recursive: true })
+  fs.mkdirSync(userData, { recursive: true })
+  fs.writeFileSync(path.join(configHome, '.leptonrc'), JSON.stringify({
+    autoUpdate: false,
+    i18n: {
+      locale: 'en'
+    },
+    logger: {
+      level: 'error'
+    },
+    notifications: {
+      failure: true,
+      success: false
+    },
+    security: {
+      cachedAccessTokenStorage: 'file'
+    }
+  }))
+
+  if (scenario.cachedUserInfo) {
+    seedCachedUserInfo(userData, scenario.cachedUserInfo)
+  }
+
+  return { configHome, root, userData }
+}
+
+function seedCachedUserInfo (userData, cachedUserInfo) {
+  const storageDir = path.join(userData, 'storage')
+  fs.mkdirSync(storageDir, { recursive: true })
+  writeStorageValue(storageDir, 'profile', cachedUserInfo.profile)
+  writeStorageValue(storageDir, 'token', cachedUserInfo.token)
+}
+
+function writeStorageValue (storageDir, key, value) {
+  const fileName = path.basename(key, '.json') + '.json'
+  fs.writeFileSync(path.join(storageDir, encodeURIComponent(fileName)), JSON.stringify(value), 'utf8')
+}
+
+function createProfile (login) {
+  return {
+    login,
+    id: login.length,
+    avatar_url: transparentGif,
+    type: 'User'
+  }
+}
+
+function extractAuthToken (request) {
+  const authorization = request.headers.authorization || ''
+  const match = authorization.match(/^token\s+(.+)$/)
+  return match ? match[1] : ''
+}
+
+function getAuthorizeRedirect (scenarioName, authorizeCount, baseUrl) {
+  if (scenarioName === 'oauth-denied-retry' && authorizeCount === 1) {
+    return `${baseUrl}/oauth/callback?error=access_denied&error_description=denied`
+  }
+
+  if (scenarioName === 'oauth-exchange-failure-retry' && authorizeCount === 1) {
+    return `${baseUrl}/oauth/callback?code=exchange-failure-code`
+  }
+
+  return `${baseUrl}/oauth/callback?code=oauth-success-code`
+}
+
+function readRequestBody (request) {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    request.on('data', chunk => {
+      body += chunk
+    })
+    request.on('end', () => resolve(body))
+    request.on('error', reject)
+  })
+}
+
+function writeJson (response, statusCode, body, headers = {}) {
+  response.writeHead(statusCode, Object.assign({
+    'content-type': 'application/json'
+  }, headers))
+  response.end(JSON.stringify(body))
+}
+
+function writeRedirect (response, location) {
+  response.writeHead(302, {
+    location
+  })
+  response.end()
+}
+
+function startMockGitHubServer (scenario) {
+  return new Promise((resolve, reject) => {
+    const requests = []
+    let authorizeCount = 0
+    let baseUrl = ''
+
+    const server = http.createServer(async (request, response) => {
+      const url = new URL(request.url, baseUrl)
+      requests.push({
+        method: request.method,
+        pathname: url.pathname
+      })
+
+      try {
+        if (url.pathname === '/login/oauth/authorize') {
+          authorizeCount += 1
+          writeRedirect(response, getAuthorizeRedirect(scenario.name, authorizeCount, baseUrl))
+          return
+        }
+
+        if (url.pathname === '/login/oauth/access_token') {
+          const form = new URLSearchParams(await readRequestBody(request))
+          const code = form.get('code')
+          if (code === 'exchange-failure-code') {
+            writeJson(response, 200, {
+              error: 'bad_verification_code',
+              error_description: 'The OAuth code was rejected by the mock service.'
+            })
+            return
+          }
+
+          writeJson(response, 200, {
+            access_token: 'oauth-token',
+            scope: 'gist',
+            token_type: 'bearer'
+          })
+          return
+        }
+
+        if (url.pathname === '/api/user') {
+          const token = extractAuthToken(request)
+          const profiles = {
+            'cached-good-token': 'cached-user',
+            'manual-good-token': 'manual-user',
+            'oauth-token': 'oauth-user'
+          }
+
+          if (!profiles[token]) {
+            writeJson(response, 401, {
+              message: 'Bad credentials',
+              documentation_url: 'https://docs.github.com/rest',
+              status: '401'
+            }, {
+              'x-github-request-id': 'LOGIN-FLOW-MOCK'
+            })
+            return
+          }
+
+          writeJson(response, 200, createProfile(profiles[token]))
+          return
+        }
+
+        if (url.pathname === '/api/gists' || /^\/api\/users\/[^/]+\/gists$/.test(url.pathname)) {
+          const token = extractAuthToken(request)
+          if (!token || token.endsWith('bad-token')) {
+            writeJson(response, 401, {
+              message: 'Bad credentials',
+              documentation_url: 'https://docs.github.com/rest',
+              status: '401'
+            })
+            return
+          }
+
+          writeJson(response, 200, [])
+          return
+        }
+
+        writeJson(response, 404, {
+          message: `Unhandled mock route: ${request.method} ${url.pathname}`
+        })
+      } catch (error) {
+        writeJson(response, 500, {
+          message: error.message
+        })
+      }
+    })
+
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      baseUrl = `http://127.0.0.1:${address.port}`
+      resolve({
+        baseUrl,
+        close: () => new Promise((resolveClose, rejectClose) => {
+          server.close(error => error ? rejectClose(error) : resolveClose())
+        }),
+        requests
+      })
+    })
+  })
+}
+
+function runSmokeProcess (tempHome, server, scenario) {
+  return new Promise((resolve, reject) => {
+    const electronArgs = [
+      `--user-data-dir=${tempHome.userData}`,
+      smokeMainPath
+    ]
+
+    if (process.env.LEPTON_SMOKE_NO_SANDBOX === '1') {
+      electronArgs.unshift('--no-sandbox')
+    }
+
+    const env = Object.assign({}, process.env, {
+      ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      LEPTON_LOGIN_FLOW_ARTIFACT_DIR: tempHome.root,
+      LEPTON_LOGIN_FLOW_SCENARIO: scenario.name,
+      LEPTON_TEST_GITHUB_API_BASE_URL: `${server.baseUrl}/api`,
+      LEPTON_TEST_GITHUB_OAUTH_ACCESS_TOKEN_URL: `${server.baseUrl}/login/oauth/access_token`,
+      LEPTON_TEST_GITHUB_OAUTH_AUTHORIZE_URL: `${server.baseUrl}/login/oauth/authorize`,
+      XDG_CONFIG_HOME: tempHome.configHome
+    })
+
+    const child = spawn(electronPath, electronArgs, {
+      cwd: repoRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    let output = ''
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`Electron login-flow smoke test timed out for ${scenario.name}.\n${output}`))
+    }, 45000)
+
+    child.stdout.on('data', data => {
+      const text = data.toString()
+      output += text
+      process.stdout.write(text)
+    })
+    child.stderr.on('data', data => {
+      const text = data.toString()
+      output += text
+      process.stderr.write(text)
+    })
+    child.on('error', error => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('exit', (code, signal) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error(`Electron login-flow smoke test failed for ${scenario.name} with exit code ${code} and signal ${signal}.\n${output}`))
+    })
+  })
+}
+
+async function runScenario (scenario) {
+  const tempHome = createTempHome(scenario)
+  const server = await startMockGitHubServer(scenario)
+
+  try {
+    await runSmokeProcess(tempHome, server, scenario)
+  } finally {
+    await server.close()
+  }
+}
+
+async function main () {
+  assertBuiltBundleExists()
+
+  for (const scenario of scenarios) {
+    await runScenario(scenario)
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tests/smoke/electron-render-smoke-main.js
+++ b/tests/smoke/electron-render-smoke-main.js
@@ -130,6 +130,7 @@ async function getRendererState (window) {
       const appContainer = document.querySelector('.app-container')
       const loginModal = document.querySelector('.login-modal')
       const expectedSelector = ${JSON.stringify(expectedSelector)}
+      const forbiddenSelector = ${JSON.stringify(process.env.LEPTON_SMOKE_FORBIDDEN_SELECTOR || '')}
       const appBounds = appContainer ? appContainer.getBoundingClientRect() : null
       const languageSelector = document.querySelector('[data-role="language-selector"]')
       const languageSelectorLabel = document.querySelector('.login-language-selector')
@@ -155,6 +156,7 @@ async function getRendererState (window) {
         hasAppContainer: Boolean(appContainer),
         hasLoginModal: Boolean(loginModal),
         hasExpectedSelector: expectedSelector ? Boolean(document.querySelector(expectedSelector)) : true,
+        hasForbiddenSelector: forbiddenSelector ? Boolean(document.querySelector(forbiddenSelector)) : false,
         hasLeptonBridge: Boolean(window.lepton),
         hasLeptonConfigBridge: Boolean(window.lepton && window.lepton.config && window.lepton.config.get),
         processType: typeof process,
@@ -469,6 +471,7 @@ function assertFixtureRendererState (state) {
   }
 
   assertForbiddenFixtureTextAbsent(state)
+  assertForbiddenFixtureSelectorAbsent(state)
 }
 
 function assertForbiddenFixtureTextAbsent (state) {
@@ -477,6 +480,11 @@ function assertForbiddenFixtureTextAbsent (state) {
   if (visibleForbiddenText) {
     throw new Error(`Forbidden fixture UI text "${visibleForbiddenText}" was visible. Body text: ${state.bodyText}`)
   }
+}
+
+function assertForbiddenFixtureSelectorAbsent (state) {
+  if (!state.hasForbiddenSelector) return
+  throw new Error(`Forbidden fixture selector was visible: ${process.env.LEPTON_SMOKE_FORBIDDEN_SELECTOR}`)
 }
 
 async function assertFixtureLoginModeSwitch (window) {

--- a/tests/smoke/electron-render-smoke.js
+++ b/tests/smoke/electron-render-smoke.js
@@ -119,6 +119,13 @@ const RENDER_FIXTURES = [
     text: 'Sign-in failed.|See log'
   },
   {
+    name: 'login-expired-token',
+    selector: '.login-modal',
+    text: 'Login|GitHub Login|Token invalid. Please try again.',
+    forbiddenText: 'See log',
+    forbiddenSelector: '.login-alert'
+  },
+  {
     name: 'login-stale-success-logged-out',
     selector: '.login-modal',
     text: 'Login|GitHub Login',
@@ -148,6 +155,7 @@ function runSmokeProcess (tempHome, options) {
       ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
       LEPTON_SMOKE_ARTIFACT_DIR: tempHome.root,
       LEPTON_SMOKE_AFTER_SWITCH_TEXT: options.switchText || '',
+      LEPTON_SMOKE_FORBIDDEN_SELECTOR: options.forbiddenSelector || '',
       LEPTON_SMOKE_FORBIDDEN_TEXT: options.forbiddenText || '',
       LEPTON_SMOKE_SWITCH_LOGIN_MODE: options.switchLoginMode ? '1' : '',
       LEPTON_SMOKE_EXPECTED_TEXT: options.expectedText,
@@ -210,6 +218,7 @@ async function main () {
       expectedSelector: fixture.selector,
       forbiddenText: fixture.forbiddenText,
       expectedText: fixture.text,
+      forbiddenSelector: fixture.forbiddenSelector,
       renderFixture: fixture.name,
       switchLoginMode: fixture.switchLoginMode,
       switchText: fixture.switchText

--- a/tests/utilities/githubApi.test.js
+++ b/tests/utilities/githubApi.test.js
@@ -107,6 +107,41 @@ describe('GitHub API utility', () => {
     expect(init).not.toHaveProperty('agent')
   })
 
+  it('supports a mock OAuth token endpoint for login-flow smoke tests', async () => {
+    const fetch = vi.fn(() => Promise.resolve(createJsonResponse({ access_token: 'token-1' })))
+
+    const mockApi = createGitHubApi({
+      conf: createConf(),
+      logger,
+      oauthAccessTokenUrl: 'http://127.0.0.1:9999/login/oauth/access_token',
+      fetchImpl: fetch
+    })
+
+    await mockApi.getGitHubApi(EXCHANGE_ACCESS_TOKEN)('client-id', 'client-secret', 'auth-code')
+
+    const [url] = fetch.mock.calls[0]
+    expect(url).toBe('http://127.0.0.1:9999/login/oauth/access_token')
+  })
+
+  it('supports a mock GitHub API base URL for login-flow smoke tests', async () => {
+    const fetch = vi.fn((url) => Promise.resolve(createJsonResponse(
+      String(url).includes('/user') ? { login: 'octo' } : []
+    )))
+    const api = createGitHubApi({
+      conf: createConf(),
+      gitHubApiBaseUrl: 'http://127.0.0.1:9999/api/',
+      logger,
+      fetchImpl: fetch
+    })
+
+    await api.getGitHubApi(GET_USER_PROFILE)('token-1')
+    expect(fetch.mock.calls[0][0]).toBe('http://127.0.0.1:9999/api/user')
+
+    fetch.mockClear()
+    await api.getGitHubApi(GET_ALL_GISTS)('token-1', 'octo')
+    expect(fetch.mock.calls[0][0]).toBe('http://127.0.0.1:9999/api/users/octo/gists?per_page=100&page=1')
+  })
+
   it('rejects OAuth token exchange responses without an access token', async () => {
     const { api } = loadGitHubApi({
       fetchImpl: () => Promise.resolve(createJsonResponse({

--- a/tests/utilities/githubOAuth.test.js
+++ b/tests/utilities/githubOAuth.test.js
@@ -4,7 +4,8 @@ import githubOAuth from '../../app/utilities/auth/githubOAuth'
 const {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
-  parseGitHubOAuthCallback
+  parseGitHubOAuthCallback,
+  shouldIgnoreGitHubOAuthLoadFailure
 } = githubOAuth
 
 describe('GitHub OAuth utility', () => {
@@ -15,6 +16,16 @@ describe('GitHub OAuth utility', () => {
     })
 
     expect(url).toBe('https://github.com/login/oauth/authorize?client_id=client-id&scope=gist+repo')
+  })
+
+  it('can build the OAuth authorize URL against a mock service', () => {
+    const url = buildGitHubOAuthUrl({
+      authorizeUrl: 'http://127.0.0.1:9999/login/oauth/authorize',
+      clientId: 'client-id',
+      scopes: ['gist']
+    })
+
+    expect(url).toBe('http://127.0.0.1:9999/login/oauth/authorize?client_id=client-id&scope=gist')
   })
 
   it('parses successful callback codes', () => {
@@ -64,5 +75,27 @@ describe('GitHub OAuth utility', () => {
         error: 'access_denied',
         errorDescription: 'nope'
       })
+  })
+
+  it('keeps OAuth auth windows open for aborted or non-main-frame load failures', () => {
+    expect(shouldIgnoreGitHubOAuthLoadFailure({
+      errorCode: -3,
+      isMainFrame: true
+    })).toBe(true)
+
+    expect(shouldIgnoreGitHubOAuthLoadFailure({
+      errorDescription: "ERR_ABORTED (-3) loading 'https://github.com/login/oauth/authorize'",
+      isMainFrame: true
+    })).toBe(true)
+
+    expect(shouldIgnoreGitHubOAuthLoadFailure({
+      errorCode: -2,
+      isMainFrame: false
+    })).toBe(true)
+
+    expect(shouldIgnoreGitHubOAuthLoadFailure({
+      errorCode: -2,
+      isMainFrame: true
+    })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Fixes the invalid-token login path so Lepton never leaves the user blocked behind stale auth state, and adds an Electron login-flow smoke framework backed by a local mock GitHub OAuth/API service.

- Bumps the prerelease version to `2.0.0-beta.8` for the Win11 verification build.
- Clears cached token/profile state when GitHub returns 401 during startup or manual-token login, then returns to the initial login modal with `Token invalid. Please try again.` visible in the consolidated bottom status line.
- Removes the old yellow login alert from the login modal and keeps bottom status/log messaging for system-level failures only.
- Keeps the GitHub OAuth auth window visible on main-frame load failures instead of immediately destroying it, while still ignoring expected navigation aborts.
- Adds redacted OAuth popup diagnostics for navigation, redirects, load start/finish/failure, window show/close, renderer crash/unresponsive events, and final auth-flow disposition to help diagnose Win11 prerelease reports.
- Adds mockable GitHub OAuth/API URL hooks for test runs without changing production defaults.
- Adds `npm run test:login-flow` covering OAuth success, OAuth denial retry, OAuth exchange failure retry, manual token success/failure, and cached token success/failure.
- Extends render smoke coverage so expired-token login renders as a retryable login modal with the invalid-token explanation and no `See log` link.
- Adds the missing star marker to the English login tagline: `Lepton is FREE. Like us on GitHub ⭐`.

## Root Cause

A stale cached token produced a GitHub 401, but the app treated that as a generic system login failure. That left the stale credential path visible as `Token invalid` / `See log` instead of clearing cached auth and returning the user to a retryable login state with a user-level explanation.

The earlier disappearing OAuth popup may still have an environment-specific root cause, such as network, proxy, firewall, DNS, TLS interception, or GitHub availability. This PR improves Lepton's handling and adds redacted logs so a Win11 prerelease can tell whether the popup reached GitHub, failed loading, redirected, crashed, closed, or returned an OAuth error.

## Validation

- `node --check main.js`
- `node --check app/index.js`
- `npm run lint`
- `npm test` - 35 files, 189 tests plus webpack development build
- `npm run test:unit -- tests/utilities/i18n.test.js`
- `npm run test:login-flow` - all 7 login-flow scenarios
- `npm run test:smoke`
- `git diff --check`

## Release Plan

After this PR is merged into `master`, create and push tag `v2.0.0-beta.8`. The tag-triggered `release` workflow will publish a GitHub prerelease and build macOS, Windows, and Linux artifacts. The Windows job uploads and publishes `.exe`, `.7z`, and `latest.yml` artifacts.

## Notes

`gh auth status` reports the local GitHub CLI token is invalid, so this PR was created through the GitHub connector after pushing with git.