### PR TITLE
[codex] Fix packaged Windows OAuth locale resources

### DIFF
--- a/app/utilities/auth/githubOAuth.js
+++ b/app/utilities/auth/githubOAuth.js
@@ -1,6 +1,5 @@
 const GITHUB_OAUTH_URL = 'https://github.com/login/oauth/authorize'
 const ELECTRON_ABORTED_LOAD_ERROR_CODE = -3
-const WINDOWS_GITHUB_OAUTH_DISABLED_CHROMIUM_FEATURES = ['RendererCodeIntegrity']
 
 function normalizeScopes (scopes = []) {
   if (Array.isArray(scopes)) {
@@ -100,20 +99,6 @@ function shouldIgnoreGitHubOAuthLoadFailure ({
   return isAbortedLoadError(errorCode, errorDescription) || isMainFrame === false
 }
 
-function shouldSandboxGitHubOAuthWindow (platform = process.platform) {
-  return platform !== 'win32'
-}
-
-function shouldDisableGitHubOAuthHardwareAccelerationWorkaround (platform = process.platform) {
-  return platform === 'win32'
-}
-
-function getGitHubOAuthDisabledChromiumFeaturesWorkaround (platform = process.platform) {
-  if (platform !== 'win32') return []
-
-  return WINDOWS_GITHUB_OAUTH_DISABLED_CHROMIUM_FEATURES.slice()
-}
-
 function isAbortedLoadError (errorCode, errorDescription) {
   return Number(errorCode) === ELECTRON_ABORTED_LOAD_ERROR_CODE ||
     /\bERR_ABORTED\b|\(-3\)/.test(String(errorDescription || ''))
@@ -132,8 +117,5 @@ module.exports = {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
   parseGitHubOAuthCallback,
-  shouldIgnoreGitHubOAuthLoadFailure,
-  shouldDisableGitHubOAuthHardwareAccelerationWorkaround,
-  getGitHubOAuthDisabledChromiumFeaturesWorkaround,
-  shouldSandboxGitHubOAuthWindow
+  shouldIgnoreGitHubOAuthLoadFailure
 }

--- a/configs/electronLanguages.js
+++ b/configs/electronLanguages.js
@@ -1,15 +1,13 @@
-const scriptSpecificChineseResourceSuffixes = {
-  Hans: [67, 78],
-  Hant: [84, 87]
+// Electron packages Chromium locale resources by .pak filename, which does not
+// always match Lepton's app-facing locale id.
+const electronLanguageOverrides = {
+  en: 'en-US',
+  'zh-Hans': 'zh-CN',
+  'zh-Hant': 'zh-TW'
 }
 
 function toElectronLanguage (locale) {
-  const [language, script] = locale.split('-')
-  const resourceSuffix = scriptSpecificChineseResourceSuffixes[script]
-
-  return resourceSuffix
-    ? [language, String.fromCharCode(...resourceSuffix)].join('_')
-    : locale
+  return electronLanguageOverrides[locale] || locale
 }
 
 function getElectronLanguages (supportedLocales) {

--- a/main.js
+++ b/main.js
@@ -34,10 +34,7 @@ const {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
   parseGitHubOAuthCallback,
-  shouldIgnoreGitHubOAuthLoadFailure,
-  shouldDisableGitHubOAuthHardwareAccelerationWorkaround,
-  getGitHubOAuthDisabledChromiumFeaturesWorkaround,
-  shouldSandboxGitHubOAuthWindow
+  shouldIgnoreGitHubOAuthLoadFailure
 } = require('./app/utilities/auth/githubOAuth')
 const {
   clearGitHubAuthWindowStorageAndDestroy
@@ -45,7 +42,6 @@ const {
 const { applyDefaultZoomPercent } = require('./app/utilities/zoom')
 
 const logger = createMainLogger()
-applyGitHubOAuthRenderWorkarounds()
 const electronLocalStorage = createElectronLocalStorage({
   getUserDataPath: () => app.getPath('userData')
 })
@@ -85,25 +81,6 @@ let operationType = 0
 const MACOS_TRAY_ICON_SIZE = 18
 
 const shortcuts = nconf.get('shortcuts')
-
-function applyGitHubOAuthRenderWorkarounds () {
-  const disableHardwareAcceleration = shouldDisableGitHubOAuthHardwareAccelerationWorkaround(process.platform)
-  const disabledChromiumFeatures = getGitHubOAuthDisabledChromiumFeaturesWorkaround(process.platform)
-  if (!disableHardwareAcceleration && disabledChromiumFeatures.length === 0) return
-
-  if (disabledChromiumFeatures.length > 0) {
-    app.commandLine.appendSwitch('disable-features', disabledChromiumFeatures.join(','))
-  }
-
-  if (disableHardwareAcceleration) {
-    app.disableHardwareAcceleration()
-  }
-
-  logger.info('[auth] Applied Electron render workarounds for Windows GitHub OAuth: ' + JSON.stringify({
-    disabledChromiumFeatures,
-    hardwareAccelerationDisabled: disableHardwareAcceleration
-  }))
-}
 
 function getConfigPath() {
   if (process && process.env && process.env.XDG_CONFIG_HOME) {
@@ -727,7 +704,6 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     })
   }
 
-  const sandboxAuthWindow = shouldSandboxGitHubOAuthWindow(process.platform)
   const authWindow = new BrowserWindow({
     parent: mainWindow,
     width: 400,
@@ -737,7 +713,7 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
       nodeIntegration: false,
       enableRemoteModule: false,
       contextIsolation: true,
-      sandbox: sandboxAuthWindow,
+      sandbox: true,
       spellcheck: false
     }
   })
@@ -763,7 +739,6 @@ function startGitHubAuthFlow ({ clientId, scopes } = {}) {
     hasClientId: Boolean(clientId),
     clientIdLength: clientId.length,
     scopeCount: Array.isArray(scopes) ? scopes.length : 0,
-    sandbox: sandboxAuthWindow,
     authorizeUrl: describeGitHubOAuthUrl(authUrl)
   }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.8",
+      "version": "2.0.0-beta.13",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.13",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",

--- a/tests/utilities/githubOAuth.test.js
+++ b/tests/utilities/githubOAuth.test.js
@@ -5,10 +5,7 @@ const {
   buildGitHubOAuthUrl,
   describeGitHubOAuthUrl,
   parseGitHubOAuthCallback,
-  shouldIgnoreGitHubOAuthLoadFailure,
-  shouldDisableGitHubOAuthHardwareAccelerationWorkaround,
-  getGitHubOAuthDisabledChromiumFeaturesWorkaround,
-  shouldSandboxGitHubOAuthWindow
+  shouldIgnoreGitHubOAuthLoadFailure
 } = githubOAuth
 
 describe('GitHub OAuth utility', () => {
@@ -100,24 +97,5 @@ describe('GitHub OAuth utility', () => {
       errorCode: -2,
       isMainFrame: true
     })).toBe(false)
-  })
-
-  it('uses a non-sandboxed OAuth auth window on Windows', () => {
-    expect(shouldSandboxGitHubOAuthWindow('win32')).toBe(false)
-    expect(shouldSandboxGitHubOAuthWindow('darwin')).toBe(true)
-    expect(shouldSandboxGitHubOAuthWindow('linux')).toBe(true)
-  })
-
-  it('disables hardware acceleration only for the Windows OAuth rendering workaround', () => {
-    expect(shouldDisableGitHubOAuthHardwareAccelerationWorkaround('win32')).toBe(true)
-    expect(shouldDisableGitHubOAuthHardwareAccelerationWorkaround('darwin')).toBe(false)
-    expect(shouldDisableGitHubOAuthHardwareAccelerationWorkaround('linux')).toBe(false)
-  })
-
-  it('disables Chromium renderer code integrity only for the Windows OAuth rendering workaround', () => {
-    expect(getGitHubOAuthDisabledChromiumFeaturesWorkaround('win32'))
-      .toEqual(['RendererCodeIntegrity'])
-    expect(getGitHubOAuthDisabledChromiumFeaturesWorkaround('darwin')).toEqual([])
-    expect(getGitHubOAuthDisabledChromiumFeaturesWorkaround('linux')).toEqual([])
   })
 })

--- a/tests/utilities/i18n.test.js
+++ b/tests/utilities/i18n.test.js
@@ -163,13 +163,28 @@ describe('i18n utilities', () => {
     expect(builderConfig.electronLanguages).toEqual(getElectronLanguages(getSupportedLocales()))
   })
 
-  it('maps script-specific Chinese locales to Electron resource names', () => {
+  it('maps app locales to Electron resource names', () => {
     expect(getElectronLanguages([
+      { code: 'en' },
       { code: 'zh-Hans' },
       { code: 'zh-Hant' }
     ])).toEqual([
-      ['zh', String.fromCharCode(67, 78)].join('_'),
-      ['zh', String.fromCharCode(84, 87)].join('_')
+      'en-US',
+      'zh-CN',
+      'zh-TW'
+    ])
+  })
+
+  it('maps every supported locale to the expected Electron resource names', () => {
+    expect(getElectronLanguages(getSupportedLocales())).toEqual([
+      'en-US',
+      'es',
+      'fr',
+      'ja',
+      'ko',
+      'tr',
+      'zh-CN',
+      'zh-TW'
     ])
   })
 


### PR DESCRIPTION
## What changed

- Map Lepton's app-facing locales to the actual Electron/Chromium locale resource names used by packaged builds:
  - `en` -> `en-US`
- Add unit coverage that every supported app locale maps to a real Electron `.pak` file.
- Remove the earlier Windows OAuth render workarounds from #650:
  - no more `RendererCodeIntegrity` switch
  - no global Windows hardware acceleration disable
  - OAuth window sandbox is restored to `sandbox: true`
- Bump the prerelease test version to `2.0.0-beta.13`.

## Root cause

The packaged Windows build was omitting `en-US.pak` because `electronLanguages` was given Lepton's app locale id `en`, but Electron ships the Chromium resource as `en-US.pak`. With no English Chromium locale resource available, packaged child renderers launched with an empty locale state and GitHub's login page could crash while loading.

Manually adding `en-US.pak` to the installed beta.11 `locales` directory changed the renderer command line to `--lang=en-US` and made the GitHub login page render. A standalone Electron 42 harness reproduced the same failure mode: simple pages such as `example.com` rendered, but GitHub and Google crashed when no English locale pack was available.

## Validation

- `npm.cmd run test:unit -- tests/utilities/i18n.test.js tests/utilities/githubOAuth.test.js`
  - 2 files passed, 25 tests passed.
- Built Windows packages with:
  - `npm.cmd run package:prepare`
  - `electron-builder.cmd --win --config electron-builder.js --publish never`
- Installed `dist/Lepton-2.0.0-beta.13-win-x64.exe`.
- Verified installed `resources/app.asar` reports version `2.0.0-beta.13`, contains the locale mapping, and no longer contains `RendererCodeIntegrity`, `disableHardwareAcceleration`, or `applyGitHubOAuthRenderWorkarounds`.
- Verified installed `locales`
- Ran packaged OAuth render checks for every supported app locale, passing the corresponding Electron `--lang` value
- In all 8 cases, the GitHub OAuth popup rendered `Sign in to GitHub · GitHub` with both `#login_field` and `#password` present.

## Test artifact

- Installer: `C:\Users\cosmo\projects\Lepton\dist\Lepton-2.0.0-beta.13-win-x64.exe`
- SHA256: `C1C9D3109E012BFD1D3ED5B949B72F26B3F8795552A8DD2DB61C2C139D8686D0`
