### PR TITLE
[codex] Bump prerelease version to 2.0.0-beta.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.13",
+      "version": "2.0.0-beta.14",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
﻿## What changed

- Bump prerelease version from `2.0.0-beta.13` to `2.0.0-beta.14` for the next GitHub prerelease flow.

## Validation

- `npm.cmd run test:unit -- tests/utilities/i18n.test.js tests/utilities/githubOAuth.test.js`
- `npm.cmd run test:build`

After this PR lands, the release flow can be started by tagging `v2.0.0-beta.14` on `master`.
