### PR TITLE
[codex] Polish scrollbar UX

### DIFF
--- a/app/containers/appContainer/index.scss
+++ b/app/containers/appContainer/index.scss
@@ -46,7 +46,7 @@
   }
 
   .split-pane-pane {
-    overflow: hidden;
+    overflow: hidden !important;
   }
 
   .alert {

--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -39,6 +39,8 @@ $quiet-scrollbar-thumb-active: color-mix(in srgb, var(--text-secondary) 58%, tra
 
 .menu-panel .tag-section-content,
 .panel-thumbnails-scroll,
+.snippet-panel,
+.snippet-panel-immersive,
 .snippet-box pre,
 .markdown-section .highlight pre,
 .markdown-section.asciidoc-section .listingblock pre,

--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -1,4 +1,48 @@
-// Avoid global WebKit scrollbar customization. Setting scrollbar dimensions
-// forces classic scrollbars in Chromium and creates blank layout gutters between
-// panes. Native overlay scrollbars avoid both hover-time resize and persistent
-// gaps on macOS.
+// Keep scrollbar customization scoped to app scroll containers. Global WebKit
+// scrollbar rules force classic scrollbars in Chromium and create blank gutters
+// between panes.
+$quiet-scrollbar-thumb: color-mix(in srgb, var(--text-secondary) 38%, transparent);
+$quiet-scrollbar-thumb-active: color-mix(in srgb, var(--text-secondary) 58%, transparent);
+
+@mixin quiet-scrollbar {
+  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
+
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-corner,
+  &::-webkit-scrollbar-button {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: transparent;
+    border: 3px solid transparent;
+    border-radius: 999px;
+  }
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    scrollbar-color: $quiet-scrollbar-thumb transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background-color: $quiet-scrollbar-thumb;
+    }
+  }
+
+  &::-webkit-scrollbar-thumb:hover,
+  &::-webkit-scrollbar-thumb:active {
+    background-color: $quiet-scrollbar-thumb-active;
+  }
+}
+
+.menu-panel .tag-section-content,
+.panel-thumbnails-scroll,
+.snippet-box pre,
+.markdown-section .highlight pre,
+.markdown-section.asciidoc-section .listingblock pre,
+.jupyterNotebook-section .nb-output,
+.raw-modal .modal-content {
+  @include quiet-scrollbar;
+}

--- a/app/containers/navigationPanel/index.scss
+++ b/app/containers/navigationPanel/index.scss
@@ -129,7 +129,8 @@
 
   .tag-section-content {
     flex: 1 1 auto;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     padding-left: 16px;
   }
 

--- a/app/containers/navigationPanelDetails/index.scss
+++ b/app/containers/navigationPanelDetails/index.scss
@@ -6,7 +6,8 @@
 .panel-thumbnails-scroll {
   float: left;
   width: 100%;
-  overflow-y: overlay;
+  overflow-x: hidden;
+  overflow-y: auto;
   height: 100%;
   visibility: visible;
 }

--- a/app/containers/snippet/index.scss
+++ b/app/containers/snippet/index.scss
@@ -9,6 +9,9 @@
 }
 
 .snippet-box {
+  max-width: 100%;
+  min-height: 100%;
+  min-width: 0;
 
   .header-table {
     width: 100%;
@@ -91,7 +94,8 @@
   }
 
   .snippet-code {
-    min-height: 100vh;
+    max-width: 100%;
+    min-height: 100%;
     border-color: var(--border-color);
     border-radius: 0;
     border-bottom: none;
@@ -140,6 +144,7 @@
     @extend .font-style-base;
     border: 0px;
     border-bottom: 1px solid var(--border-color);
+    max-width: 100%;
     overflow: hidden;
   }
 
@@ -150,6 +155,24 @@
     border-radius: 0;
     font-size: 13px;
     margin: 0 10px;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  pre > code {
+    display: block;
+  }
+
+  .collapsable-code-area {
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .code-table {
+    min-width: 100%;
+    width: max-content;
   }
 
   .file-header {
@@ -161,10 +184,13 @@
     background-color: var(--bg-secondary);
     border-top: 1px solid var(--border-color);
     border-bottom: 1px solid var(--border-color);
+    min-width: 0;
   }
 
   .file-expand {
     font-size: 15px;
+    min-width: 0;
+    overflow: hidden;
     transition: opacity .15s;
 
     &:hover {
@@ -192,7 +218,11 @@
 
     span {
       display: inline-block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
       vertical-align: middle;
+      white-space: nowrap;
     }
   }
 
@@ -209,6 +239,10 @@
     &:hover {
       opacity: .65;
     }
+  }
+
+  .file-header-controls {
+    flex: 0 0 auto;
   }
 
   .file-header-md {

--- a/app/containers/snippetPanel/index.scss
+++ b/app/containers/snippetPanel/index.scss
@@ -5,8 +5,16 @@
 .snippet-panel {
   float: right;
   width: 100%;
-  overflow: overlay;
+  overflow-x: hidden;
+  overflow-x: clip;
+  overflow-y: auto;
   height: 100vh;
+}
+
+.snippet-panel-content {
+  max-width: 100%;
+  min-height: 100%;
+  min-width: 0;
 }
 
 .snippet-panel-immersive {


### PR DESCRIPTION
## Problem
Beta 14 rendered with too much persistent scrollbar chrome. The main snippet detail area could show a low-value horizontal scrollbar, the split-pane wrapper could expose a blank scrollbar gutter, and the sidebar tag sections/middle snippet list looked visually busy even when scrolling was only an affordance.

## Summary
- Hide low-value scrollbar chrome in sidebar tag sections, snippet list, main snippet panel, and code overflow blocks until hover/focus.
- Prevent the main snippet detail panel and split-pane wrappers from exposing unnecessary horizontal scrollbars.
- Keep long code lines unwrapped and horizontally scrollable inside individual code blocks.

## Root Cause
- `react-split-pane` pane wrappers were applying inline `overflow: auto`, which surfaced a bottom scrollbar even when the snippet panel itself had no useful horizontal overflow.
- Some nested scroll regions used persistent or non-standard scrollbar behavior that made the UI look busier than the content required.

## Validation
- `webpack --mode development` using the bundled Node runtime.
- Active Electron render fixture screenshot verified no full-width bottom scrollbar.
- Long-line DOM check verified code blocks scroll horizontally while the outer snippet panel does not overflow.
- Full Electron render smoke suite passed via `node tests/smoke/electron-render-smoke.js`.