### PR TITLE
[codex] Bump prerelease version to 2.0.0-beta.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Lepton",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Lepton",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "Democratizing Code Snippets Management (macOS/Win/Linux)",
   "productName": "Lepton",
   "main": "main.js",


### PR DESCRIPTION
## Summary

Bumps the prerelease app version from `2.0.0-beta.14` to `2.0.0-beta.15` in `package.json` and `package-lock.json`.

This prepares the next public beta tag after the latest `master` commit `117d611`.

## Validation

- `git diff --check`
- Parsed `package.json` and `package-lock.json` with the .NET JSON serializer and confirmed all package metadata versions are `2.0.0-beta.15`

Node/npm are not available in this local shell, so `npm test` could not be run locally. The PR and release workflows should run the npm-based validation on GitHub Actions.