### PR TITLE
[codex] Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Built-in themes
 - macOS/Win/Linux
 - Dashboard
-- [Search snippets and downloaded content](wiki/faq.md#search)
+- [Search snippets](wiki/faq.md#search)
 - [Proxy](wiki/faq.md#proxy)
 - Free
 
@@ -35,7 +35,7 @@
 | :-------------:| :-----:| :-----: |
 | ![Screenshot](./docs/img/portfolio/stay_organized.png) | ![Screenshot](./docs/img/portfolio/markdown.png) | ![Screenshot](./docs/img/portfolio/jupyterNotebook.png) |
 
-|      Search snippets and content (*⇧ + Space*)         |    Immersive Mode *(⌘/Ctrl + i)*    | Dashboard *(⌘/Ctrl + d)* |
+|      Search snippets (*⇧ + Space*)         |    Immersive Mode *(⌘/Ctrl + i)*    | Dashboard *(⌘/Ctrl + d)* |
 | :-------------:| :-----:| :-----: |
 | ![Screenshot](./docs/img/portfolio/search_bar.png) | ![Screenshot](./docs/img/portfolio/immersive.png) | ![Screenshot](./docs/img/portfolio/dashboard.png)
 
@@ -51,7 +51,7 @@
 | Immersive Mode | `Cmd/Ctrl + I` |  Toggle the [Immersive mode](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/immersive.png)    |
 | Dashboard      | `Cmd/Ctrl + D` |  Toggle the [dashboard](https://github.com/hackjutsu/Lepton/blob/master/docs/img/portfolio/dashboard.png)     |
 | About Page     | `Cmd/Ctrl + ,` |  Toggle the [About page](https://github.com/hackjutsu/Lepton/blob/dev/docs/img/portfolio/about.png)    |
-| Search         | `Shift + Space`|  Toggle [snippet and downloaded-content search](wiki/faq.md#search)    |
+| Search         | `Shift + Space`|  Toggle [snippet search](wiki/faq.md#search)    |
 
 See the [Search FAQ](wiki/faq.md#search) for searchable fields and content-search behavior.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,7 +101,7 @@
                             <div class="platforms"> #macOS / #Win / #Linux</div>
                             <br/>
                             <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags=snippet,codesnippet,snippetmanager,lepton,leptonapp,github,opensource,developer,code" data-size="large">Tweet</a>
-                            <a class="github-button" href="https://github.com/hackjutsu/Lepton" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star hackjutsu/Lepton on GitHub">Star</a>
+                            <a class="github-button" href="https://github.com/hackjutsu/Lepton" data-icon="octicon-star" data-size="large" aria-label="Star hackjutsu/Lepton on GitHub">Star</a>
                             <a class="github-button" href="https://github.com/hackjutsu/Lepton/issues" data-size="large" data-show-count="true" aria-label="Issue hackjutsu/Lepton on GitHub">Issue</a>
                         </div>
                     </div>
@@ -181,7 +181,7 @@
                         </div>
                         <center>
                            <img src="img/portfolio/search_bar.png" class="img-responsive" alt="">
-                           <span class="feature-title">Search snippets and content (⇧ + Space)</span>
+                           <span class="feature-title">Search snippets (⇧ + Space)</span>
                         </center>
                     </a>
                 </div>
@@ -261,15 +261,6 @@
                         </div>
                     </li>
                     <li class='faq-item'>
-                        <div class="faq-question">Why is the language of my snippet "Other"?</div>
-                        <div class="faq-answer">
-                            Lepton relies on GitHub APIs to detect the language. To overwrite the result, put <code>"// vim: syntax=&ltyour_language&gt"</code> at the beginning of the snippet.
-                            <div class="github-snippet">
-                                <script src="https://gist.github.com/hackjutsu/288bbaaf821851df0ded368cf36e3104.js"></script>
-                            </div>
-                        </div>
-                    </li>
-                    <li class='faq-item'>
                         <div class="faq-question">How to specify the title and tags?</div>
                         <div class="faq-answer">
                             Follow the format <code>[title] description #tag1 #tag2</code> in the description field.
@@ -287,12 +278,6 @@
                         <div class="faq-question">What can Search find?</div>
                         <div class="faq-answer">
                             Search matches snippet metadata and downloaded file content. Complete global content search requires the download-all snippets option (<code>snippet.downloadAll</code>) before sync. See the <a class="faq-link" href="https://github.com/hackjutsu/Lepton/blob/master/wiki/faq.md#search" target="_blank">Search FAQ</a>.
-                        </div>
-                    </li>
-                    <li class='faq-item'>
-                        <div class="faq-question">Which release should I download?</div>
-                        <div class="faq-answer">
-                            Choose <a class="faq-link" href="https://github.com/hackjutsu/Lepton/releases/latest" target="_blank">Stable</a> for the latest stable build. Choose <a class="faq-link" href="https://github.com/hackjutsu/Lepton/releases/tag/v2.0.0-beta.7" target="_blank">Beta</a> to try the prerelease which includes the latest fixes and experimental features.
                         </div>
                     </li>
                     <li class='faq-item'>

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-## My Snippet's Language Is Classified As "Other"
+## Why Is The Language Of My Snippet "Other"?
 
 Lepton depends on GitHub's API to detect snippet language. If GitHub cannot classify the language, Lepton marks it as `Other`.
 
@@ -109,7 +109,25 @@ See [Configuration](configuration.md#options) for the full `enterprise` option l
 
 ## Scope For GitHub Access Token
 
-Lepton requires the `gist` scope.
+Lepton can use token login instead of GitHub OAuth credentials. Create a
+GitHub personal access token with the `gist` scope, then paste that token into
+Lepton's token login screen.
+
+The fastest path is GitHub's prefilled token page:
+[Create a Lepton token with the `gist` scope](https://github.com/settings/tokens/new?description=Lepton&scopes=gist).
+
+If you create the token manually:
+
+1. Open GitHub, then go to Settings -> Developer settings -> Personal access
+   tokens -> Tokens (classic).
+2. Select Generate new token -> Generate new token (classic).
+3. Enter a descriptive note, such as `Lepton`, and choose an expiration.
+4. Under Select scopes, enable only `gist`.
+5. Click Generate token and copy the token immediately. GitHub only shows it
+   once.
+
+For GitHub Enterprise, create the token on your Enterprise host with the same
+`gist` scope.
 
 ## About Data Collection
 


### PR DESCRIPTION
## Summary

- Update documentation copy on the GitHub Pages site.
- Align related README wording with the site copy.
- Refresh the wiki FAQ with clearer GitHub token login guidance.

## Validation

- Ran `git diff --check`.
- Opened `docs/index.html` locally in the browser for a static page check.

No app tests were run because this is a documentation-only change.