### PR TITLE
Style about modal scrollbars

### DIFF
--- a/app/containers/appContainer/scrollbar.scss
+++ b/app/containers/appContainer/scrollbar.scss
@@ -45,6 +45,9 @@ $quiet-scrollbar-thumb-active: color-mix(in srgb, var(--text-secondary) 58%, tra
 .markdown-section .highlight pre,
 .markdown-section.asciidoc-section .listingblock pre,
 .jupyterNotebook-section .nb-output,
-.raw-modal .modal-content {
+.raw-modal .modal-content,
+.about-modal .contributor-section,
+.about-modal .license-section,
+.about-modal .one-line-section {
   @include quiet-scrollbar;
 }


### PR DESCRIPTION
## Summary

- Apply the shared quiet scrollbar styling to the About modal's scrollable regions.
- Cover the contributor list, acknowledgement/license list, and one-line path fields.

## Why

The About modal defines its own scroll containers, but those containers were not included in the shared scrollbar selector list used by the other panels and modal surfaces. As a result, the About modal could fall back to default Chromium scrollbars instead of the app's styled scrollbar treatment.

## Verification

- Launched the local Electron app through the render smoke harness and reviewed screenshots for the active app fixture and About modal fixture in chat.
- Ran webpack development build via the bundled Node runtime.
- Ran `tests/smoke/electron-render-smoke.js` via the bundled Node runtime; all fixtures passed, including `about`.